### PR TITLE
Allow building with dynamic libssl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,15 +60,17 @@ if(NOT SSL_INC_PATH AND NOT SSL_LIB_PATH)
     find_package(SSL)
 
     if(NOT SSL_FOUND)
-        message(FATAL_ERROR "ssl moudle not found")
+        message(FATAL_ERROR "ssl module not found")
     endif(NOT SSL_FOUND)
 
-    if(NOT SSL_LIBRARIES_STATIC)
-        message(FATAL_ERROR "ssl/crypto static library not found")
-    endif(NOT SSL_LIBRARIES_STATIC)
-
     # compat with elder macros
-    set(SSL_LIB_PATH ${SSL_LIBRARIES_STATIC})
+    if(SSL_DYNAMIC)
+        message(NOTICE "-- Building with dynamic libssl")
+        set(SSL_LIB_PATH ${SSL_LIBRARIES})
+    else()
+        message(NOTICE "-- Building with static libssl")
+        set(SSL_LIB_PATH ${SSL_LIBRARIES_STATIC})
+    endif()
     set(SSL_INC_PATH ${SSL_INCLUDE_DIR})
 
 else()
@@ -338,11 +340,13 @@ set (
 
 
 # target
-add_library(
-    xquic-static
-    STATIC
-    ${XQC_SOURCE}
-)
+if(NOT SSL_DYNAMIC)
+    add_library(
+        xquic-static
+        STATIC
+        ${XQC_SOURCE}
+    )
+endif()
 
 add_library(
     xquic

--- a/CMakeOptions.txt
+++ b/CMakeOptions.txt
@@ -3,6 +3,7 @@
 option(ENABLE_DEBUG                     "Turn on debug output"  ON)
 option(XQC_BUILD_OPENSSL                "Turn on OpenSSL"       ON)
 option(SSL_TYPE                         "Using BoringSSL"       boringssl)
+option(SSL_DYNAMIC                      "Use dynamic libssl"    OFF)
 option(XQC_ENABLE_TESTING               "Enable Testing"        OFF)
 option(XQC_BUILD_SAMPLE                 "Build Sample"          OFF)
 option(GCOV                             "Test Coverage"         OFF)

--- a/cmake/FindSSL.cmake
+++ b/cmake/FindSSL.cmake
@@ -4,20 +4,20 @@
 
 # find include dir
 find_path(SSL_INCLUDE_DIR           NAMES openssl/ssl.h
-    PATHS ${SSL_DIR} 
+    PATHS ${SSL_DIR}
     PATH_SUFFIXES include
     NO_DEFAULT_PATH)
 
 # find ssl library
 find_library(SSL_LIBRARY            NAMES ssl
-    PATHS ${SSL_DIR} 
-    PATH_SUFFIXES lib64 lib build
+    PATHS ${SSL_DIR}
+    PATH_SUFFIXES lib64 lib build build/ssl
     NO_DEFAULT_PATH)
 
 # find crypto library
 find_library(CRYPTO_LIBRARY         NAMES crypto
-    PATHS ${SSL_DIR} 
-    PATH_SUFFIXES lib64 lib build
+    PATHS ${SSL_DIR}
+    PATH_SUFFIXES lib64 lib build build/crypto
     NO_DEFAULT_PATH)
 
 
@@ -32,7 +32,7 @@ endif()
 
 # find ssl static library
 find_library(SSL_LIBRARY_STATIC     NAMES ${SSL_LIBRARY_STATIC_NAME}
-    PATHS ${SSL_DIR} 
+    PATHS ${SSL_DIR}
     PATH_SUFFIXES lib64 lib build/ssl build/ssl/${CMAKE_BUILD_TYPE}
     NO_DEFAULT_PATH)
 
@@ -43,12 +43,21 @@ find_library(CRYPTO_LIBRARY_STATIC  NAMES ${CRYPTO_LIBRARY_STATIC_NAME}
     NO_DEFAULT_PATH)
 
 include (FindPackageHandleStandardArgs)
-find_package_handle_standard_args(SSL
-    REQUIRED_VARS
-    SSL_INCLUDE_DIR
-    SSL_LIBRARY_STATIC
-    CRYPTO_LIBRARY_STATIC
-)
+if(SSL_DYNAMIC)
+    find_package_handle_standard_args(SSL
+        REQUIRED_VARS
+        SSL_INCLUDE_DIR
+        SSL_LIBRARY
+        CRYPTO_LIBRARY
+    )
+else()
+    find_package_handle_standard_args(SSL
+        REQUIRED_VARS
+        SSL_INCLUDE_DIR
+        SSL_LIBRARY_STATIC
+        CRYPTO_LIBRARY_STATIC
+    )
+endif()
 
 set (SSL_LIBRARIES
     ${SSL_LIBRARY}


### PR DESCRIPTION
The cmake build will always statically link `libssl` and `libcrypto`. In some cases, it may be preferable to dynamically link them. This adds `-DSSL_DYNAMIC=1` which will build `libxquic` dynamically linked to `libssl` and `libcrypto` and also disable `libxquic-static`.