### PR TITLE
[~] When server side receive Retry packets, just ignore the packet instead of closing connection. 

### DIFF
--- a/src/transport/xqc_packet_parser.c
+++ b/src/transport/xqc_packet_parser.c
@@ -1037,8 +1037,8 @@ xqc_packet_parse_retry(xqc_connection_t *c, xqc_packet_in_t *packet_in)
 
     /* check conn type, only client can receive a Retry packet */
     if (c->conn_type != XQC_CONN_TYPE_CLIENT) {
-        xqc_log(c->log, XQC_LOG_WARN, "|invalid conn_type|%d|", c->conn_type);
-        return -XQC_EPROTO;
+        xqc_log(c->log, XQC_LOG_WARN, "|invalid conn_type recvd retry packet|%d|ignored|", c->conn_type);
+        return -XQC_EIGNORE_PKT;
     }
 
     /**


### PR DESCRIPTION
For handshake corruption interop cases.

The issue scene: Client side send several handshake packets to server side, which were modified by in-the-middle devices / boxed, and happen to change the Packet Type as Retry packet. In this scene, the changed packet should be dropped without causing connection error.