### PR TITLE
[+] Update multipath draft-05 etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ XQUIC Library released by Alibaba is …
 
 [![](https://img.shields.io/static/v1?label=draft-13&message=QUIC-LB&color=9cf)](https://tools.ietf.org/html/draft-ietf-quic-load-balancers-13)
 [![](https://img.shields.io/static/v1?label=draft-04&message=Multipath-QUIC&color=9cf)](https://tools.ietf.org/html/draft-ietf-quic-multipath-04)
+[![](https://img.shields.io/static/v1?label=draft-05&message=Multipath-QUIC&color=9cf)](https://tools.ietf.org/html/draft-ietf-quic-multipath-05)
 
 #### Standardized Features
 

--- a/include/xquic/xqc_errno.h
+++ b/include/xquic/xqc_errno.h
@@ -26,6 +26,8 @@ typedef enum {
     TRA_0RTT_TRANS_PARAMS_ERROR     =  0xE,   /* MUST delete the current saved 0RTT transport parameters */
     TRA_HS_CERTIFICATE_VERIFY_FAIL  =  0x1FE, /* for handshake certificate verify error */
     TRA_CRYPTO_ERROR                =  0x1FF, /* 0x1XX */
+    TRA_MP_PROTOCOL_VIOLATION_04    =  0xba01,
+    TRA_MP_PROTOCOL_VIOLATION_05    =  0x1001d76d3ded42f3,
 } xqc_trans_err_code_t;
 
 #define TRA_CRYPTO_ERROR_BASE   0x100
@@ -119,6 +121,7 @@ typedef enum {
     XQC_EMP_PATH_STATE_ERROR            = 654,      /* Multipath - abnormal path status */
     XQC_EMP_SCHEDULE_PATH               = 655,      /* Multipath - fail to schedule path for sending */
     XQC_EMP_NO_ACTIVE_PATH              = 656,      /* Multipath - no another active path */
+    XQC_EMP_INVALID_MP_VERTION          = 657,      /* Multipath - the multipath version value is invalid */
 
     XQC_EENCRYPT_LB_CID                 = 670,      /* load balance connection ID encryption error */
     XQC_EENCRYPT_AES_128_ECB            = 671,      /* aes_128_ecb algorithm error */

--- a/include/xquic/xquic_typedef.h
+++ b/include/xquic/xquic_typedef.h
@@ -152,6 +152,8 @@ typedef struct xqc_http_priority_s {
 /* max alpn buffer length */
 #define XQC_MAX_ALPN_BUF_LEN    256
 
+#define XQC_UNKNOWN_PATH_ID ((uint64_t)-1)
+
 typedef enum xqc_conn_settings_type_e {
     XQC_CONN_SETTINGS_DEFAULT,
     XQC_CONN_SETTINGS_LOW_DELAY,
@@ -165,5 +167,9 @@ typedef struct xqc_conn_public_local_trans_settings_s {
 typedef struct xqc_conn_public_remote_trans_settings_s {
     uint16_t max_datagram_frame_size;
 } xqc_conn_public_remote_trans_settings_t;
+
+typedef struct xqc_stream_settings_s {
+    uint64_t recv_rate_bytes_per_sec;
+} xqc_stream_settings_t;
 
 #endif /*_XQUIC_TYPEDEF_H_INCLUDED_*/

--- a/scripts/xquic.lds
+++ b/scripts/xquic.lds
@@ -95,7 +95,6 @@ XQUIC_VERS_1.0 {
         xqc_datagram_send_multiple;
         xqc_datagram_set_user_data;
         xqc_datagram_get_user_data;
-        xqc_path_get_stats;
         xqc_h3_ext_datagram_get_mss;
         xqc_h3_ext_datagram_set_user_data;
         xqc_h3_ext_datagram_get_user_data;
@@ -116,6 +115,8 @@ XQUIC_VERS_1.0 {
         xqc_conn_get_conn_settings_template;
         xqc_conn_get_lastest_rtt;
         xqc_log_enable;
+	xqc_h3_request_update_settings;
+  	xqc_stream_update_settings;
     local:
         *;
 };

--- a/src/http3/xqc_h3_conn.c
+++ b/src/http3/xqc_h3_conn.c
@@ -483,7 +483,7 @@ xqc_h3_conn_create_uni_stream(xqc_h3_conn_t *h3c, xqc_h3_stream_type_t h3s_type)
 
     /* create transport stream */
     xqc_stream_t *stream = xqc_create_stream_with_conn(
-        h3c->conn, XQC_UNDEFINE_STREAM_ID, stream_type, NULL);
+        h3c->conn, XQC_UNDEFINE_STREAM_ID, stream_type, NULL, NULL);
     if (!stream) {
         xqc_log(h3c->log, XQC_LOG_ERROR, "|xqc_create_stream_with_conn error|type:%d|", h3s_type);
         goto error;

--- a/src/http3/xqc_h3_ext_bytestream.c
+++ b/src/http3/xqc_h3_ext_bytestream.c
@@ -208,7 +208,7 @@ xqc_h3_ext_bytestream_create(xqc_engine_t *engine,
     xqc_h3_conn_t             *h3_conn;
     int                        ret;
 
-    stream = xqc_stream_create(engine, cid, NULL);
+    stream = xqc_stream_create(engine, cid, NULL, NULL);
     if (!stream) {
         xqc_log(engine->log, XQC_LOG_ERROR, "|xqc_stream_create error|");
         return NULL;

--- a/src/http3/xqc_h3_request.h
+++ b/src/http3/xqc_h3_request.h
@@ -27,6 +27,7 @@ typedef struct xqc_h3_request_s {
     xqc_request_notify_flag_t       read_flag;
 
     /* compressed header size recved */
+    size_t                          compressed_header_recvd;
     size_t                          header_recvd;
     /* received header buf */
     xqc_http_headers_t              h3_header[XQC_H3_REQUEST_MAX_HEADERS_CNT];
@@ -40,6 +41,7 @@ typedef struct xqc_h3_request_s {
     size_t                          body_recvd_final_size;
 
     /* compressed header size sent */
+    size_t                          compressed_header_sent;
     size_t                          header_sent;
 
     /* send body statistic information */
@@ -62,10 +64,6 @@ typedef struct xqc_h3_request_s {
     const char                     *stream_close_msg;
 
 } xqc_h3_request_t;
-
-
-xqc_h3_request_t *xqc_h3_request_create(xqc_engine_t *engine, const xqc_cid_t *cid,
-    void *user_data);
 
 xqc_h3_request_t *xqc_h3_request_create_inner(xqc_h3_conn_t *h3_conn, xqc_h3_stream_t *h3_stream,
     void *user_data);

--- a/src/http3/xqc_h3_stream.h
+++ b/src/http3/xqc_h3_stream.h
@@ -147,6 +147,8 @@ typedef struct xqc_h3_stream_s {
    /* referred count of h3 stream */
     uint32_t                        ref_cnt;
 
+    uint64_t                        recv_rate_limit;
+
 } xqc_h3_stream_t;
 
 

--- a/src/transport/reinjection_control/xqc_reinj_default.c
+++ b/src/transport/reinjection_control/xqc_reinj_default.c
@@ -49,7 +49,8 @@ xqc_default_reinj_can_reinject_after_sched(xqc_default_reinj_ctl_t *rctl,
     xqc_connection_t *conn = rctl->conn;
 
     if (xqc_list_empty(&conn->conn_send_queue->sndq_send_packets)
-        && (po->po_frame_types & XQC_FRAME_BIT_STREAM)
+        && ((po->po_frame_types & XQC_FRAME_BIT_STREAM) 
+            || (po->po_frame_types & XQC_FRAME_BIT_MAX_STREAM_DATA))
         && !(po->po_flag & XQC_POF_NOT_REINJECT)
         && !(XQC_MP_PKT_REINJECTED(po))
         && (po->po_flag & XQC_POF_IN_FLIGHT)) 

--- a/src/transport/scheduler/xqc_scheduler_backup.c
+++ b/src/transport/scheduler/xqc_scheduler_backup.c
@@ -7,9 +7,6 @@
 #include "src/transport/scheduler/xqc_scheduler_common.h"
 #include "src/transport/xqc_send_ctl.h"
 
-#define BACKUP_PATH_PROBE_SUCCESS_TIMEOUT 3000000
-#define BACKUP_PATH_PROBE_TIMEOUT 3000000
-
 
 static size_t
 xqc_backup_scheduler_size()
@@ -23,48 +20,6 @@ xqc_backup_scheduler_init(void *scheduler, xqc_log_t *log, xqc_scheduler_params_
     return;
 }
 
-static inline xqc_bool_t
-xqc_path_can_schedule(xqc_path_ctx_t *path, xqc_packet_out_t *packet_out)
-{
-    if (path->path_state != XQC_PATH_STATE_ACTIVE) {
-        return XQC_FALSE;
-    }
-
-    if (packet_out->po_flag & XQC_POF_NOT_SCHEDULE) {
-        if ((path->tra_path_status != XQC_TRA_PATH_STATUS_IN_USE) && (path->parent_conn->in_use_active_path_count > 0)) {
-            return XQC_FALSE;
-        }
-    }
-
-    return XQC_TRUE;
-}
-
-static inline xqc_bool_t
-xqc_path_can_reinject(xqc_path_ctx_t *path, xqc_packet_out_t *packet_out)
-{
-    if (path->path_state != XQC_PATH_STATE_ACTIVE) {
-        return XQC_FALSE;
-    }
-
-    if (path->path_id == packet_out->po_path_id) {
-        return XQC_FALSE;
-    }
-
-    if (packet_out->po_flag & XQC_POF_NOT_REINJECT) {
-        if ((path->tra_path_status != XQC_TRA_PATH_STATUS_IN_USE) && (path->app_path_status != XQC_APP_PATH_STATUS_AVAILABLE)) {
-            return XQC_FALSE;
-        }
-    }
-
-    return XQC_TRUE;
-}
-
-static inline xqc_bool_t
-xqc_path_can_probe(xqc_path_ctx_t *path)
-{
-    return (path->path_state == XQC_PATH_STATE_ACTIVE)
-        && (path->tra_path_status == XQC_TRA_PATH_STATUS_BACKUP);
-}
 
 xqc_path_ctx_t *
 xqc_backup_scheduler_get_path(void *scheduler,
@@ -72,6 +27,7 @@ xqc_backup_scheduler_get_path(void *scheduler,
     xqc_bool_t *cc_blocked)
 {
     xqc_path_ctx_t *best_path = NULL;
+    xqc_path_ctx_t *best_standby_path = NULL;
 
     xqc_list_head_t *pos, *next;
     xqc_path_ctx_t *path;
@@ -79,7 +35,9 @@ xqc_backup_scheduler_get_path(void *scheduler,
 
     /* min RTT */
     uint64_t min_rtt = XQC_MAX_UINT64_VALUE;
+    uint64_t min_rtt_standby = XQC_MAX_UINT64_VALUE;
     uint64_t path_srtt;
+    uint32_t avail_path_cnt = 0;
     xqc_bool_t reached_cwnd_check = XQC_FALSE;
 
     if (cc_blocked) {
@@ -89,15 +47,22 @@ xqc_backup_scheduler_get_path(void *scheduler,
     xqc_list_for_each_safe(pos, next, &conn->conn_paths_list) {
         path = xqc_list_entry(pos, xqc_path_ctx_t, path_list);
 
-        if (reinject) {
-            if (!xqc_path_can_reinject(path, packet_out)) {
-                continue;
-            }
+        /* skip inactive paths */
+        if (path->path_state != XQC_PATH_STATE_ACTIVE) {
+            continue;
+        }
 
-        } else {
-            if (!xqc_path_can_schedule(path, packet_out)) {
-                continue;
-            }
+        /* skip frozen paths */
+        if (path->app_path_status == XQC_APP_PATH_STATUS_FROZEN) {
+            continue;
+        }
+
+        if (path->app_path_status == XQC_APP_PATH_STATUS_AVAILABLE) {
+            avail_path_cnt++;
+        }
+
+        if (reinject && (packet_out->po_path_id == path->path_id)) {
+            continue;
         }
 
         if (!reached_cwnd_check) {
@@ -120,195 +85,81 @@ xqc_backup_scheduler_get_path(void *scheduler,
                 conn, path->path_id, path_srtt);
 
         if (path_srtt < min_rtt) {
-            best_path = path;
-            min_rtt = path_srtt;
+            if (path->app_path_status == XQC_APP_PATH_STATUS_AVAILABLE) {
+                best_path = path;
+                min_rtt = path_srtt;
+                
+            } else {
+                best_standby_path = path;
+                min_rtt_standby = path_srtt;
+            }
         }
     }
 
-    if (best_path == NULL) {
-        xqc_log(conn->log, XQC_LOG_DEBUG, "|No available paths to schedule|conn:%p|", conn);
 
-    } else {
-        xqc_log(conn->log, XQC_LOG_DEBUG, "|best path:%ui|frame_type:%s|",
-                best_path->path_id, xqc_frame_type_2_str(packet_out->po_frame_types));
+    if (best_path == NULL) {
+        if (best_standby_path != NULL
+            && (avail_path_cnt == 0 || reinject)) 
+        {
+            best_path = best_standby_path;
+
+        } else {
+            xqc_log(conn->log, XQC_LOG_DEBUG, "|No available paths to schedule|conn:%p|", conn);
+        }
+    }
+
+
+    if (best_path) {
+        xqc_log(conn->log, XQC_LOG_DEBUG, "|best path:%ui|frame_type:%s|app_status:%d|",
+                best_path->path_id, xqc_frame_type_2_str(packet_out->po_frame_types),
+                best_path->app_path_status);
     }
 
     return best_path;
-
 }
 
-static inline xqc_int_t
-xqc_backup_probe_standby_path(xqc_connection_t *conn,
-    xqc_path_ctx_t **default_path, xqc_path_ctx_t **standby_path)
-{
-    xqc_int_t ret;
-    xqc_list_head_t *pos, *next;
-    xqc_path_ctx_t *path;
-    xqc_send_ctl_t *send_ctl;
-
-    xqc_usec_t now = xqc_monotonic_timestamp();
-    xqc_usec_t last_time;
-
-    xqc_list_for_each_safe(pos, next, &conn->conn_paths_list) {
-        path = xqc_list_entry(pos, xqc_path_ctx_t, path_list);
-
-        if (path->path_state != XQC_PATH_STATE_ACTIVE) {
-            continue;
-        }
-
-        if (path->app_path_status == XQC_APP_PATH_STATUS_AVAILABLE) {
-            *default_path = path;
-
-        } else if (path->app_path_status == XQC_APP_PATH_STATUS_STANDBY) {
-            *standby_path = path;
-        }
-
-        if (conn->conn_settings.standby_path_probe_timeout > 0
-            && xqc_path_can_probe(path))
-        {
-            send_ctl = path->path_send_ctl;
-            last_time = send_ctl->ctl_time_of_last_sent_ack_eliciting_packet[XQC_PNS_APP_DATA];
-
-            if ((now - last_time) >= conn->conn_settings.standby_path_probe_timeout * 1000) {
-                ret = xqc_path_standby_probe(path);
-                if (ret != XQC_OK) {
-                    xqc_log(conn->log, XQC_LOG_ERROR, "|xqc_path_standby_probe error|");
-                    return ret;
-                }
-            }
-
-        }
-    }
-
-    return XQC_OK;
-}
-
-static inline xqc_bool_t
-xqc_default_path_is_in_use(xqc_path_ctx_t *default_path, xqc_path_ctx_t *standby_path)
-{
-    return (default_path->tra_path_status == XQC_TRA_PATH_STATUS_IN_USE)
-        && (standby_path->tra_path_status == XQC_TRA_PATH_STATUS_BACKUP);
-}
-
-static inline xqc_bool_t
-xqc_standby_path_is_in_use(xqc_path_ctx_t *default_path, xqc_path_ctx_t *standby_path)
-{
-    return (default_path->tra_path_status == XQC_TRA_PATH_STATUS_BACKUP)
-        && (standby_path->tra_path_status == XQC_TRA_PATH_STATUS_IN_USE);
-}
-
-static inline xqc_bool_t
-xqc_default_path_need_degrade(xqc_connection_t *conn,
-    xqc_path_ctx_t *default_path, xqc_path_ctx_t *standby_path)
-{
-    if (conn->transport_cbs.path_status_controller) {
-        return conn->transport_cbs.path_status_controller(conn, &conn->scid_set.user_scid,
-                                                          default_path->path_id, XQC_PATH_DEGRADE,
-                                                          xqc_conn_get_user_data(conn));
-    }
-
-    xqc_send_ctl_t *send_ctl = default_path->path_send_ctl;
-    if (send_ctl->ctl_pto_count_since_last_tra_path_status_changed > conn->conn_settings.path_unreachable_pto_count) {
-        return XQC_TRUE;
-    }
-
-    return XQC_FALSE;
-}
-
-static inline xqc_bool_t
-xqc_default_path_need_recovery(xqc_connection_t *conn,
-    xqc_path_ctx_t *default_path, xqc_path_ctx_t *standby_path)
-{
-    if (conn->transport_cbs.path_status_controller) {
-        return conn->transport_cbs.path_status_controller(conn, &conn->scid_set.user_scid,
-                                                          default_path->path_id, XQC_PATH_RECOVERY,
-                                                          xqc_conn_get_user_data(conn));
-    }
-
-    xqc_send_ctl_t *send_ctl = default_path->path_send_ctl;
-    if (send_ctl->ctl_send_count - send_ctl->ctl_send_count_at_last_tra_path_status_changed_time > 3
-        && xqc_monotonic_timestamp() - default_path->last_tra_path_status_changed_time > BACKUP_PATH_PROBE_TIMEOUT
-        && send_ctl->ctl_pto_count_since_last_tra_path_status_changed < 1)
-    {
-        return XQC_TRUE;
-    }
-
-    return XQC_FALSE;
-}
-
-void
-xqc_probe_before_use(xqc_connection_t *conn,
-    xqc_path_ctx_t *next_in_use_path, xqc_path_ctx_t *next_backup_path)
-{
-    xqc_usec_t now = xqc_monotonic_timestamp();
-    xqc_usec_t last_recv_time = next_in_use_path->path_send_ctl->ctl_largest_recv_time[XQC_PNS_APP_DATA];
-    xqc_usec_t last_send_time = next_in_use_path->path_send_ctl->ctl_time_of_last_sent_ack_eliciting_packet[XQC_PNS_APP_DATA];
-
-    if ((now - last_recv_time) <= BACKUP_PATH_PROBE_SUCCESS_TIMEOUT) {
-        xqc_set_transport_path_status(next_in_use_path, XQC_TRA_PATH_STATUS_IN_USE, now);
-        xqc_set_transport_path_status(next_backup_path, XQC_TRA_PATH_STATUS_BACKUP, now);
-
-    } else if ((now - last_send_time) >= BACKUP_PATH_PROBE_TIMEOUT) {
-        xqc_int_t ret = xqc_path_standby_probe(next_in_use_path);
-        if (ret != XQC_OK) {
-            xqc_log(conn->log, XQC_LOG_ERROR, "|xqc_path_standby_probe error|");
-            return;
-        }
-    }
-}
-
-
-void
+void 
 xqc_backup_scheduler_handle_conn_event(void *scheduler, 
     xqc_connection_t *conn, xqc_scheduler_conn_event_t event, void *event_arg)
 {
-    if (event == XQC_SCHED_EVENT_CONN_ROUND_START) {
+    xqc_list_head_t *pos, *next;
+    xqc_path_ctx_t *path;
+    xqc_send_ctl_t *send_ctl;
+    xqc_usec_t now = 0, deadline;
 
-        if (conn->active_path_count < 2) {
-            return;
-        }
+    if (event == XQC_SCHED_EVENT_CONN_ROUND_START 
+        && conn->conn_settings.standby_path_probe_timeout
+        && conn->enable_multipath
+        && (conn->conn_state == XQC_CONN_STATE_ESTABED)) 
+    {
+        /* check if we need to probe standby paths */
+        xqc_list_for_each_safe(pos, next, &conn->conn_paths_list) {
+            path = xqc_list_entry(pos, xqc_path_ctx_t, path_list);
+            if (path->path_state == XQC_PATH_STATE_ACTIVE
+                && path->app_path_status == XQC_APP_PATH_STATUS_STANDBY)
+            {
+                if (!now) {
+                    now = xqc_monotonic_timestamp();
+                }
 
-        if (XQC_UNLIKELY(conn->conn_state >= XQC_CONN_STATE_CLOSING)) {
-            return;
-        }
+                send_ctl = path->path_send_ctl;
 
-        xqc_int_t ret = XQC_ERROR;
+                deadline = send_ctl->ctl_time_of_last_sent_ack_eliciting_packet[XQC_PNS_APP_DATA] + conn->conn_settings.standby_path_probe_timeout * 1000;
 
-        xqc_path_ctx_t *default_path = NULL;
-        xqc_path_ctx_t *standby_path = NULL;
+                xqc_log(conn->log, XQC_LOG_DEBUG, "|standby_probe|path:%ui|deadline:%ui|now:%ui|now>=deadline:%d|last_send:%ui|",
+                        path->path_id, deadline, now, now >= deadline, send_ctl->ctl_time_of_last_sent_ack_eliciting_packet[XQC_PNS_APP_DATA]);
 
-        ret = xqc_backup_probe_standby_path(conn, &default_path, &standby_path);
-        if (ret != XQC_OK) {
-            xqc_log(conn->log, XQC_LOG_ERROR, "|xqc_backup_probe_standby_path error|ret:%d|", ret);
-            return;
-        }
-
-        if (default_path == NULL || standby_path == NULL) {
-            xqc_log(conn->log, XQC_LOG_DEBUG, "|identify default/standby path error|");
-            return;
-        }
-
-        if (xqc_default_path_is_in_use(default_path, standby_path)) {
-            if (xqc_default_path_need_degrade(conn, default_path, standby_path)) {
-                xqc_probe_before_use(conn, standby_path, default_path);
+                if (now >= deadline) {
+                    xqc_path_standby_probe(path);
+                }
             }
-
-        } else if (xqc_standby_path_is_in_use(default_path, standby_path)) {
-            if (xqc_default_path_need_recovery(conn, default_path, standby_path)) {
-                xqc_probe_before_use(conn,default_path, standby_path);
-            }
-
-        } else {
-            xqc_log(conn->log, XQC_LOG_ERROR, "|path status error|");
-            return;
         }
     }
-
 }
 
 const xqc_scheduler_callback_t xqc_backup_scheduler_cb = {
-    .xqc_scheduler_size             = xqc_backup_scheduler_size,
-    .xqc_scheduler_init             = xqc_backup_scheduler_init,
-    .xqc_scheduler_get_path         = xqc_backup_scheduler_get_path,
+    .xqc_scheduler_size      = xqc_backup_scheduler_size,
+    .xqc_scheduler_init      = xqc_backup_scheduler_init,
+    .xqc_scheduler_get_path  = xqc_backup_scheduler_get_path,
     .xqc_scheduler_handle_conn_event = xqc_backup_scheduler_handle_conn_event,
 };

--- a/src/transport/xqc_frame_parser.h
+++ b/src/transport/xqc_frame_parser.h
@@ -125,13 +125,14 @@ ssize_t xqc_gen_ack_mp_frame(xqc_connection_t *conn, uint64_t path_id, xqc_packe
 xqc_int_t xqc_parse_ack_mp_frame(xqc_packet_in_t *packet_in, xqc_connection_t *conn,
     uint64_t *dcid_seq_num, xqc_ack_info_t *ack_info);
 
-ssize_t xqc_gen_path_abandon_frame(xqc_packet_out_t *packet_out,
-    uint64_t dcid_seq_num, uint64_t error_code);
+ssize_t xqc_gen_path_abandon_frame(xqc_connection_t *conn, 
+    xqc_packet_out_t *packet_out, uint64_t dcid_seq_num, uint64_t error_code);
 
 xqc_int_t xqc_parse_path_abandon_frame(xqc_packet_in_t *packet_in,
     uint64_t *dcid_seq_num, uint64_t *error_code);
 
-ssize_t xqc_gen_path_status_frame(xqc_packet_out_t *packet_out,
+ssize_t xqc_gen_path_status_frame(xqc_connection_t *conn,
+    xqc_packet_out_t *packet_out,
     uint64_t dcid_seq_num,
     uint64_t path_status_seq_num, uint64_t path_status);
 

--- a/src/transport/xqc_packet_out.h
+++ b/src/transport/xqc_packet_out.h
@@ -146,7 +146,10 @@ xqc_packet_out_t *xqc_write_packet_for_stream(xqc_connection_t *conn, xqc_pkt_ty
 
 int xqc_write_packet_header(xqc_connection_t *conn, xqc_packet_out_t *packet_out);
 
-int xqc_write_ack_to_packets(xqc_connection_t *conn);
+xqc_int_t xqc_write_ack_or_mp_ack_to_packets(xqc_connection_t *conn);
+
+xqc_int_t xqc_write_ack_or_mp_ack_to_one_packet(xqc_connection_t *conn, xqc_packet_out_t *packet_out, 
+    xqc_pkt_num_space_t pns, xqc_path_ctx_t *path, xqc_bool_t is_mp_ack);
 
 int xqc_write_ack_to_one_packet(xqc_connection_t *conn, xqc_packet_out_t *packet_out, xqc_pkt_num_space_t pns);
 
@@ -167,7 +170,8 @@ int xqc_write_streams_blocked_to_packet(xqc_connection_t *conn, uint64_t stream_
 
 int xqc_write_max_data_to_packet(xqc_connection_t *conn, uint64_t max_data);
 
-int xqc_write_max_stream_data_to_packet(xqc_connection_t *conn, xqc_stream_id_t stream_id, uint64_t max_stream_data);
+int xqc_write_max_stream_data_to_packet(xqc_connection_t *conn, 
+xqc_stream_id_t stream_id, uint64_t max_stream_data, xqc_pkt_type_t xqc_pkt_type);
 
 int xqc_write_max_streams_to_packet(xqc_connection_t *conn, uint64_t max_stream, int bidirectional);
 
@@ -186,12 +190,11 @@ xqc_int_t xqc_write_new_conn_id_frame_to_packet(xqc_connection_t *conn, uint64_t
 
 xqc_int_t xqc_write_retire_conn_id_frame_to_packet(xqc_connection_t *conn, uint64_t seq_num);
 
-xqc_int_t xqc_write_path_challenge_frame_to_packet(xqc_connection_t *conn, xqc_path_ctx_t *path);
+xqc_int_t xqc_write_path_challenge_frame_to_packet(xqc_connection_t *conn, xqc_path_ctx_t *path, 
+    xqc_bool_t attach_path_status);
 
 xqc_int_t xqc_write_path_response_frame_to_packet(xqc_connection_t *conn, xqc_path_ctx_t *path,
     unsigned char *path_response_data);
-
-int xqc_write_ack_mp_to_packets(xqc_connection_t *conn);
 
 int xqc_write_ack_mp_to_one_packet(xqc_connection_t *conn, xqc_path_ctx_t *path,
     xqc_packet_out_t *packet_out, xqc_pkt_num_space_t pns);

--- a/src/transport/xqc_reinjection.h
+++ b/src/transport/xqc_reinjection.h
@@ -18,13 +18,14 @@
 #define XQC_MP_FIRST_FRAME_OFFSET 128 * 1024 /* 128k */
 #define XQC_MP_PKT_REINJECTED(po) (po->po_flag & (XQC_POF_REINJECTED_ORIGIN | XQC_POF_REINJECTED_REPLICA))
 
-xqc_bool_t xqc_packet_can_reinject(xqc_packet_out_t *packet_out);
-
 void xqc_associate_packet_with_reinjection(xqc_packet_out_t *reinj_origin,
     xqc_packet_out_t *reinj_replica);
 
 void xqc_conn_reinject_unack_packets(xqc_connection_t *conn, 
     xqc_reinjection_mode_t mode);
+
+xqc_int_t xqc_conn_try_reinject_packet(xqc_connection_t *conn, 
+    xqc_packet_out_t *packet_out);
 
 #endif /* XQC_REINJECTION_H */
 

--- a/src/transport/xqc_send_ctl.h
+++ b/src/transport/xqc_send_ctl.h
@@ -105,14 +105,12 @@ typedef struct xqc_send_ctl_s {
     xqc_timer_manager_t         path_timer_manager;
 
     unsigned                    ctl_pto_count;
-    unsigned                    ctl_pto_count_since_last_tra_path_status_changed;
 
     unsigned                    ctl_send_count;
     unsigned                    ctl_lost_count;
     unsigned                    ctl_tlp_count;
     unsigned                    ctl_spurious_loss_count;
     unsigned                    ctl_lost_dgram_cnt;
-    unsigned                    ctl_send_count_at_last_tra_path_status_changed_time;
 
     unsigned                    ctl_recv_count;
 

--- a/src/transport/xqc_stream.h
+++ b/src/transport/xqc_stream.h
@@ -149,6 +149,8 @@ struct xqc_stream_s {
     xqc_path_metrics_t      paths_info[XQC_MAX_PATHS_COUNT];
     uint8_t                 stream_mp_usage_schedule;
     uint8_t                 stream_mp_usage_reinject;
+
+    uint64_t                recv_rate_bytes_per_sec;
 };
 
 static inline xqc_stream_type_t
@@ -170,7 +172,7 @@ xqc_stream_is_uni(xqc_stream_id_t stream_id)
 }
 
 xqc_stream_t *xqc_create_stream_with_conn (xqc_connection_t *conn, xqc_stream_id_t stream_id,
-    xqc_stream_type_t stream_type, void *user_data);
+    xqc_stream_type_t stream_type, xqc_stream_settings_t *settings, void *user_data);
 
 void xqc_destroy_stream(xqc_stream_t *stream);
 
@@ -196,13 +198,13 @@ xqc_stream_t *xqc_find_stream_by_id(xqc_stream_id_t stream_id, xqc_id_hash_table
 
 void xqc_stream_set_flow_ctl(xqc_stream_t *stream);
 
+void xqc_stream_update_flow_ctl(xqc_stream_t *stream);
+
 int xqc_stream_do_send_flow_ctl(xqc_stream_t *stream);
 
 int xqc_stream_do_recv_flow_ctl(xqc_stream_t *stream);
 
 int xqc_stream_do_create_flow_ctl(xqc_connection_t *conn, xqc_stream_id_t stream_id, xqc_stream_type_t stream_type);
-
-uint64_t xqc_stream_get_init_max_stream_data(xqc_stream_t *stream);
 
 xqc_stream_t *xqc_passive_create_stream(xqc_connection_t *conn, xqc_stream_id_t stream_id, void *user_data);
 

--- a/src/transport/xqc_timer.c
+++ b/src/transport/xqc_timer.c
@@ -102,7 +102,6 @@ xqc_timer_loss_detection_timeout(xqc_timer_type_t type, xqc_usec_t now, void *us
     }
 
     send_ctl->ctl_pto_count++;
-    send_ctl->ctl_pto_count_since_last_tra_path_status_changed++;
     xqc_log(conn->log, XQC_LOG_DEBUG, "|xqc_send_ctl_set_loss_detection_timer|PTO|conn:%p|pto_count:%ud", 
             conn, send_ctl->ctl_pto_count);
     xqc_send_ctl_set_loss_detection_timer(send_ctl);
@@ -260,6 +259,12 @@ xqc_timer_retire_cid_timeout(xqc_timer_type_t type, xqc_usec_t now, void *user_d
                     xqc_log(conn->log, XQC_LOG_ERROR, "|xqc_cid_switch_to_next_state error|");
                     return;
                 }
+
+                xqc_log(conn->log, XQC_LOG_DEBUG, 
+                        "|retired->removed|cid:%s|seq:%ui|len:%d|", 
+                        xqc_scid_str(&inner_cid->cid), 
+                        inner_cid->cid.cid_seq_num,
+                        inner_cid->cid.cid_len);
 
                 // xqc_list_del(pos);
                 // xqc_free(inner_cid);

--- a/src/transport/xqc_transport_params.h
+++ b/src/transport/xqc_transport_params.h
@@ -24,6 +24,7 @@
 #define XQC_MAX_TRANSPORT_PARAM_BUF_LEN         512
 
 
+
 /**
  * @brief transport parameter type
  */
@@ -67,8 +68,10 @@ typedef enum {
 
     /* do no cryption on 0-RTT and 1-RTT packets */
     XQC_TRANSPORT_PARAM_NO_CRYPTO                           = 0x1000,
+
     /* multipath quic attributes */
-    XQC_TRANSPORT_PARAM_ENABLE_MULTIPATH                    = 0x0f739bbc1b666d04,
+    XQC_TRANSPORT_PARAM_ENABLE_MULTIPATH_04                 = 0x0f739bbc1b666d04,
+    XQC_TRANSPORT_PARAM_ENABLE_MULTIPATH_05                 = 0x0f739bbc1b666d05,
 
     /* upper limit of params defined by xquic */
     XQC_TRANSPORT_PARAM_UNKNOWN,
@@ -133,12 +136,16 @@ typedef struct {
     /**
      * enable_multipath is a self-defined experimental transport parameter by xquic, which will
      * enable multipath quic if enable_multipath is set to be 1.
-     * https://datatracker.ietf.org/doc/html/draft-ietf-quic-multipath-04#section-3
+
+     * https://datatracker.ietf.org/doc/html/draft-ietf-quic-multipath-05#section-3
      * enable_multipath is designed to be effective only on current connection and do not apply to
      * future connections, storing this parameter and recover on future connections is prohibited.
      * NOTICE: enable_multipath MIGHT be modified or removed as it is not an official parameter
      */
     uint64_t                enable_multipath;
+
+
+    xqc_multipath_version_t   multipath_version;
 
 } xqc_transport_params_t;
 

--- a/tests/unittest/xqc_engine_test.c
+++ b/tests/unittest/xqc_engine_test.c
@@ -45,11 +45,19 @@ xqc_test_engine_packet_process()
 
     xqc_msec_t recv_time = xqc_monotonic_timestamp();
 
+#ifdef XQC_NO_PID_PACKET_PROCESS
     xqc_int_t rc = xqc_engine_packet_process(engine, XQC_TEST_LONG_HEADER_PACKET_B,
                                              sizeof(XQC_TEST_LONG_HEADER_PACKET_B) - 1,
                                              (struct sockaddr *)(&local_addr), local_addrlen,
                                              (struct sockaddr *)(&peer_addr), peer_addrlen,
                                              recv_time, NULL);
+#else
+    xqc_int_t rc = xqc_engine_packet_process(engine, XQC_TEST_LONG_HEADER_PACKET_B,
+                                             sizeof(XQC_TEST_LONG_HEADER_PACKET_B) - 1,
+                                             (struct sockaddr *)(&local_addr), local_addrlen,
+                                             (struct sockaddr *)(&peer_addr), peer_addrlen,
+                                             XQC_UNKNOWN_PATH_ID, recv_time, NULL);
+#endif                                             
     //CU_ASSERT(rc == XQC_OK);
 
     /* get connection */
@@ -68,10 +76,17 @@ xqc_test_engine_packet_process()
     conn->conn_flag |= XQC_CONN_FLAG_HANDSHAKE_COMPLETED;
 
     recv_time = xqc_monotonic_timestamp();
+#ifdef XQC_NO_PID_PACKET_PROCESS
     rc = xqc_engine_packet_process(engine, XQC_TEST_SHORT_HEADER_PACKET_A,
                                    sizeof(XQC_TEST_SHORT_HEADER_PACKET_A) - 1,
                                    (struct sockaddr *)&local_addr, local_addrlen,
                                    (struct sockaddr *)&peer_addr, peer_addrlen, recv_time, NULL);
+#else
+    rc = xqc_engine_packet_process(engine, XQC_TEST_SHORT_HEADER_PACKET_A,
+                                   sizeof(XQC_TEST_SHORT_HEADER_PACKET_A) - 1,
+                                   (struct sockaddr *)&local_addr, local_addrlen,
+                                   (struct sockaddr *)&peer_addr, peer_addrlen, XQC_UNKNOWN_PATH_ID, recv_time, NULL);
+#endif
     //CU_ASSERT(rc == XQC_OK);
 
     xqc_engine_destroy(engine);

--- a/tests/unittest/xqc_h3_test.c
+++ b/tests/unittest/xqc_h3_test.c
@@ -430,7 +430,7 @@ xqc_test_stream()
     xqc_connection_t *conn = test_engine_connect();
     CU_ASSERT(conn != NULL);
 
-    xqc_stream_t *stream = xqc_create_stream_with_conn(conn, XQC_UNDEFINE_STREAM_ID, XQC_CLI_UNI, NULL);
+    xqc_stream_t *stream = xqc_create_stream_with_conn(conn, XQC_UNDEFINE_STREAM_ID, XQC_CLI_UNI, NULL, NULL);
     CU_ASSERT(stream != NULL);
 
     xqc_h3_conn_t *h3c = xqc_h3_conn_create(conn, NULL);

--- a/xqc_configure.h.in
+++ b/xqc_configure.h.in
@@ -7,3 +7,4 @@
 #cmakedefine XQC_ENABLE_COPA
 #cmakedefine XQC_ENABLE_UNLIMITED
 #cmakedefine XQC_ENABLE_MP_INTEROP
+#cmakedefine XQC_NO_PID_PACKET_PROCESS


### PR DESCRIPTION
This version upgrade functions as follows:

- [+] Upgrade achievement of multipath draft-05
- [+] Enable mp server to update CID during NAT Rebinding
- [+] Add test of NAT rebinding in demo_client
- [~] Simplify MPQUIC backup scheduler
- [~] Upgrade MPQUIC reinjection
- [~] Fix bug on connection migration (simple path)
- [~] Fix PTO infinite loop
- [~] Fix sending ACK_MP in Init/HSK PNS