### PR TITLE
[!] fix interop multiplexing testcase error when hq stream send content and fin separately

### DIFF
--- a/demo/xqc_hq_request.c
+++ b/demo/xqc_hq_request.c
@@ -324,6 +324,9 @@ xqc_hq_request_recv_req(xqc_hq_request_t *hqr, char *res_buf, size_t buf_sz, uin
         read = (ssize_t)strncpy(res_buf, hqr->resource_buf, buf_sz);
         hqr->resource_read_offset += read;
         *fin = (hqr->fin || req_fin);
+
+    } else {
+        read = 0;
     }
 
     return read;


### PR DESCRIPTION
when client send separated stream content and fin, the read variable might be negative, makes state of hq request read error and infinite loop