### PR TITLE
fix complie error: specified bound depends on the length of the source argument

### DIFF
--- a/src/tls/xqc_tls.c
+++ b/src/tls/xqc_tls.c
@@ -169,7 +169,7 @@ xqc_tls_set_alpn(SSL *ssl, const char *alpn)
      * the rest bytes, set the last byte with '\0'
      */
     p_alpn[0] = alpn_len;
-    strncpy(&p_alpn[1], alpn, protos_len);
+    memcpy(&p_alpn[1], alpn, alpn_len);
     p_alpn[protos_len] = '\0';
     SSL_set_alpn_protos(ssl, p_alpn, protos_len);
 

--- a/src/transport/xqc_client.c
+++ b/src/transport/xqc_client.c
@@ -160,7 +160,7 @@ xqc_client_create_tls(xqc_connection_t *conn, const xqc_conn_ssl_config_t *conn_
         ret = -XQC_EMALLOC;
         goto end;
     }
-    strncpy(cfg.alpn, alpn, alpn_cap);
+    memcpy(cfg.alpn, alpn, alpn_cap);
 
     /* copy hostname */
     host_cap = strlen(hostname) + 1;
@@ -170,7 +170,7 @@ xqc_client_create_tls(xqc_connection_t *conn, const xqc_conn_ssl_config_t *conn_
         ret = -XQC_EMALLOC;
         goto end;
     }
-    strncpy(cfg.hostname, hostname, host_cap);
+    memcpy(cfg.hostname, hostname, host_cap);
 
     /* encode local transport parameters, and set to tls config */
     cfg.trans_params = tp_buf;


### PR DESCRIPTION
Fix compilation errors under gcc version 11.3.1 20221121 (Red Hat 11.3.1-4)

/tmp/build/xquic-1.5.2/src/tls/xqc_tls.c: In function 'xqc_tls_set_alpn':
/tmp/build/xquic-1.5.2/src/tls/xqc_tls.c:172:5: error: 'strncpy' specified bound depends on the length of the source argument [-Werror=stringop-truncation]
  172 |     strncpy(&p_alpn[1], alpn, protos_len);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/tmp/build/xquic-1.5.2/src/tls/xqc_tls.c:152:23: note: length computed here
  152 |     size_t alpn_len = strlen(alpn);
      |                       ^~~~~~~~~~~~
cc1: all warnings being treated as errors