### PR TITLE
xqc_pow2 cann't work in windows.

### DIFF
--- a/src/common/xqc_id_hash.h
+++ b/src/common/xqc_id_hash.h
@@ -35,32 +35,27 @@ typedef struct xqc_id_hash_table_s {
 static inline int
 xqc_pow2(unsigned int n)
 {
-  
-    int clz , power = sizeof(n), count1 = 0;
-
+    int count1 = 0;
+    unsigned long power = sizeof(n);
 #ifdef __GNUC__
-    count1 = __builtin_popcount(n) ;
+    count1 = __builtin_popcount(n);
 #else
-    while (n) {
-		count1 += n & 1;
-		n >>= 1;
-	}
-#endif
-
-    if (count1 <= 1) {
-        return n ;
+    unsigned int t = n;
+    while (t) {
+        count1 += t & 1;
+        t >>= 1;
     }
-
+#endif
+    if (count1 <= 1) {
+        return n;
+    }
 #if defined(XQC_SYS_WINDOWS) && defined(_MSC_VER)
     /* __lzcnt available beginning VS2008 or up*/
-    _BitScanReverse(&clz, n);
+    _BitScanReverse((unsigned long*)&power, n);
 #else
-    clz = __builtin_clz(n);
-#endif  
-
-    power = (power << 3) - clz ;
-
-    return pow(2 , power);
+    power = (power << 3) - __builtin_clz(n) - 1;
+#endif
+    return (int)pow(2, power);
 }
 
 

--- a/src/transport/xqc_quic_lb.c
+++ b/src/transport/xqc_quic_lb.c
@@ -341,13 +341,13 @@ xqc_lb_cid_encryption(uint8_t *cid_buf, size_t enc_len, uint8_t *out_buf, size_t
     if (enc_len == XQC_EN_SINGLE_PASS_ENCRYPTION_LEN) {
         xqc_int_t res = xqc_cid_encryption_aes_128_ecb(cid_buf + XQC_FIRST_OCTET, enc_len, out_buf + XQC_FIRST_OCTET, enc_len, lb_cid_key, lb_cid_key_len, engine);
         if (res < XQC_OK) {
-            xqc_log(log, XQC_LOG_ERROR, "|lb-cid aes_128_ecb encryption error|%d｜", res);
+            xqc_log(log, XQC_LOG_ERROR, "|lb-cid aes_128_ecb encryption error|%d|", res);
             return -XQC_EENCRYPT_LB_CID;
         }
     } else {
         xqc_int_t res = xqc_cid_encryption_four_pass(cid_buf + XQC_FIRST_OCTET, enc_len, out_buf + XQC_FIRST_OCTET, enc_len, lb_cid_key, lb_cid_key_len, engine);
         if (res < XQC_OK) {
-            xqc_log(log, XQC_LOG_ERROR, "|lb-cid four-pass encryption error|%d｜", res);
+            xqc_log(log, XQC_LOG_ERROR, "|lb-cid four-pass encryption error|%d|", res);
             return -XQC_EENCRYPT_LB_CID;
         }
     }


### PR DESCRIPTION
```
#include <assert.h>
#include <math.h>
#ifdef _WIN32
#include <intrin.h>
#define XQC_SYS_WINDOWS 1
#endif
/* make n to 2 pow  */
static int xqc_pow2(unsigned int n)
{
    int count1 = 0;    
    unsigned long power = sizeof(n);
#ifdef __GNUC__
    count1 = __builtin_popcount(n);
#else
    unsigned int t = n;
    while (t) {
        count1 += t & 1;
        t >>= 1;
    }
#endif
    if (count1 <= 1) {
        return n;
    }
#if defined(XQC_SYS_WINDOWS) && defined(_MSC_VER)
    /* __lzcnt available beginning VS2008 or up*/
    _BitScanReverse((unsigned long *)&power, n);    
#else
    power = (power << 3) - __builtin_clz(n) - 1;    
#endif
    return (int)pow(2, power);
}
int main()
{
    assert(xqc_pow2(4) == 4);
    assert(xqc_pow2(12) == 8);
    assert(xqc_pow2(1024) == 1024);
    assert(xqc_pow2(0) == 0);
    assert(xqc_pow2(1) == 1);
}
```