### PR TITLE
fix vulnerablilities

### DIFF
--- a/src/http3/xqc_h3_stream.c
+++ b/src/http3/xqc_h3_stream.c
@@ -1687,8 +1687,10 @@ xqc_h3_stream_process_data(xqc_stream_t *stream, xqc_h3_stream_t *h3s, xqc_bool_
 
         } else if (h3s->type == XQC_H3_STREAM_TYPE_BYTESTEAM) {
             //TODO: mark the fin flag of the bytestream and record time
-            xqc_h3_ext_bytestream_fin_rcvd(h3s->h3_ext_bs);
-            xqc_h3_ext_bytestream_set_fin_rcvd_flag(h3s->h3_ext_bs);
+            if (h3s->h3_ext_bs) {
+                xqc_h3_ext_bytestream_fin_rcvd(h3s->h3_ext_bs);
+                xqc_h3_ext_bytestream_set_fin_rcvd_flag(h3s->h3_ext_bs);
+            }
         }    
     }
 
@@ -1882,6 +1884,7 @@ xqc_h3_stream_read_notify(xqc_stream_t *stream, void *user_data)
 
         /* TODO: BYTESTRAM: notify DATA to application ASAP */
         if (h3s->type == XQC_H3_STREAM_TYPE_BYTESTEAM
+            && h3s->h3_ext_bs
             && xqc_h3_ext_bytestream_should_notify_read(h3s->h3_ext_bs))
         {
             ret = xqc_h3_ext_bytestream_notify_read(h3s->h3_ext_bs);

--- a/src/transport/xqc_send_queue.c
+++ b/src/transport/xqc_send_queue.c
@@ -277,10 +277,19 @@ xqc_send_queue_remove_probe(xqc_list_head_t *pos)
 void
 xqc_send_queue_insert_unacked(xqc_packet_out_t *packet_out, xqc_list_head_t *head, xqc_send_queue_t *send_queue)
 {
+    xqc_connection_t *conn = send_queue->sndq_conn;
     xqc_list_add_tail(&packet_out->po_list, head);
     if (!(packet_out->po_flag & XQC_POF_IN_UNACK_LIST)) {
         send_queue->sndq_packets_in_unacked_list++;
         packet_out->po_flag |= XQC_POF_IN_UNACK_LIST;
+        if (send_queue->sndq_packets_in_unacked_list > XQC_SNDQ_MAX_UNACK_PACKETS_LIMIT) {
+            if (conn) {
+                XQC_CONN_ERR(conn, XQC_ELIMIT);
+                xqc_log(conn->log, XQC_LOG_ERROR,
+                        "|sndq unack packets exceed|sndq_packets_in_unacked_list:%ui|",
+                        send_queue->sndq_packets_in_unacked_list); 
+            }
+        }  
     }
 }
 

--- a/src/transport/xqc_send_queue.h
+++ b/src/transport/xqc_send_queue.h
@@ -7,6 +7,7 @@
 
 #define XQC_SNDQ_PACKETS_USED_MAX            18000
 #define XQC_SNDQ_RELEASE_ENOUGH_SPACE_TH     10  /* 1 / 10*/
+#define XQC_SNDQ_MAX_UNACK_PACKETS_LIMIT     (100 * 1000) /* limit unack packets to avoid ddos attack */
 
 typedef struct xqc_send_queue_s {
 

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -1367,8 +1367,8 @@ xqc_server_request_read_notify(xqc_h3_request_t *h3_request, xqc_request_notify_
 
         for (int i = 0; i < headers->count; i++) {
             printf("%s = %s\n", (char *)headers->headers[i].name.iov_base, (char *)headers->headers[i].value.iov_base);
-
-            if (memcmp((char *)headers->headers[i].name.iov_base, "priority", 8) == 0) {
+            if (headers->headers[i].name.iov_len == 8
+                && memcmp((char *)headers->headers[i].name.iov_base, "priority", 8) == 0) {
                 xqc_h3_priority_t h3_prio;
                 xqc_int_t ret = xqc_parse_http_priority(&h3_prio,
                                                         headers->headers[i].value.iov_base,


### PR DESCRIPTION
fix vulnerablilities:
1、NULL pointer dereference and Heap OOB read 
2、Stack OOB read when copying a string for logs
3、limit crypto stream frame data buffer and unack packets send buffer