### PR TITLE
[+] Fix: Enhance request parsing to avoid hq parsing error

### DIFF
--- a/demo/xqc_hq_request.c
+++ b/demo/xqc_hq_request.c
@@ -233,25 +233,23 @@ xqc_hq_parse_req(xqc_hq_request_t *hqr, char *res, size_t sz, uint8_t *fin)
     char method[16] = {0};
     char fmt[32] = {0};
     size_t method_cap = sizeof(method) - 1;
-    size_t res_cap;
-    int ret;
-    size_t request_line_len;
+
 
     if (sz <= 1) {
         PRINT_LOG("|invalid resource buffer size|sz:%zu|", sz);
         return -XQC_EPROTO;
     }
 
-    res_cap = sz - 1;
+    size_t res_cap = sz - 1;
     snprintf(fmt, sizeof(fmt), "%%%zus %%%zus", method_cap, res_cap);
 
-    ret = sscanf((char *)hqr->req_recv_buf, fmt, method, res);
+    int ret = sscanf((char *)hqr->req_recv_buf, fmt, method, res);
     if (ret <= 0) {
         PRINT_LOG("|parse hq request failed: %s", hqr->req_recv_buf);
         return -XQC_EPROTO;
     }
 
-    request_line_len = strlen(method) + strlen(res) + 1; /* method + ' ' + path */
+    int request_line_len = strlen(method) + strlen(res) + 1; /* method + ' ' + path */
     if (request_line_len + 2 <= hqr->recv_buf_len
         && (*(hqr->req_recv_buf + request_line_len) == '\r')
         && (*(hqr->req_recv_buf + request_line_len + 1) == '\n'))


### PR DESCRIPTION
Related issue: #518 #511

**Issue:** xqc_hq_parse_req uses sscanf("%s %s") without bounds, so a long URL from neqo overruns the 256‑byte buffer. Since xqc_hq_request_recv_req didn’t null‑terminate the buffer, later strlen() walks into uninitialized memory, causing an ASan heap-buffer-overflow and leaving HQ requests stuck after “hq recv CR LF”.
**Fixes:**
Build a bounded format string (e.g. "%15s %255s") before calling sscanf, so both method and path respect the buffer size.
After reading from the QUIC stream, check whether recv_cnt hits the buffer limit; if not, append '\0'. This guarantees strlen()/sscanf() operate on a valid C string.

When neqo client interop with xquic server, xquic server will trigger core dump & timeout, gdb log like this:
 
```
=================================================================
==8799==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x615000002080 …
    #3 0x100f51c80 in xqc_hq_parse_req xqc_hq_request.c:234
    #4 0x100f52aac in xqc_hq_request_recv_req xqc_hq_request.c:297
    #5 0x100f58600 in xqc_demo_svr_hq_req_read_notify demo_server.c:632
    
```

This PR will solve the issue of parsing error if server run as expected.