### PR TITLE
[!] fix xqc_pacing_rate_calc() return zero

### DIFF
--- a/src/congestion_control/xqc_cubic.c
+++ b/src/congestion_control/xqc_cubic.c
@@ -158,9 +158,9 @@ xqc_cubic_on_lost(void *cong_ctl, xqc_usec_t lost_sent_time)
 
     /* Multiplicative Decrease */
     cubic->cwnd = cubic->cwnd * XQC_CUBIC_BETA / XQC_CUBIC_BETA_SCALE;
+    cubic->cwnd = xqc_max(cubic->cwnd, XQC_CUBIC_MIN_WIN);
     cubic->tcp_cwnd = cubic->cwnd;
-    /* threshold is at least XQC_CUBIC_MIN_WIN */
-    cubic->ssthresh = xqc_max(cubic->cwnd, XQC_CUBIC_MIN_WIN);
+    cubic->ssthresh = cubic->cwnd;
 }
 
 

--- a/src/transport/xqc_pacing.c
+++ b/src/transport/xqc_pacing.c
@@ -13,6 +13,7 @@
 #define FALSE 0
 #define XQC_CLOCK_GRANULARITY_US 1000 /* 1ms */
 #define XQC_PACING_DELAY_US XQC_CLOCK_GRANULARITY_US
+#define XQC_DEFAULT_PACING_RATE (((2 * XQC_QUIC_MSS * 1000000ULL)/(XQC_kInitialRtt * 1000)))
 
 void
 xqc_pacing_init(xqc_pacing_t *pacing, int pacing_on, xqc_send_ctl_t *ctl)
@@ -49,6 +50,11 @@ xqc_pacing_rate_calc(xqc_pacing_t *pacing)
 
     /* bytes can be sent per second */
     pacing_rate = cwnd * 1000000 / srtt;
+    if (pacing_rate == 0) {
+        pacing_rate = XQC_DEFAULT_PACING_RATE;
+        xqc_log(pacing->ctl_ctx->ctl_conn->log, XQC_LOG_ERROR,
+                "|pacing_rate zero|cwnd:%ui|srtt:%ui|", cwnd, srtt);
+    }
 
     if (ctl->ctl_cong_callback->xqc_cong_ctl_in_slow_start 
         && ctl->ctl_cong_callback->xqc_cong_ctl_in_slow_start(ctl->ctl_cong))


### PR DESCRIPTION
1. fix cubic cwnd
2. check return value of xqc_pacing_rate_calc() before dividing it

Fix #127