### PR TITLE
Fix Bug in xqc_engine.c, Bug: Reinject unacked packet twice 

### DIFF
--- a/src/transport/xqc_engine.c
+++ b/src/transport/xqc_engine.c
@@ -921,11 +921,6 @@ xqc_engine_main_logic(xqc_engine_t *engine)
                 xqc_conn_send_packets(conn);
             }
 
-            if (conn->conn_settings.mp_enable_reinjection & XQC_REINJ_UNACK_AFTER_SEND) {
-                xqc_conn_reinject_unack_packets(conn, XQC_REINJ_UNACK_AFTER_SEND);
-                xqc_conn_send_packets(conn);
-            }
-
             if (XQC_UNLIKELY(conn->conn_state == XQC_CONN_STATE_CLOSED)) {
                 conn->conn_flag &= ~XQC_CONN_FLAG_TICKING;
                 if (!(engine->eng_flag & XQC_ENG_FLAG_NO_DESTROY)) {


### PR DESCRIPTION


In xqc_conn_schedule_packets_to_paths, the unacked packets are reinjected. After that, they are reinjected again. So, those lines of code should be deleted.