### PR TITLE
[+] Feat: Add retry interop test and fix retry-interop error 

### DIFF
--- a/demo/demo_server.c
+++ b/demo/demo_server.c
@@ -1411,6 +1411,16 @@ xqc_demo_svr_parse_args(int argc, char *argv[], xqc_demo_svr_args_t *args)
     }
 }
 
+int
+xqc_demo_svr_retry_packet_condition_check(xqc_engine_t *engine, xqc_connection_t *conn,
+    const xqc_cid_t *cid, void *user_data)
+{
+    if (svr_ctx.args && svr_ctx.args->quic_cfg.retry_on) {
+        return XQC_TRUE;
+    }
+    return XQC_FALSE;
+}
+
 void
 xqc_demo_svr_init_callback(xqc_engine_callback_t *cb, xqc_transport_callbacks_t *transport_cbs,
     xqc_demo_svr_args_t* args)
@@ -1431,6 +1441,8 @@ xqc_demo_svr_init_callback(xqc_engine_callback_t *cb, xqc_transport_callbacks_t 
         .write_socket = xqc_demo_svr_write_socket,
         .write_socket_ex = xqc_demo_svr_write_socket_ex,
         .conn_update_cid_notify = xqc_demo_svr_conn_update_cid_notify,
+        .conn_send_packet_before_accept = xqc_demo_svr_write_socket,
+        .conn_retry_packet_condition_check = xqc_demo_svr_retry_packet_condition_check,
     };
 
     *cb = callback;

--- a/interop/run_endpoint.sh
+++ b/interop/run_endpoint.sh
@@ -86,18 +86,16 @@ if [ "$ROLE" == "client" ]; then
 
 
 elif [ "$ROLE" == "server" ]; then
-
-    if [ "$TESTCASE" == "retry" ]; then
-        exit 127
-    fi
-
     cp /certs/priv.key server.key
     cp /certs/cert.pem server.crt
-    cp server.* /logs/
-
-    #cp -r /www /logs
 
     ARGS="-l d -L "$LOG_DIR/server.log" -p 443 -D "/www" -k $SSLKEYLOGFILE -i -M"
+
+    if [ "$TESTCASE" = "retry" ]; then
+        ARGS="$ARGS -r"
+        echo "Retry test: adding -r flag"
+    fi
+
     echo "./demo_server $ARGS"
     ./demo_server $ARGS
 fi


### PR DESCRIPTION
Fix #506 

Add retry callback into retry test and add retry into quic-interop-runner test.

Now test result:

<img width="657" height="213" alt="Running" src="https://github.com/user-attachments/assets/bacc5ddd-0041-4c82-957c-615f05f40a44" />
