### PR TITLE
[+] Fix: Handle illegal STREAM frames in INIT and HSK packets

### DIFF
--- a/src/transport/xqc_frame.c
+++ b/src/transport/xqc_frame.c
@@ -447,6 +447,16 @@ xqc_process_stream_frame(xqc_connection_t *conn, xqc_packet_in_t *packet_in)
     xqc_stream_t        *stream = NULL;
     xqc_stream_frame_t  *stream_frame;
 
+    if (packet_in->pi_pkt.pkt_type == XQC_PTYPE_INIT
+        || packet_in->pi_pkt.pkt_type == XQC_PTYPE_HSK)
+    {
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|illegal STREAM frame in %s packet, close with PROTOCOL_VIOLATION|",
+                xqc_pkt_type_2_str(packet_in->pi_pkt.pkt_type));
+        XQC_CONN_ERR(conn, TRA_PROTOCOL_VIOLATION);
+        return -XQC_EPROTO;
+    }
+
     stream_frame = xqc_calloc(1, sizeof(xqc_stream_frame_t));
     if (stream_frame == NULL) {
         xqc_log(conn->log, XQC_LOG_ERROR, "|xqc_calloc error|");

--- a/tests/unittest/xqc_process_frame_test.c
+++ b/tests/unittest/xqc_process_frame_test.c
@@ -12,6 +12,7 @@
 
 char XQC_TEST_ILL_FRAME_1[] = {0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 char XQC_TEST_ZERO_LEN_NEW_TOKEN_FRAME[] = {0x07, 0x00};
+char XQC_TEST_STREAM_FRAME[] = {0x0a, 0x00, 0x01, 0x00};
 
 
 void
@@ -29,6 +30,14 @@ xqc_test_process_frame()
     packet_in.pos = XQC_TEST_ZERO_LEN_NEW_TOKEN_FRAME;
     packet_in.last = packet_in.pos + sizeof(XQC_TEST_ZERO_LEN_NEW_TOKEN_FRAME);
     ret = xqc_process_frames(conn, &packet_in);
+    CU_ASSERT(ret == -XQC_EPROTO);
+
+    xqc_packet_in_t pi_stream_init;
+    memset(&pi_stream_init, 0, sizeof(xqc_packet_in_t));
+    pi_stream_init.pi_pkt.pkt_type = XQC_PTYPE_INIT;
+    pi_stream_init.pos = XQC_TEST_STREAM_FRAME;
+    pi_stream_init.last = pi_stream_init.pos + sizeof(XQC_TEST_STREAM_FRAME);
+    ret = xqc_process_frames(conn, &pi_stream_init);
     CU_ASSERT(ret == -XQC_EPROTO);
 
     xqc_engine_destroy(conn->engine);


### PR DESCRIPTION
Fix the [issue](https://github.com/alibaba/xquic/security/advisories/GHSA-3x9f-rg77-hvch)  mentioned in #523 

The original description is shown below (written by @NErinola) :

> Description
Description of the Issue
The XQUIC implementation currently accepts STREAM frames in both Initial and Handshake packets. It appears to buffer the received application data and sends a response after handshake completion in a 1‑RTT packet. Accepting STREAM frames in Initial or Handshake packets violates the QUIC specification and allows arbitrary application data injection.
Impact
A man‑in‑the‑middle attacker can use Initial packats to inject arbitrary application data into a new QUIC connection before the handshake fully completes. This can lead to:
Injection of arbitrary data that the client/server will process.
Potential confusion of the application protocol, escalating into further vulnerabilities (e.g. resource confusion in HTTP/3).
Mitigation
According to the QUIC specification, STREAM frames must only be processed from 0‑RTT or 1‑RTT packets, never from Initial and Handshake packets.
Tested Implementation
XQUIC v1.8.3 with BabaSSL v8.3-stbale
The official demo server with HTTP3 support

QUIC RFC in [here](https://www.rfc-editor.org/rfc/rfc9000.html#section-12.4-6):

```
0x08-0x0f | STREAM | Section 19.8 | __01 | F
```
So QUIC RFC do not allow stream frame in Handshake/Initial ptks.
