### PR TITLE
Version update 1.8.4

### DIFF
--- a/include/xquic/xquic.h
+++ b/include/xquic/xquic.h
@@ -72,7 +72,9 @@ typedef enum xqc_proto_version_s {
 
 #define XQC_RESET_TOKEN_MAX_KEY_LEN     256
 
-
+#define XQC_TOKEN_MAX_KEY_VERSION       4
+#define XQC_TOKEN_VERSION_MASK          3
+#define XQC_TOKEN_MAX_KEY_LEN           256
 /**
  * the max message count of iovec in sendmmsg
  */
@@ -417,6 +419,17 @@ typedef void (*xqc_conn_ready_to_create_path_notify_pt)(const xqc_cid_t *scid,
 typedef xqc_int_t (*xqc_conn_cert_cb_pt)(const char *sni,
     void **chain, void **crt, void **key, void *user_data);
 
+typedef void (*xqc_conn_ssl_msg_cb_pt)(int msg_type, 
+    const void *msg, size_t msg_len, void *user_data);
+
+/**
+ * @brief to determine whether to send a retry packet
+ * @return XQC_TRUE(1): meet condition to send a retry packet
+ *         XQC_FALSE(0): don't meet condition to send a retry packet or  an error occurred while judging the condition
+ */
+typedef int (*xqc_conn_retry_packet_pt)(xqc_engine_t *engine, xqc_connection_t *conn,
+    const xqc_cid_t *cid, void *user_data);
+
 /**
  * @brief multi-path create callback function
  *
@@ -702,6 +715,17 @@ typedef struct xqc_transport_callbacks_s {
      * @brief cert callback
      */
     xqc_conn_cert_cb_pt                     conn_cert_cb;
+
+    xqc_conn_ssl_msg_cb_pt                  conn_ssl_msg_cb;
+    /**
+     * @brief check the conditions to send retry packet
+     */
+    xqc_conn_retry_packet_pt                conn_retry_packet_condition_check;
+    /**
+     * @brief server send packet before server accept the connection.
+     * for example, retry packet is sent when the application layer connection has not been established, 
+     */
+    xqc_socket_write_pt                     conn_send_packet_before_accept;
 
 } xqc_transport_callbacks_t;
 

--- a/include/xquic/xquic_typedef.h
+++ b/include/xquic/xquic_typedef.h
@@ -229,6 +229,7 @@ typedef struct xqc_http_priority_s {
     uint8_t                 schedule;
     uint8_t                 reinject;
     uint32_t                fec;
+    uint8_t                 fastpath;
 } xqc_h3_priority_t;
 
 /* ALPN definition */
@@ -332,5 +333,18 @@ typedef enum {
     /* max */
     XQC_APP_PATH_STATUS_MAX,
 } xqc_app_path_status_t;
+
+typedef enum xqc_tls_msg_type_e {
+    XQC_TLS_1_3_CLIENT_HELLO,
+    XQC_TLS_1_3_SERVER_HELLO
+} xqc_tls_msg_type_t;
+
+typedef enum xqc_tls_group_type_e {
+    XQC_TLS_GROUP_DEFAULT      = 0,
+    XQC_TLS_GROUP_P256_FIRST   = 1,
+    XQC_TLS_GROUP_X25519_FIRST = 2,
+    XQC_TLS_GROUP_P384_FIRST   = 3,
+    XQC_TLS_GROUP_P521_FIRST   = 4,
+} xqc_tls_group_type_t;
 
 #endif /*_XQUIC_TYPEDEF_H_INCLUDED_*/

--- a/src/common/xqc_random.c
+++ b/src/common/xqc_random.c
@@ -23,15 +23,19 @@
 
 long xqc_random(void) {
 #ifdef XQC_SYS_WINDOWS
-    unsigned int  val;
-    if (rand_s(&val)) {
+    unsigned int  val = 0;
+    long result = 0;
+
+    if (rand_s(&val) == 0) {
         val = rand();
     }
-    return (long)val & 0xFFFFFFFF;
-#else
-    return random();
-#endif
 
+    result = (long)(val & 0x7FFFFFFF);
+    return result;
+#else
+    long result = random();
+    return result;
+#endif
 }
 
 xqc_random_generator_t * 

--- a/src/common/xqc_time.c
+++ b/src/common/xqc_time.c
@@ -52,5 +52,11 @@ xqc_now()
     return  ul;
 }
 
+xqc_usec_t
+xqc_update_avg_time(xqc_usec_t new_time, xqc_usec_t ori_time, xqc_int_t ori_time_num)
+{
+    return (xqc_usec_t)(1.0 * new_time / (ori_time_num + 1) + 1.0 * ori_time / (ori_time_num + 1) * ori_time_num);
+}
+
 xqc_timestamp_pt xqc_realtime_timestamp  = xqc_now;
 xqc_timestamp_pt xqc_monotonic_timestamp = xqc_now;

--- a/src/common/xqc_time.h
+++ b/src/common/xqc_time.h
@@ -30,5 +30,7 @@ extern xqc_timestamp_pt xqc_realtime_timestamp;
  */
 extern xqc_timestamp_pt xqc_monotonic_timestamp;
 
+xqc_usec_t xqc_update_avg_time(xqc_usec_t new_time, xqc_usec_t ori_time, xqc_int_t ori_time_num);
+
 #endif /* _XQC_TIME_H_INCLUDED_ */
 

--- a/src/congestion_control/xqc_bbr.c
+++ b/src/congestion_control/xqc_bbr.c
@@ -581,7 +581,7 @@ xqc_bbr_enter_probe_bw(xqc_bbr_t *bbr, xqc_sample_t *sampler)
 {
     bbr->mode = BBR_PROBE_BW;
     bbr->cwnd_gain = xqc_bbr_cwnd_gain;
-    bbr->cycle_idx = xqc_random() % (XQC_BBR_CYCLE_LENGTH - 1);
+    bbr->cycle_idx = (uint32_t)(xqc_random() % (XQC_BBR_CYCLE_LENGTH - 1));
     bbr->cycle_idx = bbr->cycle_idx == 0 ? bbr->cycle_idx : bbr->cycle_idx + 1;
     bbr->pacing_gain = xqc_bbr_get_pacing_gain(bbr, bbr->cycle_idx);
     bbr->cycle_start_stamp = sampler->now;

--- a/src/http3/xqc_h3_stream.c
+++ b/src/http3/xqc_h3_stream.c
@@ -2117,12 +2117,16 @@ xqc_h3_stream_set_priority(xqc_h3_stream_t *h3s, xqc_h3_priority_t *prio)
         h3s->priority.schedule    = prio->schedule;
         h3s->priority.reinject    = prio->reinject;
         h3s->priority.fec         = prio->fec;
+        h3s->priority.fastpath    = prio->fastpath;
 
         if (h3s->stream == NULL) {
             xqc_log(h3s->log, XQC_LOG_ERROR, "|transport stream was NULL|stream_id:%ui|", h3s->stream_id);
             return;
         }
 
+        if (h3s->priority.fastpath) {
+            xqc_stream_set_priority(h3s->stream, XQC_STREAM_PRI_HIGH);
+        }
         xqc_stream_set_multipath_usage(h3s->stream, h3s->priority.schedule, h3s->priority.reinject);
         h3s->stream->stream_fec_blk_mode = xqc_set_stream_fec_block_mode(h3s->priority.fec);
         h3s->h3r->block_size_mode = h3s->stream->stream_fec_blk_mode;

--- a/src/tls/xqc_ssl_cbs.h
+++ b/src/tls/xqc_ssl_cbs.h
@@ -18,6 +18,14 @@
  */
 void xqc_ssl_keylog_cb(const SSL *ssl, const char *line);
 
+/**
+ * @brief log tls message
+ * @see SSL_CTX_set_msg_callback
+ */
+void
+xqc_ssl_msg_cb(int write_p, int version, int content_type, 
+    const void *buf, size_t len, SSL *ssl, void *arg);
+
 
 /**
  * @brief select an ALPN protocol from the client's list of offered protocols

--- a/src/tls/xqc_tls.h
+++ b/src/tls/xqc_tls.h
@@ -27,7 +27,6 @@
 #undef X509_NAME
 #endif
 
-
 /**
  * @brief init tls context. MUST be called before any creation of xqc_tls_t
  */
@@ -209,9 +208,9 @@ void xqc_tls_discard_old_1rtt_keys(xqc_tls_t *tls);
 /**
  * @brief encrypt retry pseudo-packet to calculate retry integrity tag
  */
-xqc_int_t xqc_tls_cal_retry_integrity_tag(xqc_tls_t *tls,
+xqc_int_t xqc_tls_cal_retry_integrity_tag(xqc_log_t *log,
     uint8_t *retry_pseudo_packet, size_t retry_pseudo_packet_len,
-    uint8_t *dst, size_t dst_cap, size_t *dst_len);
+    uint8_t *dst, size_t dst_cap, size_t *dst_len, xqc_proto_version_t ver);
 
 void xqc_tls_get_selected_alpn(xqc_tls_t *tls, const char **out_alpn,
                                size_t *out_len);

--- a/src/tls/xqc_tls_ctx.c
+++ b/src/tls/xqc_tls_ctx.c
@@ -342,6 +342,10 @@ xqc_tls_ctx_create(xqc_tls_type_t type, const xqc_engine_ssl_config_t *cfg,
         SSL_CTX_set_keylog_callback(ctx->ssl_ctx, xqc_ssl_keylog_cb);
     }
 
+    if (cbs->msg_cb) {
+        SSL_CTX_set_msg_callback(ctx->ssl_ctx, xqc_ssl_msg_cb);
+    }
+
     return ctx;
 
 fail:

--- a/src/tls/xqc_tls_defs.h
+++ b/src/tls/xqc_tls_defs.h
@@ -87,6 +87,8 @@ typedef struct xqc_tls_config_s {
     uint8_t                *trans_params;
     size_t                  trans_params_len;
 
+    char                   *tls_groups;
+
 } xqc_tls_config_t;
 
 
@@ -138,6 +140,10 @@ typedef void (*xqc_tls_handshake_completed_pt)(void *user_data);
 typedef xqc_int_t (*xqc_tls_cert_cb_pt)(const char *sni,
     void **chain, void **crt, void **key, void *user_data);
 
+    
+typedef void (*xqc_tls_msg_cb_pt)(int msg_type, 
+    const void *msg, size_t msg_len, void *user_data);
+
 /**
  * @brief definition of callback functions to upper layer
  */
@@ -169,6 +175,8 @@ typedef struct xqc_tls_callbacks_s {
     xqc_tls_handshake_completed_pt  hsk_completed_cb;
 
     xqc_tls_cert_cb_pt              cert_cb;
+
+    xqc_tls_msg_cb_pt               msg_cb;
 } xqc_tls_callbacks_t;
 
 

--- a/src/transport/xqc_defs.h
+++ b/src/transport/xqc_defs.h
@@ -49,6 +49,10 @@
 
 /* max token length supported by xquic */
 #define XQC_MAX_TOKEN_LEN               256
+#define XQC_TOKEN_IV_LEN                12
+#define XQC_TOKEN_TAG_LEN               16
+/* EVP_aes_128_gcm secret len */
+#define XQC_TOKEN_SECRET_LEN            16 
 
 /* length of retry integrity tag */
 #define XQC_RETRY_INTEGRITY_TAG_LEN     16

--- a/src/transport/xqc_engine.h
+++ b/src/transport/xqc_engine.h
@@ -11,7 +11,7 @@
 #include <xquic/xquic.h>
 #include "src/tls/xqc_tls.h"
 #include "src/common/xqc_list.h"
-
+#include "src/transport/xqc_defs.h"
 #define XQC_RESET_CNT_ARRAY_LEN 16384
 
 
@@ -80,7 +80,9 @@ typedef struct xqc_engine_s {
     char                            peer_addr_str[INET6_ADDRSTRLEN];
 
     void                           *priv_ctx;
-
+    unsigned char                   token_secret_list[XQC_TOKEN_MAX_KEY_VERSION][XQC_TOKEN_SECRET_LEN];
+    uint8_t                         cur_ts_index;
+    
 } xqc_engine_t;
 
 

--- a/src/transport/xqc_fec.c
+++ b/src/transport/xqc_fec.c
@@ -1572,3 +1572,22 @@ xqc_fec_on_stream_size_changed(xqc_stream_t *quic_stream)
         conn->conn_settings.fec_callback.xqc_fec_init_one(conn, 0);
     }
 }
+
+void
+xqc_record_fec_state(xqc_stream_t *stream)
+{
+    xqc_int_t   enable_stream_num;
+    xqc_usec_t  curr_recv_delay, curr_fec_recv_opt;
+    xqc_usec_t  curr_close_delay;
+    if (stream->stream_conn->fec_ctl == NULL) {
+        return;
+    }
+
+#define __calc_delay(a, b) ((a && b && (a > b))? (a) - (b) : 0)
+    enable_stream_num = stream->stream_conn->fec_ctl->fec_enable_stream_num++;
+    curr_recv_delay = __calc_delay(stream->stream_stats.recv_time_with_fec, stream->stream_stats.create_time);
+    curr_fec_recv_opt = __calc_delay(stream->stream_stats.final_packet_time, stream->stream_stats.recv_time_with_fec);
+    stream->stream_conn->fec_ctl->conn_avg_recv_delay = xqc_update_avg_time(curr_recv_delay, stream->stream_conn->fec_ctl->conn_avg_recv_delay, enable_stream_num); 
+    stream->stream_conn->fec_ctl->fec_avg_opt_time = xqc_update_avg_time(curr_fec_recv_opt, stream->stream_conn->fec_ctl->fec_avg_opt_time, enable_stream_num); 
+#undef __calc_delay
+}

--- a/src/transport/xqc_fec.h
+++ b/src/transport/xqc_fec.h
@@ -220,4 +220,6 @@ xqc_int_t xqc_send_repair_packets(xqc_connection_t *conn, xqc_fec_schemes_e sche
 xqc_int_t xqc_process_fec_protected_packet_moq(xqc_stream_t *stream);
 
 void xqc_fec_on_stream_size_changed(xqc_stream_t *quic_stream);
+
+void xqc_record_fec_state(xqc_stream_t *stream);
 #endif  /* _XQC_FEC_H_INCLUDED_ */

--- a/src/transport/xqc_packet.c
+++ b/src/transport/xqc_packet.c
@@ -120,6 +120,7 @@ xqc_conn_check_initial_packet_from_cur_state(xqc_conn_state_t cur_state)
     return XQC_TRUE;
 }
 
+
 xqc_int_t
 xqc_packet_parse_single(xqc_connection_t *c, xqc_packet_in_t *packet_in)
 {
@@ -183,6 +184,12 @@ xqc_packet_parse_single(xqc_connection_t *c, xqc_packet_in_t *packet_in)
             xqc_log(c->log, XQC_LOG_ERROR,
                     "|xqc_packet_parse_long_header error:%d|", ret);
             return ret;
+        }
+
+        if (XQC_PTYPE_INIT == XQC_PACKET_LONG_HEADER_GET_TYPE(pos)) {
+            if (c->conn_type == XQC_CONN_TYPE_SERVER && !(c->conn_flag & XQC_CONN_FLAG_SERVER_ACCEPT)) {
+                return xqc_conn_server_accept(c); 
+            }
         }
 
     } else {

--- a/src/transport/xqc_packet_out.c
+++ b/src/transport/xqc_packet_out.c
@@ -1125,7 +1125,10 @@ xqc_write_new_token_to_packet(xqc_connection_t *conn)
 
     unsigned char token[XQC_MAX_TOKEN_LEN];
     unsigned token_len = XQC_MAX_TOKEN_LEN;
-    xqc_conn_gen_token(conn, token, &token_len);
+    if (xqc_conn_gen_token(conn, token, &token_len) != XQC_OK) {
+        xqc_log(conn->log, XQC_LOG_ERROR, "|gen token failed|");
+        return -XQC_EWRITE_PKT;
+    }
 
     need = 1 /* type */
             + xqc_vint_get_2bit(token_len) /* token len */

--- a/src/transport/xqc_packet_parser.h
+++ b/src/transport/xqc_packet_parser.h
@@ -48,7 +48,7 @@ xqc_int_t xqc_packet_parse_zero_rtt(xqc_connection_t *c, xqc_packet_in_t *packet
 
 xqc_int_t xqc_packet_parse_handshake(xqc_connection_t *c, xqc_packet_in_t *packet_in);
 
-int xqc_gen_retry_packet(unsigned char *dst_buf,
+int xqc_gen_retry_packet(xqc_connection_t *c, unsigned char *dst_buf,
     const unsigned char *dcid, unsigned char dcid_len,
     const unsigned char *scid, unsigned char scid_len,
     const unsigned char *odcid, unsigned char odcid_len,

--- a/src/transport/xqc_stream.h
+++ b/src/transport/xqc_stream.h
@@ -195,8 +195,6 @@ struct xqc_stream_s {
         xqc_list_head_t    *stream_fec_head;
         xqc_list_head_t    *stream_fec_tail;
 
-        uint16_t            is_video_frame;
-
     } stream_fec_ctl;
 };
 
@@ -296,5 +294,8 @@ void xqc_stream_closing(xqc_stream_t *stream, xqc_int_t err);
 
 void xqc_stream_close_discarded_stream(xqc_stream_t *stream);
 
+xqc_bool_t xqc_is_stream_finished(xqc_stream_t *stream);
+
+void xqc_record_stream_state(xqc_stream_t *stream);
 #endif /* _XQC_STREAM_H_INCLUDED_ */
 


### PR DESCRIPTION
[+] [Supports address validation using retry packets](https://www.rfc-editor.org/rfc/rfc9000#name-address-validation-using-re), and Support for the X25519 cipher suite. @derekwin 
[+] feat: support TLS message callback. @yangfurong 
[+] feat: support the client to specify the order of ssl curves for individual connections. @yangfurong 
