### PR TITLE
[WIP][Feat] Support Relay basic ability & Support track_namespace_tuple 

### DIFF
--- a/include/moq/xqc_moq.h
+++ b/include/moq/xqc_moq.h
@@ -92,10 +92,16 @@ typedef struct {
 } xqc_moq_selection_params_t;
 
 typedef struct {
-    char                            *track_namespace;
+    size_t                      len;
+    unsigned char              *data;
+} xqc_moq_track_ns_field_t;
+
+typedef struct {
     char                            *track_name;
     xqc_moq_track_type_t            track_type;
     xqc_moq_selection_params_t      selection_params;
+    uint64_t                        track_namespace_num;
+    xqc_moq_track_ns_field_t        *track_namespace_tuple;
 } xqc_moq_track_info_t;
 
 typedef enum {
@@ -130,10 +136,15 @@ typedef struct xqc_moq_subscribe_update_msg_s xqc_moq_subscribe_update_msg_t;
 typedef struct xqc_moq_publish_msg_s xqc_moq_publish_msg_t;
 typedef struct xqc_moq_publish_ok_msg_s xqc_moq_publish_ok_msg_t;
 typedef struct xqc_moq_publish_error_msg_s xqc_moq_publish_error_msg_t;
-typedef struct xqc_moq_announce_msg_s xqc_moq_announce_msg_t;
-typedef struct xqc_moq_announce_ok_msg_s xqc_moq_announce_ok_msg_t;
-typedef struct xqc_moq_announce_error_msg_s xqc_moq_announce_error_msg_t;
-typedef struct xqc_moq_unannounce_msg_s xqc_moq_unannounce_msg_t;
+typedef struct xqc_moq_publish_namespace_msg_s xqc_moq_publish_namespace_msg_t;
+typedef struct xqc_moq_publish_namespace_ok_msg_s xqc_moq_publish_namespace_ok_msg_t;
+typedef struct xqc_moq_publish_namespace_error_msg_s xqc_moq_publish_namespace_error_msg_t;
+typedef struct xqc_moq_publish_namespace_done_msg_s xqc_moq_publish_namespace_done_msg_t;
+typedef struct xqc_moq_publish_namespace_cancel_msg_s xqc_moq_publish_namespace_cancel_msg_t;
+typedef struct xqc_moq_subscribe_namespace_msg_s xqc_moq_subscribe_namespace_msg_t;
+typedef struct xqc_moq_subscribe_namespace_ok_msg_s xqc_moq_subscribe_namespace_ok_msg_t;
+typedef struct xqc_moq_subscribe_namespace_error_msg_s xqc_moq_subscribe_namespace_error_msg_t;
+typedef struct xqc_moq_unsubscribe_namespace_msg_s xqc_moq_unsubscribe_namespace_msg_t;
 typedef struct xqc_moq_unsubscribe_msg_s xqc_moq_unsubscribe_msg_t;
 typedef struct xqc_moq_publish_done_msg_s xqc_moq_publish_done_msg_t;
 typedef struct xqc_moq_client_setup_v14_msg_s xqc_moq_client_setup_v14_msg_t;
@@ -160,18 +171,21 @@ typedef enum {
     XQC_MOQ_MSG_SUBSCRIBE           = 0x3,
     XQC_MOQ_MSG_SUBSCRIBE_OK        = 0x4,
     XQC_MOQ_MSG_SUBSCRIBE_ERROR     = 0x5,
-    XQC_MOQ_MSG_ANNOUNCE            = 0x6,
-    XQC_MOQ_MSG_ANNOUNCE_OK         = 0x7,
-    XQC_MOQ_MSG_ANNOUNCE_ERROR      = 0x8,
-    XQC_MOQ_MSG_UNANNOUNCE          = 0x9,
+    XQC_MOQ_MSG_PUBLISH_NAMESPACE         = 0x6,
+    XQC_MOQ_MSG_PUBLISH_NAMESPACE_OK      = 0x7,
+    XQC_MOQ_MSG_PUBLISH_NAMESPACE_ERROR   = 0x8,
+    XQC_MOQ_MSG_PUBLISH_NAMESPACE_DONE    = 0x9,
     XQC_MOQ_MSG_UNSUBSCRIBE         = 0xA,
     // XQC_MOQ_MSG_SUBSCRIBE_DONE      = 0xB,
     XQC_MOQ_MSG_PUBLISH_DONE        = 0xB,
-    XQC_MOQ_MSG_ANNOUNCE_CANCEL     = 0xC,
+    XQC_MOQ_MSG_PUBLISH_NAMESPACE_CANCEL  = 0xC,
     XQC_MOQ_MSG_TRACK_STATUS_REQUEST = 0xD,
     XQC_MOQ_MSG_TRACK_STATUS        = 0xE,
     XQC_MOQ_MSG_GOAWAY              = 0x10,
-    XQC_MOQ_MSG_SUBGROUP            = 0x14,
+    XQC_MOQ_MSG_SUBSCRIBE_NAMESPACE        = 0x11,
+    XQC_MOQ_MSG_SUBSCRIBE_NAMESPACE_OK     = 0x12,
+    XQC_MOQ_MSG_SUBSCRIBE_NAMESPACE_ERROR  = 0x13,
+    XQC_MOQ_MSG_UNSUBSCRIBE_NAMESPACE      = 0x14,
     XQC_MOQ_MSG_CLIENT_SETUP_V14    = 0x20,
     XQC_MOQ_MSG_SERVER_SETUP_V14    = 0x21,
     XQC_MOQ_MSG_CLIENT_SETUP        = 0x40,
@@ -182,6 +196,7 @@ typedef enum {
     XQC_MOQ_MSG_PUBLISH_OK          = 0x1E,
     XQC_MOQ_MSG_PUBLISH_ERROR       = 0x1F,
     /* Phony message types */
+    XQC_MOQ_MSG_SUBGROUP            = 0xA3,
     XQC_MOQ_MSG_TRACK_STREAM_OBJECT = 0xA0,
     XQC_MOQ_MSG_GROUP_STREAM_OBJECT = 0xA1,
     XQC_MOQ_MSG_SUBGROUP_STREAM_OBJECT = 0xA2,
@@ -234,7 +249,7 @@ typedef struct xqc_moq_subscribe_msg_s {
     uint64_t                    subscribe_id;
     uint64_t                    track_alias;
     uint64_t                    track_namespace_num;
-    char                        *track_namespace;
+    xqc_moq_track_ns_field_t    *track_namespace_tuple;
     size_t                      track_namespace_len;
     char                        *track_name;
     size_t                      track_name_len;
@@ -277,7 +292,7 @@ typedef struct xqc_moq_publish_msg_s {
     uint64_t                    subscribe_id;
     uint64_t                    track_alias;
     uint64_t                    track_namespace_num;
-    char                        *track_namespace;
+    xqc_moq_track_ns_field_t    *track_namespace_tuple;
     size_t                      track_namespace_len;
     char                        *track_name;
     size_t                      track_name_len;
@@ -326,11 +341,93 @@ typedef struct xqc_moq_publish_done_msg_s {
     size_t                      reason_phrase_len;
 } xqc_moq_publish_done_msg_t;
 
+typedef struct xqc_moq_publish_namespace_msg_s {
+    xqc_moq_msg_base_t          msg_base;
+    uint64_t                    request_id;
+    uint64_t                    track_namespace_num;
+    xqc_moq_track_ns_field_t    *track_namespace_tuple;
+    size_t                      track_namespace_len;
+    uint64_t                    params_num;
+    xqc_moq_message_parameter_t *params;
+} xqc_moq_publish_namespace_msg_t;
+
+typedef struct xqc_moq_publish_namespace_ok_msg_s {
+    xqc_moq_msg_base_t          msg_base;
+    uint64_t                    request_id;
+} xqc_moq_publish_namespace_ok_msg_t;
+
+typedef struct xqc_moq_publish_namespace_error_msg_s {
+    xqc_moq_msg_base_t          msg_base;
+    uint64_t                    request_id;
+    uint64_t                    error_code;
+    char                        *reason_phrase;
+    size_t                      reason_phrase_len;
+} xqc_moq_publish_namespace_error_msg_t;
+
+typedef struct xqc_moq_publish_namespace_done_msg_s {
+    xqc_moq_msg_base_t          msg_base;
+    uint64_t                    track_namespace_num;
+    xqc_moq_track_ns_field_t    *track_namespace_tuple;
+    size_t                      track_namespace_len;
+} xqc_moq_publish_namespace_done_msg_t;
+
+typedef struct xqc_moq_publish_namespace_cancel_msg_s {
+    xqc_moq_msg_base_t          msg_base;
+    uint64_t                    track_namespace_num;
+    xqc_moq_track_ns_field_t    *track_namespace_tuple;
+    size_t                      track_namespace_len;
+    uint64_t                    error_code;
+    char                        *reason_phrase;
+    size_t                      reason_phrase_len;
+} xqc_moq_publish_namespace_cancel_msg_t;
+
+typedef struct xqc_moq_subscribe_namespace_msg_s {
+    xqc_moq_msg_base_t          msg_base;
+    uint64_t                    request_id;
+    uint64_t                    track_namespace_num;
+    xqc_moq_track_ns_field_t    *track_namespace_tuple;
+    size_t                      track_namespace_len;
+    uint64_t                    params_num;
+    xqc_moq_message_parameter_t *params;
+} xqc_moq_subscribe_namespace_msg_t;
+
+typedef struct xqc_moq_subscribe_namespace_ok_msg_s {
+    xqc_moq_msg_base_t          msg_base;
+    uint64_t                    request_id;
+} xqc_moq_subscribe_namespace_ok_msg_t;
+
+typedef struct xqc_moq_subscribe_namespace_error_msg_s {
+    xqc_moq_msg_base_t          msg_base;
+    uint64_t                    request_id;
+    uint64_t                    error_code;
+    char                        *reason_phrase;
+    size_t                      reason_phrase_len;
+} xqc_moq_subscribe_namespace_error_msg_t;
+
+typedef struct xqc_moq_unsubscribe_namespace_msg_s {
+    xqc_moq_msg_base_t          msg_base;
+    uint64_t                    track_namespace_num;
+    xqc_moq_track_ns_field_t    *track_namespace_tuple;
+    size_t                      track_namespace_len;
+} xqc_moq_unsubscribe_namespace_msg_t;
+
 typedef enum {
     XQC_MOQ_PUBLISH_ERR_INTERNAL              = 0x0,
     XQC_MOQ_PUBLISH_ERR_SUBSCRIPTION_EXISTS   = 0x3,
     XQC_MOQ_PUBLISH_ERR_TRACK_NOT_FOUND       = 0x4,
 } xqc_moq_publish_error_code_t;
+
+/* draft-14: SUBSCRIBE_NAMESPACE_ERROR error codes */
+typedef enum {
+    XQC_MOQ_SUBSCRIBE_NAMESPACE_ERR_INTERNAL_ERROR           = 0x0,
+    XQC_MOQ_SUBSCRIBE_NAMESPACE_ERR_UNAUTHORIZED             = 0x1,
+    XQC_MOQ_SUBSCRIBE_NAMESPACE_ERR_TIMEOUT                  = 0x2,
+    XQC_MOQ_SUBSCRIBE_NAMESPACE_ERR_NOT_SUPPORTED            = 0x3,
+    XQC_MOQ_SUBSCRIBE_NAMESPACE_ERR_PREFIX_UNKNOWN           = 0x4,
+    XQC_MOQ_SUBSCRIBE_NAMESPACE_ERR_PREFIX_OVERLAP           = 0x5,
+    XQC_MOQ_SUBSCRIBE_NAMESPACE_ERR_MALFORMED_AUTH_TOKEN     = 0x10,
+    XQC_MOQ_SUBSCRIBE_NAMESPACE_ERR_EXPIRED_AUTH_TOKEN       = 0x12,
+} xqc_moq_subscribe_namespace_error_code_t;
 
 typedef struct {
     uint8_t     forward;
@@ -404,6 +501,21 @@ typedef void (*xqc_moq_on_bitrate_change_pt)(xqc_moq_user_session_t *user_sessio
 typedef void (*xqc_moq_on_object_pt)(xqc_moq_user_session_t *user_session,
     xqc_moq_track_t *track, xqc_moq_track_info_t *track_info, xqc_moq_object_t *object);
 
+typedef void (*xqc_moq_on_publish_namespace_pt)(xqc_moq_user_session_t *user_session,
+    xqc_moq_publish_namespace_msg_t *msg);
+
+typedef void (*xqc_moq_on_publish_namespace_done_pt)(xqc_moq_user_session_t *user_session,
+    xqc_moq_publish_namespace_done_msg_t *msg);
+
+typedef void (*xqc_moq_on_publish_namespace_cancel_pt)(xqc_moq_user_session_t *user_session,
+    xqc_moq_publish_namespace_cancel_msg_t *msg);
+
+typedef void (*xqc_moq_on_subscribe_namespace_pt)(xqc_moq_user_session_t *user_session,
+    xqc_moq_subscribe_namespace_msg_t *msg);
+
+typedef void (*xqc_moq_on_unsubscribe_namespace_pt)(xqc_moq_user_session_t *user_session,
+    xqc_moq_unsubscribe_namespace_msg_t *msg);
+
 typedef struct {
     xqc_moq_on_session_setup_pt     on_session_setup; /* Required */
     xqc_moq_on_datachannel_pt       on_datachannel; /* Required */
@@ -425,6 +537,12 @@ typedef struct {
     xqc_moq_on_video_frame_pt       on_video; /* Required */
     xqc_moq_on_audio_frame_pt       on_audio; /* Required */
     xqc_moq_on_object_pt            on_object; /* Optional, raw object callback for CONTAINER_NONE */
+    /* Namespace related callbacks (draft-14) */
+    xqc_moq_on_publish_namespace_pt        on_publish_namespace; /* Optional */
+    xqc_moq_on_publish_namespace_done_pt   on_publish_namespace_done; /* Optional */
+    xqc_moq_on_publish_namespace_cancel_pt on_publish_namespace_cancel; /* Optional */
+    xqc_moq_on_subscribe_namespace_pt      on_subscribe_namespace; /* Optional */
+    xqc_moq_on_unsubscribe_namespace_pt    on_unsubscribe_namespace; /* Optional */
 } xqc_moq_session_callbacks_t;
 
 XQC_EXPORT_PUBLIC_API
@@ -485,27 +603,52 @@ XQC_EXPORT_PUBLIC_API
 uint64_t xqc_moq_target_bitrate(xqc_moq_session_t *session);
 
 XQC_EXPORT_PUBLIC_API
-xqc_moq_track_t *xqc_moq_track_create(xqc_moq_session_t *session, char *track_namespace, char *track_name,
-    xqc_moq_track_type_t track_type, xqc_moq_selection_params_t *params,
-    xqc_moq_container_t container, xqc_moq_track_role_t role);
-
-XQC_EXPORT_PUBLIC_API
 void xqc_moq_track_set_reuse_subgroup_stream(xqc_moq_track_t *track, xqc_int_t reuse);
 
 XQC_EXPORT_PUBLIC_API
-xqc_int_t xqc_moq_subscribe(xqc_moq_session_t *session, const char *track_namespace, const char *track_name,
-    xqc_moq_filter_type_t filter_type, uint64_t start_group_id, uint64_t start_object_id,
+xqc_moq_track_t *xqc_moq_track_create(xqc_moq_session_t *session,
+    char *track_namespace, char *track_name, xqc_moq_track_type_t track_type,
+    xqc_moq_selection_params_t *params, xqc_moq_container_t container, xqc_moq_track_role_t role);
+
+XQC_EXPORT_PUBLIC_API
+xqc_moq_track_t *xqc_moq_track_create_with_namespace_tuple(xqc_moq_session_t *session,
+    uint64_t track_namespace_num, const xqc_moq_track_ns_field_t *track_namespace_tuple,
+    char *track_name, xqc_moq_track_type_t track_type, xqc_moq_selection_params_t *params,
+    xqc_moq_container_t container, xqc_moq_track_role_t role);
+
+XQC_EXPORT_PUBLIC_API
+xqc_int_t xqc_moq_subscribe(xqc_moq_session_t *session,
+    const xqc_moq_track_ns_field_t *track_namespace_tuple, uint64_t track_namespace_num,
+    const char *track_name, xqc_moq_filter_type_t filter_type, uint64_t start_group_id, uint64_t start_object_id,
     uint64_t end_group_id, uint64_t end_object_id, char *authinfo);
 
 XQC_EXPORT_PUBLIC_API
-xqc_int_t xqc_moq_subscribe_latest(xqc_moq_session_t *session, const char *track_namespace, const char *track_name);
+xqc_int_t xqc_moq_subscribe_latest(xqc_moq_session_t *session,
+    const xqc_moq_track_ns_field_t *track_namespace_tuple, uint64_t track_namespace_num,
+    const char *track_name);
+
+XQC_EXPORT_PUBLIC_API
+xqc_int_t xqc_moq_subscribe_with_namespace_tuple(xqc_moq_session_t *session,
+    const xqc_moq_track_ns_field_t *track_namespace_tuple, uint64_t track_namespace_num,
+    const char *track_name, xqc_moq_filter_type_t filter_type, uint64_t start_group_id, uint64_t start_object_id,
+    uint64_t end_group_id, uint64_t end_object_id, char *authinfo);
+
+XQC_EXPORT_PUBLIC_API
+xqc_int_t xqc_moq_subscribe_latest_with_namespace_tuple(xqc_moq_session_t *session, const xqc_moq_track_ns_field_t *track_namespace_tuple,
+    uint64_t track_namespace_num, const char *track_name);
 
 XQC_EXPORT_PUBLIC_API
 xqc_int_t xqc_moq_publish(xqc_moq_session_t *session, xqc_moq_publish_msg_t *publish_msg);
 
 XQC_EXPORT_PUBLIC_API
-xqc_int_t xqc_moq_create_datachannel(xqc_moq_session_t *session, const char *track_namespace, const char *track_name,
-    xqc_moq_track_t **track, uint64_t *subscribe_id, xqc_int_t raw_object);
+xqc_int_t xqc_moq_create_datachannel(xqc_moq_session_t *session,
+    const xqc_moq_track_ns_field_t *track_namespace_tuple, uint64_t track_namespace_num,
+    const char *track_name, xqc_moq_track_t **track, uint64_t *subscribe_id, xqc_int_t raw_object);
+
+XQC_EXPORT_PUBLIC_API
+xqc_int_t xqc_moq_create_datachannel_with_namespace_tuple(xqc_moq_session_t *session,
+    const xqc_moq_track_ns_field_t *track_namespace_tuple, uint64_t track_namespace_num,
+    const char *track_name, xqc_moq_track_t **track, uint64_t *subscribe_id, xqc_int_t raw_object);
 
 XQC_EXPORT_PUBLIC_API
 xqc_int_t xqc_moq_unsubscribe(xqc_moq_session_t *session, uint64_t subscribe_id);
@@ -527,6 +670,41 @@ xqc_int_t xqc_moq_write_publish_error(xqc_moq_session_t *session, xqc_moq_publis
 
 XQC_EXPORT_PUBLIC_API
 xqc_int_t xqc_moq_write_publish_done(xqc_moq_session_t *session, xqc_moq_publish_done_msg_t *publish_done);
+
+XQC_EXPORT_PUBLIC_API
+xqc_int_t xqc_moq_write_publish_namespace(xqc_moq_session_t *session, xqc_moq_publish_namespace_msg_t *publish_namespace);
+
+XQC_EXPORT_PUBLIC_API
+xqc_int_t xqc_moq_write_publish_namespace_ok(xqc_moq_session_t *session,
+    xqc_moq_publish_namespace_ok_msg_t *publish_namespace_ok);
+
+XQC_EXPORT_PUBLIC_API
+xqc_int_t xqc_moq_write_publish_namespace_error(xqc_moq_session_t *session,
+    xqc_moq_publish_namespace_error_msg_t *publish_namespace_error);
+
+XQC_EXPORT_PUBLIC_API
+xqc_int_t xqc_moq_write_publish_namespace_done(xqc_moq_session_t *session,
+    xqc_moq_publish_namespace_done_msg_t *publish_namespace_done);
+
+XQC_EXPORT_PUBLIC_API
+xqc_int_t xqc_moq_write_publish_namespace_cancel(xqc_moq_session_t *session,
+    xqc_moq_publish_namespace_cancel_msg_t *publish_namespace_cancel);
+
+XQC_EXPORT_PUBLIC_API
+xqc_int_t xqc_moq_write_subscribe_namespace(xqc_moq_session_t *session,
+    xqc_moq_subscribe_namespace_msg_t *subscribe_namespace);
+
+XQC_EXPORT_PUBLIC_API
+xqc_int_t xqc_moq_write_subscribe_namespace_ok(xqc_moq_session_t *session,
+    xqc_moq_subscribe_namespace_ok_msg_t *subscribe_namespace_ok);
+
+XQC_EXPORT_PUBLIC_API
+xqc_int_t xqc_moq_write_subscribe_namespace_error(xqc_moq_session_t *session,
+    xqc_moq_subscribe_namespace_error_msg_t *subscribe_namespace_error);
+
+XQC_EXPORT_PUBLIC_API
+xqc_int_t xqc_moq_write_unsubscribe_namespace(xqc_moq_session_t *session,
+    xqc_moq_unsubscribe_namespace_msg_t *unsubscribe_namespace);
 
 XQC_EXPORT_PUBLIC_API
 xqc_int_t xqc_moq_write_datachannel(xqc_moq_session_t *session, uint8_t *msg, size_t msg_len);

--- a/moq/CMakeLists.txt
+++ b/moq/CMakeLists.txt
@@ -4,6 +4,7 @@ if (XQC_ENABLE_MOQ)
         "moq/moq_transport/xqc_moq_message.c"
         "moq/moq_transport/xqc_moq_message_handler.c"
         "moq/moq_transport/xqc_moq_message_writer.c"
+        "moq/moq_transport/xqc_moq_namespace.c"
         "moq/moq_transport/xqc_moq_track.c"
         "moq/moq_transport/xqc_moq_proxy.c"
         "moq/moq_transport/xqc_moq_session.c"

--- a/moq/demo/CMakeLists.txt
+++ b/moq/demo/CMakeLists.txt
@@ -22,6 +22,12 @@ set(
     "xqc_moq_demo_comm.c"
 )
 
+set(
+    MOQ_INTEROP_CLIENT_SOURCE
+    "xqc_moq_interop_client.c"
+    "xqc_moq_demo_comm.c"
+)
+
 
 include_directories(
     "${CMAKE_SOURCE_DIR}/"
@@ -46,15 +52,21 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
         ${MOQ_DEMO_AUDIO_SERVER_SOURCE}
         ${GETOPT_SOURCES}
     )
+    set(MOQ_INTEROP_CLIENT_SOURCE
+        ${MOQ_INTEROP_CLIENT_SOURCE}
+        ${GETOPT_SOURCES}
+    )
 endif()
 
 add_executable(moq_demo_client ${MOQ_DEMO_CLIENT_SOURCE})
 add_executable(moq_demo_server ${MOQ_DEMO_SERVER_SOURCE})
 add_executable(moq_demo_relay_v14 ${MOQ_DEMO_RELAY_V14_SOURCE})
 add_executable(moq_demo_audio_server ${MOQ_DEMO_AUDIO_SERVER_SOURCE})
+add_executable(moq_interop_client ${MOQ_INTEROP_CLIENT_SOURCE})
 
 
 target_link_libraries(moq_demo_client ${APP_DEPEND_LIBS})
 target_link_libraries(moq_demo_server ${APP_DEPEND_LIBS})
 target_link_libraries(moq_demo_relay_v14 ${APP_DEPEND_LIBS})
 target_link_libraries(moq_demo_audio_server ${APP_DEPEND_LIBS})
+target_link_libraries(moq_interop_client ${APP_DEPEND_LIBS})

--- a/moq/demo/CMakeLists.txt
+++ b/moq/demo/CMakeLists.txt
@@ -11,6 +11,12 @@ set(
 )
 
 set(
+    MOQ_DEMO_RELAY_V14_SOURCE
+    "xqc_moq_demo_relay_v14.c"
+    "xqc_moq_demo_comm.c"
+)
+
+set(
     MOQ_DEMO_AUDIO_SERVER_SOURCE
     "xqc_moq_audiodemo_server.c"
     "xqc_moq_demo_comm.c"
@@ -44,9 +50,11 @@ endif()
 
 add_executable(moq_demo_client ${MOQ_DEMO_CLIENT_SOURCE})
 add_executable(moq_demo_server ${MOQ_DEMO_SERVER_SOURCE})
+add_executable(moq_demo_relay_v14 ${MOQ_DEMO_RELAY_V14_SOURCE})
 add_executable(moq_demo_audio_server ${MOQ_DEMO_AUDIO_SERVER_SOURCE})
 
 
 target_link_libraries(moq_demo_client ${APP_DEPEND_LIBS})
 target_link_libraries(moq_demo_server ${APP_DEPEND_LIBS})
+target_link_libraries(moq_demo_relay_v14 ${APP_DEPEND_LIBS})
 target_link_libraries(moq_demo_audio_server ${APP_DEPEND_LIBS})

--- a/moq/demo/xqc_moq_audiodemo_server.c
+++ b/moq/demo/xqc_moq_audiodemo_server.c
@@ -228,8 +228,9 @@ void on_session_setup(xqc_moq_user_session_t *user_session, char *extdata,
     audio_params.channel_config = "2";
     //xqc_moq_track_t *video_track = xqc_moq_track_create(session, "namespace", "video", XQC_MOQ_TRACK_VIDEO, &video_params,
     //                                                    XQC_MOQ_CONTAINER_LOC, XQC_MOQ_TRACK_FOR_PUB);
-    xqc_moq_track_t *audio_track = xqc_moq_track_create(session, "namespace", "audio", XQC_MOQ_TRACK_AUDIO, &audio_params,
-                                                        XQC_MOQ_CONTAINER_LOC, XQC_MOQ_TRACK_FOR_PUB);
+    xqc_moq_track_t *audio_track = xqc_moq_track_create(session,
+        "namespace/xquic", "audio", XQC_MOQ_TRACK_AUDIO, &audio_params,
+        XQC_MOQ_CONTAINER_LOC, XQC_MOQ_TRACK_FOR_PUB);
     if (audio_track == NULL) {
         printf("create audio track error\n");
     }
@@ -240,7 +241,7 @@ void on_datachannel(xqc_moq_user_session_t *user_session, xqc_moq_track_t *track
 {
     DEBUG;
     printf("on_datachannel: track_namespace:%s track_name:%s\n",
-           track_info ? track_info->track_namespace : "null",
+           xqc_demo_track_info_namespace(track_info),
            track_info ? track_info->track_name : "null");
 }
 
@@ -248,7 +249,7 @@ void on_datachannel_msg(struct xqc_moq_user_session_s *user_session, xqc_moq_tra
 {
     DEBUG;
     printf("on_datachannel_msg: track_namespace:%s track_name:%s\n",
-           track_info ? track_info->track_namespace : "null",
+           xqc_demo_track_info_namespace(track_info),
            track_info ? track_info->track_name : "null");
     xqc_int_t ret;
     xqc_moq_session_t *session = user_session->session;
@@ -291,7 +292,7 @@ void on_subscribe_ok(xqc_moq_user_session_t *user_session, xqc_moq_track_t *trac
 {
     DEBUG;
     printf("on_subscribe_ok: track_namespace:%s track_name:%s\n",
-           track_info ? track_info->track_namespace : "null",
+           xqc_demo_track_info_namespace(track_info),
            track_info ? track_info->track_name : "null");
     printf("subscribe_id:%d expire_ms:%d content_exist:%d largest_group_id:%d largest_object_id:%d\n",
            (int)subscribe_ok->subscribe_id, (int)subscribe_ok->expire_ms, (int)subscribe_ok->content_exist,
@@ -302,7 +303,7 @@ void on_subscribe_error(xqc_moq_user_session_t *user_session, xqc_moq_track_t *t
 {
     DEBUG;
     printf("on_subscribe_error: track_namespace:%s track_name:%s\n",
-           track_info ? track_info->track_namespace : "null",
+           xqc_demo_track_info_namespace(track_info),
            track_info ? track_info->track_name : "null");
     printf("subscribe_id:%d error_code:%d reason_phrase:%s track_alias:%d\n",
            (int)subscribe_error->subscribe_id, (int)subscribe_error->error_code, subscribe_error->reason_phrase, (int)subscribe_error->track_alias);
@@ -319,7 +320,8 @@ void on_catalog(xqc_moq_user_session_t *user_session, xqc_moq_track_info_t **tra
         xqc_moq_track_info_t *track_info = track_info_array[i];
         printf("track_namespace:%s track_name:%s track_type:%d codec:%s mime_type:%s bitrate:%d lang:%s framerate:%d width:%d height:%d "
                "display_width:%d display_height:%d samplerate:%d channel_config:%s\n",
-               track_info->track_namespace, track_info->track_name, track_info->track_type, track_info->selection_params.codec,
+               xqc_demo_track_info_namespace(track_info),
+               track_info->track_name, track_info->track_type, track_info->selection_params.codec,
                track_info->selection_params.mime_type, track_info->selection_params.bitrate,
                track_info->selection_params.lang ? track_info->selection_params.lang : "null",
                track_info->selection_params.framerate, track_info->selection_params.width, track_info->selection_params.height,
@@ -328,7 +330,9 @@ void on_catalog(xqc_moq_user_session_t *user_session, xqc_moq_track_info_t **tra
         
         //subscribe media
         if (track_info->track_type == XQC_MOQ_TRACK_AUDIO) {
-            ret = xqc_moq_subscribe_latest(session, track_info->track_namespace, track_info->track_name);
+            ret = xqc_moq_subscribe_latest_with_namespace_tuple(session,
+                track_info->track_namespace_tuple, track_info->track_namespace_num,
+                track_info->track_name);
             if (ret < 0) {
                 printf("xqc_moq_subscribe error\n");
             }

--- a/moq/demo/xqc_moq_demo_client.c
+++ b/moq/demo/xqc_moq_demo_client.c
@@ -59,6 +59,12 @@ void xqc_app_send_callback(int fd, short what, void* arg);
 xqc_app_ctx_t ctx;
 struct event_base *eb;
 
+#ifndef XQC_MOQ_MAX_NAMESPACE_TUPLE_ELEMS
+#define XQC_MOQ_DEMO_MAX_NAMESPACE_TUPLE_ELEMS 32
+#else
+#define XQC_MOQ_DEMO_MAX_NAMESPACE_TUPLE_ELEMS XQC_MOQ_MAX_NAMESPACE_TUPLE_ELEMS
+#endif
+
 int g_ipv6 = 0;
 int g_spec_local_addr = 0;
 int g_frame_num = 5;
@@ -67,8 +73,128 @@ xqc_moq_role_t g_role = XQC_MOQ_PUBSUB;
 int g_enable_client_setup_v14 = 0;
 int g_publish_mode = 0;
 int g_raw_object_mode = 0;
+int g_subscribe_namespace_mode = 0;
+int g_subscribe_namespace_wait_media = 0;
+int g_subscribe_namespace_wait_done = 0;
+int g_subscribe_namespace_no_auto_close = 0;
+uint64_t g_subscribe_namespace_close_after_publish_count = 0;
+
+static xqc_moq_track_ns_field_t g_demo_namespace_tuple[XQC_MOQ_DEMO_MAX_NAMESPACE_TUPLE_ELEMS];
+static uint64_t g_demo_namespace_tuple_num = 0;
 
 static void xqc_app_timestamp_callback(int fd, short what, void *arg);
+static void xqc_demo_close_conn_callback(int fd, short what, void *arg);
+
+static uint64_t g_subscribe_namespace_request_id = 1;
+
+static xqc_int_t
+xqc_demo_parse_namespace_tuple_arg(const char *arg)
+{
+    if (arg == NULL) {
+        return -1;
+    }
+
+    char *copy = strdup(arg);
+    if (copy == NULL) {
+        return -1;
+    }
+
+    for (uint64_t i = 0; i < g_demo_namespace_tuple_num; i++) {
+        free(g_demo_namespace_tuple[i].data);
+        g_demo_namespace_tuple[i].data = NULL;
+        g_demo_namespace_tuple[i].len = 0;
+    }
+    g_demo_namespace_tuple_num = 0;
+
+    char *saveptr = NULL;
+    char *token = strtok_r(copy, ",", &saveptr);
+    while (token != NULL) {
+        if (g_demo_namespace_tuple_num >= XQC_MOQ_DEMO_MAX_NAMESPACE_TUPLE_ELEMS) {
+            free(copy);
+            return -1;
+        }
+        size_t len = strlen(token);
+        unsigned char *data = NULL;
+        if (len > 0) {
+            data = calloc(1, len + 1);
+            if (data == NULL) {
+                free(copy);
+                return -1;
+            }
+            memcpy(data, token, len);
+        }
+        g_demo_namespace_tuple[g_demo_namespace_tuple_num].data = data;
+        g_demo_namespace_tuple[g_demo_namespace_tuple_num].len = len;
+        g_demo_namespace_tuple_num++;
+        token = strtok_r(NULL, ",", &saveptr);
+    }
+
+    free(copy);
+    return (g_demo_namespace_tuple_num > 0) ? 0 : -1;
+}
+
+static void
+xqc_demo_init_av_namespace_tuple(xqc_moq_track_ns_field_t *namespace_tuple, uint64_t *namespace_num)
+{
+    if (namespace_tuple == NULL || namespace_num == NULL) {
+        return;
+    }
+
+    if (g_subscribe_namespace_mode) {
+        if (g_demo_namespace_tuple_num > 0) {
+            for (uint64_t i = 0; i < g_demo_namespace_tuple_num; i++) {
+                namespace_tuple[i].data = g_demo_namespace_tuple[i].data;
+                namespace_tuple[i].len = g_demo_namespace_tuple[i].len;
+            }
+            *namespace_num = g_demo_namespace_tuple_num;
+            return;
+        }
+        namespace_tuple[0].data = (unsigned char *)"namespace";
+        namespace_tuple[0].len = sizeof("namespace") - 1;
+        namespace_tuple[1].data = (unsigned char *)"xquic";
+        namespace_tuple[1].len = sizeof("xquic") - 1;
+        *namespace_num = 2;
+        return;
+    }
+
+    namespace_tuple[0].data = (unsigned char *)"namespace/xquic";
+    namespace_tuple[0].len = sizeof("namespace/xquic") - 1;
+    *namespace_num = 1;
+}
+
+static xqc_int_t
+xqc_demo_send_subscribe_namespace(xqc_moq_session_t *session)
+{
+    if (session == NULL) {
+        return -1;
+    }
+
+    xqc_moq_track_ns_field_t namespace_prefix_tuple[XQC_MOQ_DEMO_MAX_NAMESPACE_TUPLE_ELEMS];
+    uint64_t namespace_prefix_num = 0;
+    xqc_demo_init_av_namespace_tuple(namespace_prefix_tuple, &namespace_prefix_num);
+    if (namespace_prefix_num == 0) {
+        return -1;
+    }
+
+    xqc_moq_subscribe_namespace_msg_t subscribe_namespace_msg;
+    memset(&subscribe_namespace_msg, 0, sizeof(subscribe_namespace_msg));
+    subscribe_namespace_msg.request_id = g_subscribe_namespace_request_id++;
+    subscribe_namespace_msg.track_namespace_num = namespace_prefix_num;
+    subscribe_namespace_msg.track_namespace_tuple = namespace_prefix_tuple;
+    subscribe_namespace_msg.track_namespace_len = 0;
+    subscribe_namespace_msg.params_num = 0;
+    subscribe_namespace_msg.params = NULL;
+
+    xqc_int_t ret = xqc_moq_write_subscribe_namespace(session, &subscribe_namespace_msg);
+    if (ret < 0) {
+        printf("xqc_moq_write_subscribe_namespace error, ret:%d\n", ret);
+    } else {
+        printf("send subscribe_namespace: request_id:%"PRIu64" namespaces:%s\n",
+               subscribe_namespace_msg.request_id,
+               xqc_demo_namespace_tuple_to_str(namespace_prefix_tuple, namespace_prefix_num));
+    }
+    return ret;
+}
 
 static void
 xqc_demo_start_send_timer(user_conn_t *user_conn)
@@ -88,6 +214,16 @@ xqc_demo_start_timestamp_timer(user_conn_t *user_conn)
     }
     struct timeval time = { 1, 0 };
     event_add(user_conn->ev_timestamp_timer, &time);
+}
+
+static void
+xqc_demo_close_conn_callback(int fd, short what, void *arg)
+{
+    user_conn_t *user_conn = (user_conn_t *)arg;
+    if (user_conn == NULL) {
+        return;
+    }
+    xqc_conn_close(ctx.engine, &user_conn->cid);
 }
 
 static xqc_demo_track_ctx_t *
@@ -114,9 +250,21 @@ xqc_demo_publish_track(user_conn_t *user_conn, xqc_demo_track_ctx_t *ctx,
     }
     xqc_moq_publish_msg_t publish_msg;
     memset(&publish_msg, 0, sizeof(publish_msg));
-    publish_msg.track_namespace = (char *)track_namespace;
-    publish_msg.track_namespace_len = strlen(track_namespace);
-    publish_msg.track_namespace_num = 1;
+
+    xqc_moq_track_ns_field_t namespace_tuple[XQC_MOQ_DEMO_MAX_NAMESPACE_TUPLE_ELEMS];
+    uint64_t namespace_num = 0;
+    if (g_subscribe_namespace_mode) {
+        xqc_demo_init_av_namespace_tuple(namespace_tuple, &namespace_num);
+    } else {
+        namespace_tuple[0].data = (unsigned char *)track_namespace;
+        namespace_tuple[0].len = strlen(track_namespace);
+        namespace_num = 1;
+    }
+
+    publish_msg.track_namespace_num = namespace_num;
+    publish_msg.track_namespace_tuple = namespace_tuple;
+    publish_msg.track_namespace_len = 0;
+
     publish_msg.track_name = (char *)track_name;
     publish_msg.track_name_len = strlen(track_name);
     publish_msg.group_order = 0;
@@ -315,7 +463,7 @@ xqc_demo_try_publish(user_conn_t *user_conn)
     int ret;
 
     if (user_conn->video_track) {
-        ret = xqc_demo_publish_track(user_conn, &user_conn->video_ctx, "namespace", "video");
+        ret = xqc_demo_publish_track(user_conn, &user_conn->video_ctx, "namespace/xquic", "video");
         if (ret < 0) {
             printf("publish video track error\n");
         } else {
@@ -325,7 +473,7 @@ xqc_demo_try_publish(user_conn_t *user_conn)
     }
 
     if (user_conn->audio_track) {
-        ret = xqc_demo_publish_track(user_conn, &user_conn->audio_ctx, "namespace", "audio");
+        ret = xqc_demo_publish_track(user_conn, &user_conn->audio_ctx, "namespace/xquic", "audio");
         if (ret < 0) {
             printf("publish audio track error\n");
         } else {
@@ -424,13 +572,13 @@ xqc_client_socket_read_handler(user_conn_t *user_conn, int fd)
 
         if (user_conn->get_local_addr == 0) {
             user_conn->get_local_addr = 1;
-            socklen_t tmp = sizeof(struct sockaddr_in6);
-            int ret = getsockname(user_conn->fd, (struct sockaddr *) user_conn->local_addr, &tmp);
+            socklen_t local_addr_len = sizeof(struct sockaddr_in6);
+            int ret = getsockname(user_conn->fd, (struct sockaddr *) user_conn->local_addr, &local_addr_len);
             if (ret < 0) {
                 printf("getsockname error, errno: %d\n", get_sys_errno());
                 break;
             }
-            user_conn->local_addrlen = tmp;
+            user_conn->local_addrlen = local_addr_len;
         }
 
         uint64_t recv_time = xqc_now();
@@ -627,17 +775,51 @@ void on_session_setup(xqc_moq_user_session_t *user_session, char *extdata,
     user_conn->audio_ctx.track_alias = XQC_MOQ_INVALID_ID;
     user_conn->audio_ctx.subgroup_group_id = XQC_MOQ_INVALID_ID;
 
+    if (g_subscribe_namespace_mode && (g_role & XQC_MOQ_SUBSCRIBER)) {
+        (void)xqc_demo_send_subscribe_namespace(session);
+    }
+
     if (!g_publish_mode && (g_role & XQC_MOQ_SUBSCRIBER)) {
+        if (g_subscribe_namespace_mode) {
+            xqc_moq_track_ns_field_t namespace_tuple_for_sub[XQC_MOQ_DEMO_MAX_NAMESPACE_TUPLE_ELEMS];
+            uint64_t namespace_num_for_sub = 0;
+            xqc_demo_init_av_namespace_tuple(namespace_tuple_for_sub, &namespace_num_for_sub);
+
+            xqc_moq_track_t *sub_video = xqc_moq_track_create_with_namespace_tuple(session,
+                namespace_num_for_sub, namespace_tuple_for_sub, "video",
+                XQC_MOQ_TRACK_VIDEO, NULL, XQC_MOQ_CONTAINER_LOC, XQC_MOQ_TRACK_FOR_SUB);
+            if (sub_video == NULL) {
+                printf("create subscriber video track error\n");
+            } else {
+                user_conn->video_track = sub_video;
+            }
+
+            xqc_moq_track_t *sub_audio = xqc_moq_track_create_with_namespace_tuple(session,
+                namespace_num_for_sub, namespace_tuple_for_sub, "audio",
+                XQC_MOQ_TRACK_AUDIO, NULL, XQC_MOQ_CONTAINER_LOC, XQC_MOQ_TRACK_FOR_SUB);
+            if (sub_audio == NULL) {
+                printf("create subscriber audio track error\n");
+            } else {
+                user_conn->audio_track = sub_audio;
+            }
+            return;
+        }
         xqc_int_t ret;
 
-        xqc_moq_track_t *sub_video = xqc_moq_track_create(session,
-            "namespace", "video", XQC_MOQ_TRACK_VIDEO, NULL,
+        char track_namespace[] = "namespace/xquic";
+        xqc_moq_track_ns_field_t namespace_tuple[1];
+        namespace_tuple[0].data = (unsigned char *)track_namespace;
+        namespace_tuple[0].len = strlen(track_namespace);
+
+        xqc_moq_track_t *sub_video = NULL;
+        sub_video = xqc_moq_track_create(session,
+            track_namespace, "video", XQC_MOQ_TRACK_VIDEO, NULL,
             XQC_MOQ_CONTAINER_LOC, XQC_MOQ_TRACK_FOR_SUB);
         if (sub_video == NULL) {
             printf("create subscriber video track error\n");
         } else {
             user_conn->video_track = sub_video;
-            ret = xqc_moq_subscribe_latest(session, "namespace", "video");
+            ret = xqc_moq_subscribe_latest(session, namespace_tuple, 1, "video");
             if (ret < 0) {
                 printf("xqc_moq_subscribe video error\n");
             } else {
@@ -645,14 +827,15 @@ void on_session_setup(xqc_moq_user_session_t *user_session, char *extdata,
             }
         }
 
-        xqc_moq_track_t *sub_audio = xqc_moq_track_create(session,
-            "namespace", "audio", XQC_MOQ_TRACK_AUDIO, NULL,
+        xqc_moq_track_t *sub_audio = NULL;
+        sub_audio = xqc_moq_track_create(session,
+            track_namespace, "audio", XQC_MOQ_TRACK_AUDIO, NULL,
             XQC_MOQ_CONTAINER_LOC, XQC_MOQ_TRACK_FOR_SUB);
         if (sub_audio == NULL) {
             printf("create subscriber audio track error\n");
         } else {
             user_conn->audio_track = sub_audio;
-            ret = xqc_moq_subscribe_latest(session, "namespace", "audio");
+            ret = xqc_moq_subscribe_latest(session, namespace_tuple, 1, "audio");
             if (ret < 0) {
                 printf("xqc_moq_subscribe audio error\n");
             } else {
@@ -671,8 +854,18 @@ void on_session_setup(xqc_moq_user_session_t *user_session, char *extdata,
     video_params.bitrate = 1000000;
     video_params.framerate = 30;
     xqc_moq_container_t v_container = g_raw_object_mode ? XQC_MOQ_CONTAINER_NONE : XQC_MOQ_CONTAINER_LOC;
-    xqc_moq_track_t *video_track = xqc_moq_track_create(session, "namespace", "video", XQC_MOQ_TRACK_VIDEO, &video_params,
-                                                        v_container, XQC_MOQ_TRACK_FOR_PUB);
+    char track_namespace[] = "namespace/xquic";
+    xqc_moq_track_t *video_track = NULL;
+    if (g_subscribe_namespace_mode) {
+        xqc_moq_track_ns_field_t namespace_tuple_for_pub[XQC_MOQ_DEMO_MAX_NAMESPACE_TUPLE_ELEMS];
+        uint64_t namespace_num_for_pub = 0;
+        xqc_demo_init_av_namespace_tuple(namespace_tuple_for_pub, &namespace_num_for_pub);
+        video_track = xqc_moq_track_create_with_namespace_tuple(session, namespace_num_for_pub, namespace_tuple_for_pub,
+            "video", XQC_MOQ_TRACK_VIDEO, &video_params, v_container, XQC_MOQ_TRACK_FOR_PUB);
+    } else {
+        video_track = xqc_moq_track_create(session, track_namespace, "video", XQC_MOQ_TRACK_VIDEO, &video_params,
+                                           v_container, XQC_MOQ_TRACK_FOR_PUB);
+    }
     if (video_track == NULL) {
         printf("create video track error\n");
     }
@@ -698,25 +891,32 @@ void on_session_setup(xqc_moq_user_session_t *user_session, char *extdata,
     audio_params.channel_config = "2";
     audio_params.bitrate = 32000;
     xqc_moq_container_t container = g_raw_object_mode ? XQC_MOQ_CONTAINER_NONE : XQC_MOQ_CONTAINER_LOC;
-    xqc_moq_track_t *audio_track = xqc_moq_track_create(session, "namespace", "audio", XQC_MOQ_TRACK_AUDIO, &audio_params,
-                                                        container, XQC_MOQ_TRACK_FOR_PUB);
+    xqc_moq_track_t *audio_track = NULL;
+    if (g_subscribe_namespace_mode) {
+        xqc_moq_track_ns_field_t namespace_tuple_for_pub[XQC_MOQ_DEMO_MAX_NAMESPACE_TUPLE_ELEMS];
+        uint64_t namespace_num_for_pub = 0;
+        xqc_demo_init_av_namespace_tuple(namespace_tuple_for_pub, &namespace_num_for_pub);
+        audio_track = xqc_moq_track_create_with_namespace_tuple(session, namespace_num_for_pub, namespace_tuple_for_pub,
+            "audio", XQC_MOQ_TRACK_AUDIO, &audio_params, container, XQC_MOQ_TRACK_FOR_PUB);
+    } else {
+        audio_track = xqc_moq_track_create(session, track_namespace, "audio", XQC_MOQ_TRACK_AUDIO, &audio_params,
+                                           container, XQC_MOQ_TRACK_FOR_PUB);
+    }
     if (audio_track == NULL) {
         printf("create audio track error\n");
     }
     user_conn->audio_track = audio_track;
     if (audio_track) {
-        /* For test: reuse one subgroup stream for multiple audio objects. */
-        xqc_moq_track_set_reuse_subgroup_stream(audio_track, 1);
         if (g_raw_object_mode) {
             xqc_moq_track_set_raw_object(audio_track, 1);
         }
         user_conn->audio_ctx.track = audio_track;
         user_conn->audio_ctx.subscribe_id = XQC_MOQ_INVALID_ID;
         user_conn->audio_ctx.track_alias = XQC_MOQ_INVALID_ID;
-        user_conn->audio_ctx.group_id = 0;
-        user_conn->audio_ctx.object_id = 0;
-        user_conn->audio_ctx.subgroup_group_id = XQC_MOQ_INVALID_ID;
-        user_conn->audio_ctx.subgroup_id = 0;
+    user_conn->audio_ctx.group_id = 0;
+    user_conn->audio_ctx.object_id = 0;
+    user_conn->audio_ctx.subgroup_group_id = XQC_MOQ_INVALID_ID;
+    user_conn->audio_ctx.subgroup_id = 0;
     }
     if (g_publish_mode) {
         xqc_demo_try_publish(user_conn);
@@ -729,10 +929,10 @@ void on_datachannel(xqc_moq_user_session_t *user_session, xqc_moq_track_t *track
     DEBUG;
     user_conn_t *user_conn = (user_conn_t *)user_session->data;
     printf("on_datachannel: track_namespace:%s track_name:%s\n",
-           track_info ? track_info->track_namespace : "null",
+           xqc_demo_track_info_namespace(track_info),
            track_info ? track_info->track_name : "null");
 
-    if ((g_role & XQC_MOQ_SUBSCRIBER) && user_conn->publish_request_sent == 0) {
+    if ((g_role & XQC_MOQ_SUBSCRIBER) && user_conn->publish_request_sent == 0 && !g_subscribe_namespace_mode) {
         int ret = xqc_moq_write_datachannel(user_session->session,
                                             (uint8_t*)"publish_request", strlen("publish_request"));
         if (ret < 0) {
@@ -747,7 +947,7 @@ void on_datachannel_msg(struct xqc_moq_user_session_s *user_session, xqc_moq_tra
 {
     DEBUG;
     printf("on_datachannel_msg: track_namespace:%s track_name:%s\n",
-           track_info ? track_info->track_namespace : "null",
+           xqc_demo_track_info_namespace(track_info),
            track_info ? track_info->track_name : "null");
 
     xqc_moq_session_t *session = user_session->session;
@@ -782,7 +982,7 @@ void on_subscribe(xqc_moq_user_session_t *user_session, uint64_t subscribe_id,
         xqc_moq_subscribe_ok_msg_t subscribe_ok;
         memset(&subscribe_ok, 0, sizeof(subscribe_ok));
         subscribe_ok.subscribe_id = subscribe_id;
-        printf("subscribe id recv from server side: %llu\n", subscribe_id);
+        printf("subscribe id recv from server side: %ld\n",subscribe_id);
         subscribe_ok.track_alias = msg ? msg->track_alias : 0;
         subscribe_ok.expire_ms = 0;
         subscribe_ok.group_order = 0;
@@ -828,7 +1028,9 @@ void on_bitrate_change(xqc_moq_user_session_t *user_session, xqc_moq_track_t *tr
 {
     DEBUG;
     printf("on_bitrate_change: track_namespace:%s track_name:%s bitrate:%"PRIu64"\n",
-           track_info->track_namespace, track_info->track_name, bitrate);
+           xqc_demo_track_info_namespace(track_info),
+           track_info ? track_info->track_name : "null",
+           bitrate);
     /* Configure encoder target bitrate */
 }
 
@@ -836,7 +1038,7 @@ void on_subscribe_ok(xqc_moq_user_session_t *user_session, xqc_moq_track_t *trac
 {
     DEBUG;
     printf("on_subscribe_ok: track_namespace:%s track_name:%s\n",
-           track_info ? track_info->track_namespace : "null",
+           xqc_demo_track_info_namespace(track_info),
            track_info ? track_info->track_name : "null");
     printf("subscribe_id:%d expire_ms:%d content_exist:%d largest_group_id:%d largest_object_id:%d\n",
            (int)subscribe_ok->subscribe_id, (int)subscribe_ok->expire_ms, (int)subscribe_ok->content_exist,
@@ -847,7 +1049,7 @@ void on_subscribe_error(xqc_moq_user_session_t *user_session, xqc_moq_track_t *t
 {
     DEBUG;
     printf("on_subscribe_error: track_namespace:%s track_name:%s\n",
-           track_info ? track_info->track_namespace : "null",
+           xqc_demo_track_info_namespace(track_info),
            track_info ? track_info->track_name : "null");
     printf("subscribe_id:%d error_code:%d reason_phrase:%s track_alias:%d\n",
            (int)subscribe_error->subscribe_id, (int)subscribe_error->error_code, subscribe_error->reason_phrase, (int)subscribe_error->track_alias);
@@ -857,11 +1059,106 @@ void on_publish_msg(xqc_moq_user_session_t *user_session, xqc_moq_track_t *track
 {
     printf("on_publish: subscribe_id:%"PRIu64" track:%s/%s track_alias:%"PRIu64" forward:%u content_exist:%u\n",
            publish_msg->subscribe_id,
-           publish_msg->track_namespace,
+           xqc_demo_namespace_tuple_to_str(publish_msg->track_namespace_tuple, publish_msg->track_namespace_num),
            publish_msg->track_name,
            publish_msg->track_alias,
            publish_msg->forward,
            publish_msg->content_exist);
+
+    xqc_moq_publish_ok_msg_t publish_ok;
+    memset(&publish_ok, 0, sizeof(publish_ok));
+    publish_ok.subscribe_id = publish_msg->subscribe_id;
+    publish_ok.forward = 1;
+    publish_ok.subscriber_priority = 0;
+    publish_ok.group_order = publish_msg->group_order;
+    publish_ok.filter_type = XQC_MOQ_FILTER_LAST_GROUP;
+    publish_ok.start_group_id = 0;
+    publish_ok.start_object_id = 0;
+    publish_ok.end_group_id = 0;
+    publish_ok.params_num = 0;
+    publish_ok.params = NULL;
+
+    int ret = xqc_moq_write_publish_ok(user_session->session, &publish_ok);
+    if (ret < 0) {
+        printf("xqc_moq_write_publish_ok error\n");
+    }
+
+    user_conn_t *user_conn = (user_conn_t *)user_session->data;
+    if (g_subscribe_namespace_mode && g_role == XQC_MOQ_SUBSCRIBER && user_conn != NULL) {
+        user_conn->subscribe_namespace_received_publish_count++;
+        if (publish_msg->track_name != NULL) {
+            if (strcmp(publish_msg->track_name, "video") == 0) {
+                user_conn->subscribe_namespace_received_video_publish = 1;
+            } else if (strcmp(publish_msg->track_name, "audio") == 0) {
+                user_conn->subscribe_namespace_received_audio_publish = 1;
+            }
+        }
+
+        if (!g_subscribe_namespace_no_auto_close
+            && !g_subscribe_namespace_wait_done
+            && !g_subscribe_namespace_wait_media
+            && !user_conn->subscribe_namespace_close_initiated
+            && ((g_subscribe_namespace_close_after_publish_count > 0
+                 && user_conn->subscribe_namespace_received_publish_count >= g_subscribe_namespace_close_after_publish_count)
+                || (g_subscribe_namespace_close_after_publish_count == 0
+                    && user_conn->subscribe_namespace_received_video_publish
+                    && user_conn->subscribe_namespace_received_audio_publish)))
+        {
+            user_conn->subscribe_namespace_close_initiated = 1;
+            if (user_conn->ev_timeout == NULL) {
+                user_conn->ev_timeout = evtimer_new(eb, xqc_demo_close_conn_callback, user_conn);
+            }
+            if (user_conn->ev_timeout != NULL) {
+                struct timeval delay = { 0, 200000 };
+                event_add(user_conn->ev_timeout, &delay);
+            } else {
+                xqc_conn_close(ctx.engine, &user_conn->cid);
+            }
+        }
+    }
+}
+
+static void
+on_publish_namespace(xqc_moq_user_session_t *user_session, xqc_moq_publish_namespace_msg_t *msg)
+{
+    (void)user_session;
+    if (msg == NULL) {
+        return;
+    }
+    printf("on_publish_namespace: request_id:%"PRIu64" namespaces:%s\n",
+           msg->request_id,
+           xqc_demo_namespace_tuple_to_str(msg->track_namespace_tuple, msg->track_namespace_num));
+}
+
+static void
+on_publish_namespace_done(xqc_moq_user_session_t *user_session, xqc_moq_publish_namespace_done_msg_t *done)
+{
+    if (user_session == NULL || done == NULL) {
+        return;
+    }
+
+    printf("on_publish_namespace_done: namespaces:%s\n",
+           xqc_demo_namespace_tuple_to_str(done->track_namespace_tuple, done->track_namespace_num));
+
+    user_conn_t *user_conn = (user_conn_t *)user_session->data;
+    if (g_subscribe_namespace_mode
+        && g_subscribe_namespace_wait_done
+        && !g_subscribe_namespace_no_auto_close
+        && g_role == XQC_MOQ_SUBSCRIBER
+        && user_conn != NULL
+        && !user_conn->subscribe_namespace_close_initiated)
+    {
+        user_conn->subscribe_namespace_close_initiated = 1;
+        if (user_conn->ev_timeout == NULL) {
+            user_conn->ev_timeout = evtimer_new(eb, xqc_demo_close_conn_callback, user_conn);
+        }
+        if (user_conn->ev_timeout != NULL) {
+            struct timeval delay = { 0, 200000 };
+            event_add(user_conn->ev_timeout, &delay);
+        } else {
+            xqc_conn_close(ctx.engine, &user_conn->cid);
+        }
+    }
 }
 
 void on_publish_ok_msg(xqc_moq_user_session_t *user_session, xqc_moq_track_t *track, xqc_moq_publish_ok_msg_t *publish_ok)
@@ -910,9 +1207,10 @@ void on_catalog(xqc_moq_user_session_t *user_session, xqc_moq_track_info_t **tra
 
     for (int i = 0; i < array_size; i++) {
         xqc_moq_track_info_t *track_info = track_info_array[i];
+        const char *ns_str = xqc_demo_track_info_namespace(track_info);
         printf("track_namespace:%s track_name:%s track_type:%d codec:%s mime_type:%s bitrate:%d lang:%s framerate:%d width:%d height:%d "
                "display_width:%d display_height:%d samplerate:%d channel_config:%s\n",
-               track_info->track_namespace, track_info->track_name, track_info->track_type, track_info->selection_params.codec,
+               ns_str, track_info->track_name, track_info->track_type, track_info->selection_params.codec,
                track_info->selection_params.mime_type, track_info->selection_params.bitrate,
                track_info->selection_params.lang ? track_info->selection_params.lang : "null",
                track_info->selection_params.framerate, track_info->selection_params.width, track_info->selection_params.height,
@@ -921,12 +1219,12 @@ void on_catalog(xqc_moq_user_session_t *user_session, xqc_moq_track_info_t **tra
 
         if (g_role & XQC_MOQ_SUBSCRIBER) {
             xqc_moq_track_t *sub_track = xqc_moq_track_create(session,
-                track_info->track_namespace, track_info->track_name,
+                (char *)ns_str, track_info->track_name,
                 track_info->track_type, &track_info->selection_params,
                 XQC_MOQ_CONTAINER_LOC, XQC_MOQ_TRACK_FOR_SUB);
             if (sub_track == NULL) {
                 printf("create subscriber track error:%s/%s\n",
-                       track_info->track_namespace, track_info->track_name);
+                       ns_str, track_info->track_name);
             }
         }
 
@@ -935,10 +1233,12 @@ void on_catalog(xqc_moq_user_session_t *user_session, xqc_moq_track_info_t **tra
         }
         if (g_publish_mode) {
             printf("publish mode, skip subscribing remote track:%s/%s\n",
-                   track_info->track_namespace, track_info->track_name);
+                   ns_str, track_info->track_name);
             continue;
         }
-        ret = xqc_moq_subscribe_latest(session, track_info->track_namespace, track_info->track_name);
+        ret = xqc_moq_subscribe_latest(session,
+            track_info->track_namespace_tuple, track_info->track_namespace_num,
+            track_info->track_name);
         if (ret < 0) {
             printf("xqc_moq_subscribe error\n");
         }
@@ -984,9 +1284,35 @@ void on_video_frame(xqc_moq_user_session_t *user_session, uint64_t subscribe_id,
                          video_frame->seq_num, video_frame->timestamp_us, video_frame->video_len);
         if (n > 0) {
             size_t msg_len = (n < (int)sizeof(msg)) ? (size_t)n : sizeof(msg) - 1;
-            int ret = xqc_moq_write_datachannel(session, msg, msg_len);
-            if (ret < 0) {
-                printf("xqc_moq_write_datachannel video echo error\n");
+            if (!g_subscribe_namespace_mode) {
+                int ret = xqc_moq_write_datachannel(session, msg, msg_len);
+                if (ret < 0) {
+                    printf("xqc_moq_write_datachannel video echo error\n");
+                }
+            }
+        }
+    }
+
+    if (g_subscribe_namespace_mode
+        && g_subscribe_namespace_wait_media
+        && !g_subscribe_namespace_wait_done
+        && !g_subscribe_namespace_no_auto_close
+        && g_role == XQC_MOQ_SUBSCRIBER
+        && user_conn != NULL)
+    {
+        user_conn->subscribe_namespace_received_video_frames++;
+        if (user_conn->subscribe_namespace_received_video_frames >= 1
+            && user_conn->subscribe_namespace_received_audio_frames >= 1
+            && !user_conn->subscribe_namespace_close_initiated) {
+            user_conn->subscribe_namespace_close_initiated = 1;
+            if (user_conn->ev_timeout == NULL) {
+                user_conn->ev_timeout = evtimer_new(eb, xqc_demo_close_conn_callback, user_conn);
+            }
+            if (user_conn->ev_timeout != NULL) {
+                struct timeval delay = { 0, 200000 };
+                event_add(user_conn->ev_timeout, &delay);
+            } else {
+                xqc_conn_close(ctx.engine, &user_conn->cid);
             }
         }
     }
@@ -1011,9 +1337,32 @@ void on_audio_frame(xqc_moq_user_session_t *user_session, uint64_t subscribe_id,
                           audio_frame->seq_num, audio_frame->timestamp_us, audio_frame->audio_len);
         if (an > 0) {
             size_t msg_len = (an < (int)sizeof(amsg)) ? (size_t)an : sizeof(amsg) - 1;
-            int ret = xqc_moq_write_datachannel(session, amsg, msg_len);
-            if (ret < 0) {
-                printf("xqc_moq_write_datachannel audio echo error\n");
+            if (!g_subscribe_namespace_mode) {
+                int ret = xqc_moq_write_datachannel(session, amsg, msg_len);
+                if (ret < 0) {
+                    printf("xqc_moq_write_datachannel audio echo error\n");
+                }
+            }
+        }
+    }
+
+    if (g_subscribe_namespace_mode && g_subscribe_namespace_wait_media
+        && !g_subscribe_namespace_wait_done && !g_subscribe_namespace_no_auto_close
+        && g_role == XQC_MOQ_SUBSCRIBER && user_conn != NULL)
+    {
+        user_conn->subscribe_namespace_received_audio_frames++;
+        if (user_conn->subscribe_namespace_received_video_frames >= 1
+            && user_conn->subscribe_namespace_received_audio_frames >= 1
+            && !user_conn->subscribe_namespace_close_initiated) {
+            user_conn->subscribe_namespace_close_initiated = 1;
+            if (user_conn->ev_timeout == NULL) {
+                user_conn->ev_timeout = evtimer_new(eb, xqc_demo_close_conn_callback, user_conn);
+            }
+            if (user_conn->ev_timeout != NULL) {
+                struct timeval delay = { 0, 200000 };
+                event_add(user_conn->ev_timeout, &delay);
+            } else {
+                xqc_conn_close(ctx.engine, &user_conn->cid);
             }
         }
     }
@@ -1044,6 +1393,8 @@ xqc_client_conn_create_notify(xqc_connection_t *conn, const xqc_cid_t *cid, void
         .on_catalog = on_catalog,
         .on_video = on_video_frame,
         .on_audio = on_audio_frame,
+        .on_publish_namespace = on_publish_namespace,
+        .on_publish_namespace_done = on_publish_namespace_done,
     };
     xqc_moq_session_t *session;
 
@@ -1214,8 +1565,9 @@ xqc_app_timestamp_callback(int fd, short what, void* arg)
         }
 
         int ret = xqc_moq_create_datachannel(user_conn->moq_session,
-                                             "datachannel", dc_name[0] ? dc_name : "extra",
-                                             &dc_track, &dc_subscribe_id, 1);
+                                             (xqc_moq_track_ns_field_t[]) {
+                                                 { .data = (uint8_t *)"datachannel", .len = sizeof("datachannel") - 1 },},
+                                             1, dc_name[0] ? dc_name : "extra", &dc_track, &dc_subscribe_id, 1);
         if (ret >= 0 && dc_track != NULL) {
             user_conn->extra_dc_track = dc_track;
             user_conn->extra_dc_subscribe_id = dc_subscribe_id;
@@ -1281,7 +1633,7 @@ int main(int argc, char *argv[])
     uint8_t secret_key[16] = {0};
     int use_proxy = 0;
     int use_1rtt = 0;
-    while ((ch = getopt(argc, argv, "a:p:r:c:l:A:P:k:n:f1MVR")) != -1) {
+    while ((ch = getopt(argc, argv, "a:p:r:c:l:A:P:k:n:f1MVRNWDT:ZE:")) != -1) {
         switch (ch) {
             case 'a':
                 printf("option addr :%s\n", optarg);
@@ -1372,6 +1724,33 @@ int main(int argc, char *argv[])
             case 'V':
                 printf("option draft14 client setup : on\n");
                 g_enable_client_setup_v14 = 1;
+                break;
+            case 'N':
+                printf("option subscribe namespace mode : on\n");
+                g_subscribe_namespace_mode = 1;
+                break;
+            case 'W':
+                printf("option subscribe namespace wait media : on\n");
+                g_subscribe_namespace_wait_media = 1;
+                break;
+            case 'D':
+                printf("option subscribe namespace wait done : on\n");
+                g_subscribe_namespace_wait_done = 1;
+                break;
+            case 'Z':
+                printf("option subscribe namespace no auto close : on\n");
+                g_subscribe_namespace_no_auto_close = 1;
+                break;
+            case 'E':
+                printf("option subscribe namespace exit after publish count :%s\n", optarg);
+                g_subscribe_namespace_close_after_publish_count = (uint64_t)atoll(optarg);
+                break;
+            case 'T':
+                printf("option namespace tuple :%s\n", optarg);
+                if (xqc_demo_parse_namespace_tuple_arg(optarg) != 0) {
+                    printf("invalid namespace tuple arg\n");
+                    return -1;
+                }
                 break;
             default:
                 printf("other option :%c\n", ch);

--- a/moq/demo/xqc_moq_demo_comm.c
+++ b/moq/demo/xqc_moq_demo_comm.c
@@ -1,12 +1,54 @@
 
 #include "xqc_moq_demo_comm.h"
 
+#include <string.h>
+
 // #define TEST_DROP (g_drop_rate != 0 && (rand() % 1000 < g_drop_rate || g_loss_cnt++ == 0))
 
 #define TEST_DROP (g_drop_rate != 0 && ((g_loss_cnt++) % g_drop_rate == 0))
 
 int g_drop_rate = 0;
 int g_loss_cnt = 0;
+
+#define XQC_MOQ_DEMO_NS_BUF_SIZE 4097
+
+const char *
+xqc_demo_namespace_tuple_to_str(const xqc_moq_track_ns_field_t *tuple, uint64_t num)
+{
+    static char buf[XQC_MOQ_DEMO_NS_BUF_SIZE];
+    size_t off = 0;
+
+    if (tuple == NULL || num == 0) {
+        return "null";
+    }
+
+    buf[0] = '\0';
+    for (uint64_t i = 0; i < num && off < sizeof(buf) - 1; i++) {
+        const xqc_moq_track_ns_field_t *field = &tuple[i];
+        if (i > 0 && off < sizeof(buf) - 1) {
+            buf[off++] = '/';
+        }
+        if (field->data != NULL && field->len > 0) {
+            size_t copy_len = field->len;
+            if (off + copy_len >= sizeof(buf) - 1) {
+                copy_len = sizeof(buf) - 1 - off;
+            }
+            memcpy(buf + off, field->data, copy_len);
+            off += copy_len;
+        }
+    }
+    buf[off] = '\0';
+    return buf;
+}
+
+const char *
+xqc_demo_track_info_namespace(const xqc_moq_track_info_t *track_info)
+{
+    if (track_info == NULL) {
+        return "null";
+    }
+    return xqc_demo_namespace_tuple_to_str(track_info->track_namespace_tuple, track_info->track_namespace_num);
+}
 
 void
 xqc_app_set_log_level(char c_log_level, xqc_config_t *config)

--- a/moq/demo/xqc_moq_demo_comm.h
+++ b/moq/demo/xqc_moq_demo_comm.h
@@ -89,6 +89,14 @@ typedef struct user_conn_s {
     int                 extra_dc_created;
     int                 extra_dc_ready;
     int                 extra_dc_msg_cnt;
+
+    /* demo-only state for SUBSCRIBE_NAMESPACE mode (-N) */
+    int                 subscribe_namespace_received_video_publish;
+    int                 subscribe_namespace_received_audio_publish;
+    uint64_t            subscribe_namespace_received_publish_count;
+    int                 subscribe_namespace_close_initiated;
+    uint64_t            subscribe_namespace_received_video_frames;
+    uint64_t            subscribe_namespace_received_audio_frames;
 } user_conn_t;
 
 
@@ -124,5 +132,17 @@ xqc_app_write_socket_ex(uint64_t path_id, const unsigned char *buf, size_t size,
                         socklen_t peer_addrlen, void *user_data);
 
 xqc_moq_stream_t *xqc_demo_stream_create(xqc_moq_session_t *session, xqc_stream_direction_t direction);
+
+/**
+ * @brief Convert namespace tuple to a printable "ns0/ns1/.../nsN" string for demo logs.
+ * @note  Returns a static buffer; not thread-safe.
+ */
+const char *xqc_demo_namespace_tuple_to_str(const xqc_moq_track_ns_field_t *tuple, uint64_t num);
+
+/**
+ * @brief Convenience wrapper of xqc_demo_namespace_tuple_to_str for xqc_moq_track_info_t.
+ * @note  Returns a static buffer; not thread-safe.
+ */
+const char *xqc_demo_track_info_namespace(const xqc_moq_track_info_t *track_info);
 
 #endif /* _XQC_MOQ_DEMO_COMM_H_INCLUDED_ */

--- a/moq/demo/xqc_moq_demo_relay_v14.c
+++ b/moq/demo/xqc_moq_demo_relay_v14.c
@@ -748,12 +748,15 @@ xqc_moq_relay_on_subscribe(xqc_moq_user_session_t *user_session, uint64_t subscr
 
     if (pub_ns != NULL) {
         printf("relay on_subscribe: found publisher for namespace, sending subscribe_ok "
-               "subscribe_id:%"PRIu64" track:%s\n",
-               subscribe_id, msg->track_name ? msg->track_name : "null");
+               "subscribe_id:%"PRIu64" track_alias:%"PRIu64" track:%s\n",
+               subscribe_id, msg->track_alias,
+               msg->track_name ? msg->track_name : "null");
         xqc_moq_subscribe_ok_msg_t ok;
         memset(&ok, 0, sizeof(ok));
         ok.subscribe_id = subscribe_id;
+        ok.track_alias = msg->track_alias;
         ok.expire_ms = 0;
+        ok.group_order = 1;
         ok.content_exist = 0;
         ok.largest_group_id = 0;
         ok.largest_object_id = 0;

--- a/moq/demo/xqc_moq_demo_relay_v14.c
+++ b/moq/demo/xqc_moq_demo_relay_v14.c
@@ -1,0 +1,964 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <errno.h>
+#include <memory.h>
+#include <string.h>
+#include <stdlib.h>
+#include <event2/event.h>
+#include <inttypes.h>
+#include <xquic/xquic_typedef.h>
+#include <xquic/xquic.h>
+#include <xquic/xqc_http3.h>
+#include <time.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdint.h>
+#include <arpa/inet.h>
+#
+#include "tests/platform.h"
+#include "xqc_moq_demo_comm.h"
+#
+#ifndef XQC_SYS_WINDOWS
+#include <unistd.h>
+#include <getopt.h>
+#else
+#include "getopt.h"
+#pragma comment(lib,"ws2_32.lib")
+#pragma comment(lib, "Iphlpapi.lib")
+#pragma comment(lib, "Bcrypt.lib")
+#pragma comment(lib, "crypt32")
+#endif
+#
+#include "moq/moq_transport/xqc_moq_session.h"
+#include "moq/moq_transport/xqc_moq_namespace.h"
+#include "moq/moq_transport/xqc_moq_message.h"
+
+#define DEBUG printf("%s:%d (%s)\n", __FILE__, __LINE__, __FUNCTION__);
+
+#define TEST_ADDR "127.0.0.1"
+#define TEST_PORT 4433
+
+extern long xqc_random(void);
+extern xqc_usec_t xqc_now();
+
+static xqc_app_ctx_t g_app_ctx;
+static struct event_base *g_event_base;
+
+static int g_ipv6 = 0;
+static int g_enable_client_setup_v14 = 1;
+
+static int g_relay_port = TEST_PORT;
+static char g_log_level = 'd';
+
+typedef struct xqc_moq_relay_downstream_s {
+    xqc_list_head_t          list_member;
+    xqc_moq_session_t        *session;
+    xqc_moq_track_t          *track;
+    uint64_t                 subscribe_id;
+    uint8_t                  publish_ok_received;
+} xqc_moq_relay_downstream_t;
+
+typedef struct xqc_moq_relay_forwarding_s {
+    xqc_list_head_t              list_member;
+    xqc_moq_session_t            *upstream_session;
+    uint64_t                     upstream_subscribe_id;
+    xqc_moq_track_t              *upstream_track;
+    xqc_moq_track_type_t         track_type;
+    uint64_t                     track_namespace_num;
+    xqc_moq_track_ns_field_t     *track_namespace_tuple;
+    char                         *track_name;
+    xqc_list_head_t              downstream_list;
+} xqc_moq_relay_forwarding_t;
+
+typedef struct xqc_moq_relay_conn_s {
+    user_conn_t              base; /* must be first: used by demo_comm write_socket helpers */
+    xqc_list_head_t          list_member;
+    xqc_moq_user_session_t   *user_session;
+    xqc_moq_session_t        *session;
+    xqc_connection_t         *conn;
+    xqc_cid_t                cid;
+} xqc_moq_relay_conn_t;
+
+static xqc_list_head_t g_relay_conn_list;
+static xqc_list_head_t g_relay_forwarding_list;
+
+static xqc_int_t
+xqc_moq_relay_forwarding_has_downstream(xqc_moq_relay_forwarding_t *forwarding, xqc_moq_session_t *downstream_session)
+{
+    if (forwarding == NULL || downstream_session == NULL) {
+        return 0;
+    }
+
+    xqc_list_head_t *pos;
+    xqc_list_for_each(pos, &forwarding->downstream_list) {
+        xqc_moq_relay_downstream_t *downstream = xqc_list_entry(pos, xqc_moq_relay_downstream_t, list_member);
+        if (downstream->session == downstream_session) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static xqc_int_t
+xqc_moq_relay_peer_wants_namespace(xqc_moq_session_t *session,
+    const xqc_moq_track_ns_field_t *track_namespace_tuple, uint64_t track_namespace_num)
+{
+    if (session == NULL || track_namespace_tuple == NULL || track_namespace_num == 0) {
+        return 0;
+    }
+
+    xqc_list_head_t *pos;
+    xqc_list_for_each(pos, &session->peer_subscribe_namespace_list) {
+        xqc_moq_namespace_prefix_t *prefix = xqc_list_entry(pos, xqc_moq_namespace_prefix_t, list_member);
+        if (prefix->prefix_tuple == NULL || prefix->prefix_num == 0) {
+            continue;
+        }
+        if (xqc_moq_namespace_tuple_is_prefix(prefix->prefix_tuple, prefix->prefix_num,
+                track_namespace_tuple, track_namespace_num)) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static xqc_int_t
+xqc_moq_relay_session_is_active(xqc_moq_session_t *session)
+{
+    if (session == NULL) {
+        return 0;
+    }
+
+    xqc_list_head_t *pos;
+    xqc_list_for_each(pos, &g_relay_conn_list) {
+        xqc_moq_relay_conn_t *conn_ctx = xqc_list_entry(pos, xqc_moq_relay_conn_t, list_member);
+        if (conn_ctx->session == session) {
+            return conn_ctx->base.closing_notified ? 0 : 1;
+        }
+    }
+    return 0;
+}
+
+static void
+xqc_moq_relay_forwarding_cleanup(xqc_moq_relay_forwarding_t *forwarding, xqc_int_t destroy_downstream_tracks)
+{
+    if (forwarding == NULL) {
+        return;
+    }
+
+    xqc_list_head_t *pos, *next;
+    xqc_list_for_each_safe(pos, next, &forwarding->downstream_list) {
+        xqc_moq_relay_downstream_t *downstream = xqc_list_entry(pos, xqc_moq_relay_downstream_t, list_member);
+        xqc_list_del(&downstream->list_member);
+
+        if (destroy_downstream_tracks
+            && downstream->track != NULL
+            && downstream->session != NULL
+            && xqc_moq_relay_session_is_active(downstream->session))
+        {
+            if (downstream->track->list_member.next != XQC_LIST_POISON1
+                && downstream->track->list_member.prev != XQC_LIST_POISON2)
+            {
+                xqc_list_del(&downstream->track->list_member);
+            }
+            xqc_moq_track_destroy(downstream->track);
+            downstream->track = NULL;
+        }
+        xqc_free(downstream);
+    }
+
+    if (forwarding->track_namespace_tuple != NULL) {
+        xqc_moq_namespace_tuple_free(forwarding->track_namespace_tuple, forwarding->track_namespace_num);
+        forwarding->track_namespace_tuple = NULL;
+        forwarding->track_namespace_num = 0;
+    }
+
+    if (forwarding->track_name != NULL) {
+        xqc_free(forwarding->track_name);
+        forwarding->track_name = NULL;
+    }
+
+    xqc_free(forwarding);
+}
+
+static xqc_moq_relay_forwarding_t *
+xqc_moq_relay_find_forwarding(xqc_moq_session_t *upstream_session, uint64_t upstream_subscribe_id)
+{
+    xqc_list_head_t *pos;
+    xqc_list_for_each(pos, &g_relay_forwarding_list) {
+        xqc_moq_relay_forwarding_t *forwarding = xqc_list_entry(pos, xqc_moq_relay_forwarding_t, list_member);
+        if (forwarding->upstream_session == upstream_session
+            && forwarding->upstream_subscribe_id == upstream_subscribe_id) {
+            return forwarding;
+        }
+    }
+    return NULL;
+}
+
+static void
+xqc_moq_relay_on_publish_ok(xqc_moq_user_session_t *user_session, xqc_moq_track_t *track,
+    xqc_moq_publish_ok_msg_t *publish_ok)
+{
+    (void)user_session;
+    if (publish_ok == NULL) {
+        return;
+    }
+
+    xqc_list_head_t *pos_fwd;
+    xqc_list_for_each(pos_fwd, &g_relay_forwarding_list) {
+        xqc_moq_relay_forwarding_t *forwarding = xqc_list_entry(pos_fwd, xqc_moq_relay_forwarding_t, list_member);
+        xqc_list_head_t *pos_ds;
+        xqc_list_for_each(pos_ds, &forwarding->downstream_list) {
+            xqc_moq_relay_downstream_t *downstream = xqc_list_entry(pos_ds, xqc_moq_relay_downstream_t, list_member);
+            if (downstream->session == user_session->session && downstream->subscribe_id == publish_ok->subscribe_id) {
+                downstream->publish_ok_received = 1;
+                printf("relay downstream publish_ok: subscribe_id:%"PRIu64" track_ptr:%p\n",
+                       publish_ok->subscribe_id, (void *)track);
+                return;
+            }
+        }
+    }
+}
+
+static void
+xqc_moq_relay_attach_forwarding_to_subscriber(xqc_moq_relay_forwarding_t *forwarding,
+    xqc_moq_relay_conn_t *subscriber_conn_ctx)
+{
+    if (forwarding == NULL || subscriber_conn_ctx == NULL || subscriber_conn_ctx->session == NULL) {
+        return;
+    }
+
+    xqc_moq_session_t *subscriber_session = subscriber_conn_ctx->session;
+    if (!xqc_moq_relay_session_is_active(subscriber_session)) {
+        return;
+    }
+    if ((subscriber_session->peer_role & XQC_MOQ_SUBSCRIBER) == 0) {
+        return;
+    }
+    if (subscriber_session == forwarding->upstream_session) {
+        return;
+    }
+    if (!xqc_moq_relay_peer_wants_namespace(subscriber_session,
+            forwarding->track_namespace_tuple, forwarding->track_namespace_num)) {
+        return;
+    }
+    if (xqc_moq_relay_forwarding_has_downstream(forwarding, subscriber_session)) {
+        return;
+    }
+
+    xqc_moq_track_t *down_track = xqc_moq_find_track_by_track_namespace_tuple(subscriber_session,
+        forwarding->track_namespace_tuple, forwarding->track_namespace_num,
+        forwarding->track_name, XQC_MOQ_TRACK_FOR_PUB);
+
+    if (down_track == NULL) {
+        xqc_moq_container_t container = XQC_MOQ_CONTAINER_LOC;
+        if (forwarding->track_type == XQC_MOQ_TRACK_DATACHANNEL) {
+            container = XQC_MOQ_CONTAINER_NONE;
+        }
+        down_track = xqc_moq_track_create_with_namespace_tuple(subscriber_session,
+            forwarding->track_namespace_num, forwarding->track_namespace_tuple,
+            forwarding->track_name, forwarding->track_type,
+            NULL, container, XQC_MOQ_TRACK_FOR_PUB);
+    }
+
+    if (down_track == NULL) {
+        return;
+    }
+
+    xqc_moq_relay_downstream_t *downstream = xqc_calloc(1, sizeof(*downstream));
+    if (downstream == NULL) {
+        return;
+    }
+    xqc_init_list_head(&downstream->list_member);
+    downstream->session = subscriber_session;
+    downstream->track = down_track;
+    downstream->subscribe_id = down_track->subscribe_id;
+    downstream->publish_ok_received = 0;
+    xqc_list_add_tail(&downstream->list_member, &forwarding->downstream_list);
+
+    printf("relay history forward publish: upstream_subscribe_id:%"PRIu64" -> downstream_subscribe_id:%"PRIu64" track:%s/%s\n",
+           forwarding->upstream_subscribe_id,
+           downstream->subscribe_id,
+           xqc_demo_namespace_tuple_to_str(forwarding->track_namespace_tuple, forwarding->track_namespace_num),
+           forwarding->track_name ? forwarding->track_name : "null");
+}
+
+static void
+xqc_moq_relay_forward_publish_to_downstreams(xqc_moq_session_t *upstream_session,
+    xqc_moq_track_t *upstream_track, xqc_moq_publish_msg_t *publish_msg)
+{
+    if (upstream_session == NULL || upstream_track == NULL || publish_msg == NULL) {
+        return;
+    }
+
+    xqc_moq_relay_forwarding_t *forwarding =
+        xqc_moq_relay_find_forwarding(upstream_session, publish_msg->subscribe_id);
+    if (forwarding == NULL) {
+        forwarding = xqc_calloc(1, sizeof(*forwarding));
+        if (forwarding == NULL) {
+            return;
+        }
+        xqc_init_list_head(&forwarding->list_member);
+        xqc_init_list_head(&forwarding->downstream_list);
+        forwarding->upstream_session = upstream_session;
+        forwarding->upstream_subscribe_id = publish_msg->subscribe_id;
+        forwarding->upstream_track = upstream_track;
+        forwarding->track_type = upstream_track->track_info.track_type;
+        forwarding->track_namespace_num = publish_msg->track_namespace_num;
+        forwarding->track_namespace_tuple = xqc_moq_namespace_tuple_copy(publish_msg->track_namespace_tuple,
+                                                                  publish_msg->track_namespace_num);
+        if (publish_msg->track_name != NULL) {
+            size_t name_len = strlen(publish_msg->track_name);
+            forwarding->track_name = xqc_calloc(1, name_len + 1);
+            if (forwarding->track_name != NULL) {
+                xqc_memcpy(forwarding->track_name, publish_msg->track_name, name_len);
+            }
+        }
+        xqc_list_add_tail(&forwarding->list_member, &g_relay_forwarding_list);
+    }
+
+    xqc_list_head_t *pos;
+    xqc_list_for_each(pos, &g_relay_conn_list) {
+        xqc_moq_relay_conn_t *conn_ctx = xqc_list_entry(pos, xqc_moq_relay_conn_t, list_member);
+        if (conn_ctx->session == NULL || conn_ctx->session == upstream_session) {
+            continue;
+        }
+        if ((conn_ctx->session->peer_role & XQC_MOQ_SUBSCRIBER) == 0) {
+            continue;
+        }
+        if (!xqc_moq_relay_peer_wants_namespace(conn_ctx->session,
+                publish_msg->track_namespace_tuple, publish_msg->track_namespace_num)) {
+            continue;
+        }
+
+        xqc_moq_track_t *down_track = xqc_moq_find_track_by_track_namespace_tuple(conn_ctx->session,
+            publish_msg->track_namespace_tuple, publish_msg->track_namespace_num,
+            publish_msg->track_name, XQC_MOQ_TRACK_FOR_PUB);
+
+        if (down_track == NULL) {
+            xqc_moq_container_t container = XQC_MOQ_CONTAINER_LOC;
+            if (forwarding->track_type == XQC_MOQ_TRACK_DATACHANNEL) {
+                container = XQC_MOQ_CONTAINER_NONE;
+            }
+            down_track = xqc_moq_track_create_with_namespace_tuple(conn_ctx->session,
+                publish_msg->track_namespace_num, publish_msg->track_namespace_tuple,
+                publish_msg->track_name, forwarding->track_type,
+                &upstream_track->track_info.selection_params, container, XQC_MOQ_TRACK_FOR_PUB);
+        }
+
+        if (down_track == NULL) {
+            continue;
+        }
+
+        if (xqc_moq_relay_forwarding_has_downstream(forwarding, conn_ctx->session)) {
+            continue;
+        }
+
+        xqc_moq_relay_downstream_t *downstream = xqc_calloc(1, sizeof(*downstream));
+        if (downstream == NULL) {
+            continue;
+        }
+        xqc_init_list_head(&downstream->list_member);
+        downstream->session = conn_ctx->session;
+        downstream->track = down_track;
+        downstream->subscribe_id = down_track->subscribe_id;
+        downstream->publish_ok_received = 0;
+        xqc_list_add_tail(&downstream->list_member, &forwarding->downstream_list);
+
+        printf("relay forward publish: upstream_subscribe_id:%"PRIu64" -> downstream_subscribe_id:%"PRIu64" track:%s/%s\n",
+               forwarding->upstream_subscribe_id, downstream->subscribe_id,
+               xqc_demo_namespace_tuple_to_str(publish_msg->track_namespace_tuple, publish_msg->track_namespace_num),
+               publish_msg->track_name ? publish_msg->track_name : "null");
+    }
+}
+
+static void
+xqc_moq_relay_on_publish(xqc_moq_user_session_t *user_session, xqc_moq_track_t *track,
+    xqc_moq_publish_msg_t *publish_msg)
+{
+    if (user_session == NULL || user_session->session == NULL || track == NULL || publish_msg == NULL) {
+        return;
+    }
+    xqc_moq_session_t *session = user_session->session;
+
+    printf("relay on_publish: subscribe_id:%"PRIu64" track:%s/%s\n",
+           publish_msg->subscribe_id,
+           xqc_demo_namespace_tuple_to_str(publish_msg->track_namespace_tuple, publish_msg->track_namespace_num),
+           publish_msg->track_name ? publish_msg->track_name : "null");
+
+    xqc_moq_publish_ok_msg_t publish_ok;
+    memset(&publish_ok, 0, sizeof(publish_ok));
+    publish_ok.subscribe_id = publish_msg->subscribe_id;
+    publish_ok.forward = 1;
+    publish_ok.subscriber_priority = 0;
+    publish_ok.group_order = publish_msg->group_order;
+    publish_ok.filter_type = XQC_MOQ_FILTER_LAST_GROUP;
+    publish_ok.start_group_id = 0;
+    publish_ok.start_object_id = 0;
+    publish_ok.end_group_id = 0;
+    publish_ok.params_num = 0;
+    publish_ok.params = NULL;
+    if (xqc_moq_write_publish_ok(session, &publish_ok) < 0) {
+        printf("relay xqc_moq_write_publish_ok error\n");
+        return;
+    }
+
+    xqc_moq_relay_forward_publish_to_downstreams(session, track, publish_msg);
+}
+
+static void
+xqc_moq_relay_on_publish_done(xqc_moq_user_session_t *user_session, xqc_moq_track_t *track,
+    xqc_moq_publish_done_msg_t *publish_done)
+{
+    (void)track;
+    if (user_session == NULL || user_session->session == NULL || publish_done == NULL) {
+        return;
+    }
+
+    xqc_moq_session_t *upstream_session = user_session->session;
+    xqc_moq_relay_forwarding_t *forwarding =
+        xqc_moq_relay_find_forwarding(upstream_session, publish_done->subscribe_id);
+    if (forwarding == NULL) {
+        return;
+    }
+
+    printf("relay on_publish_done: subscribe_id:%"PRIu64" status:%"PRIu64"\n",
+           publish_done->subscribe_id, publish_done->status_code);
+
+    xqc_list_del(&forwarding->list_member);
+    xqc_moq_relay_forwarding_cleanup(forwarding, 1);
+}
+
+static void
+xqc_moq_relay_on_video_frame(xqc_moq_user_session_t *user_session, uint64_t subscribe_id,
+    xqc_moq_video_frame_t *video_frame)
+{
+    if (user_session == NULL || user_session->session == NULL || video_frame == NULL) {
+        return;
+    }
+    xqc_moq_session_t *session = user_session->session;
+    xqc_moq_relay_forwarding_t *fwd = xqc_moq_relay_find_forwarding(session, subscribe_id);
+    if (fwd == NULL) {
+        return;
+    }
+
+    xqc_list_head_t *pos;
+    xqc_list_for_each(pos, &fwd->downstream_list) {
+        xqc_moq_relay_downstream_t *downstream = xqc_list_entry(pos, xqc_moq_relay_downstream_t, list_member);
+        if (!downstream->publish_ok_received || downstream->track == NULL
+            || downstream->subscribe_id == XQC_MOQ_INVALID_ID) {
+            continue;
+        }
+        if (!xqc_moq_relay_session_is_active(downstream->session)) {
+            continue;
+        }
+        (void)xqc_moq_write_video_frame(downstream->session, downstream->subscribe_id, downstream->track, video_frame);
+    }
+}
+
+static void
+xqc_moq_relay_on_audio_frame(xqc_moq_user_session_t *user_session, uint64_t subscribe_id,
+    xqc_moq_audio_frame_t *audio_frame)
+{
+    if (user_session == NULL || user_session->session == NULL || audio_frame == NULL) {
+        return;
+    }
+    xqc_moq_session_t *session = user_session->session;
+    xqc_moq_relay_forwarding_t *fwd = xqc_moq_relay_find_forwarding(session, subscribe_id);
+    if (fwd == NULL) {
+        return;
+    }
+
+    xqc_list_head_t *pos;
+    xqc_list_for_each(pos, &fwd->downstream_list) {
+        xqc_moq_relay_downstream_t *downstream = xqc_list_entry(pos, xqc_moq_relay_downstream_t, list_member);
+        if (!downstream->publish_ok_received || downstream->track == NULL
+            || downstream->subscribe_id == XQC_MOQ_INVALID_ID) {
+            continue;
+        }
+        if (!xqc_moq_relay_session_is_active(downstream->session)) {
+            continue;
+        }
+        (void)xqc_moq_write_audio_frame(downstream->session, downstream->subscribe_id, downstream->track, audio_frame);
+    }
+}
+
+static void
+xqc_moq_relay_detach_session_from_forwardings(xqc_moq_session_t *session)
+{
+    xqc_list_head_t *pos_forwarding, *next_forwarding;
+    xqc_list_for_each_safe(pos_forwarding, next_forwarding, &g_relay_forwarding_list) {
+        xqc_moq_relay_forwarding_t *forwarding =
+            xqc_list_entry(pos_forwarding, xqc_moq_relay_forwarding_t, list_member);
+
+        if (forwarding->upstream_session == session) {
+            xqc_list_del(&forwarding->list_member);
+            xqc_moq_relay_forwarding_cleanup(forwarding, 1);
+            continue;
+        }
+
+        xqc_list_head_t *pos_downstream, *next_downstream;
+        xqc_list_for_each_safe(pos_downstream, next_downstream, &forwarding->downstream_list) {
+            xqc_moq_relay_downstream_t *downstream =
+                xqc_list_entry(pos_downstream, xqc_moq_relay_downstream_t, list_member);
+            if (downstream->session == session) {
+                xqc_list_del(&downstream->list_member);
+                xqc_free(downstream);
+            }
+        }
+    }
+}
+
+static void
+xqc_moq_relay_on_subscribe_namespace(xqc_moq_user_session_t *user_session, xqc_moq_subscribe_namespace_msg_t *msg)
+{
+    if (user_session == NULL || user_session->session == NULL || msg == NULL) {
+        return;
+    }
+
+    xqc_moq_session_t *session = user_session->session;
+
+    if (msg->track_namespace_tuple == NULL
+        || msg->track_namespace_num == 0
+        || msg->track_namespace_num > XQC_MOQ_MAX_NAMESPACE_TUPLE_ELEMS)
+    {
+        xqc_log(session->log, XQC_LOG_ERROR,
+                "|subscribe_namespace invalid prefix|request_id:%ui|prefix_num:%ui|",
+                msg->request_id, msg->track_namespace_num);
+        xqc_moq_session_error(session, MOQ_PROTOCOL_VIOLATION, "subscribe namespace invalid prefix");
+        return;
+    }
+
+    if (xqc_moq_session_namespace_prefix_overlaps(session, msg->track_namespace_tuple, msg->track_namespace_num)) {
+        xqc_moq_subscribe_namespace_error_msg_t err;
+        memset(&err, 0, sizeof(err));
+        err.request_id = msg->request_id;
+        err.error_code = XQC_MOQ_SUBSCRIBE_NAMESPACE_ERR_PREFIX_OVERLAP;
+        err.reason_phrase = "namespace prefix overlap";
+        xqc_int_t ret = xqc_moq_write_subscribe_namespace_error(session, &err);
+        if (ret < 0) {
+            xqc_log(session->log, XQC_LOG_ERROR, "|write_subscribe_namespace_error error|ret:%d|", ret);
+            xqc_moq_session_error(session, MOQ_INTERNAL_ERROR, "on subscribe namespace");
+        }
+        return;
+    }
+
+    xqc_int_t ret = xqc_moq_session_add_namespace_prefix(session, msg->track_namespace_tuple, msg->track_namespace_num);
+    if (ret < 0) {
+        xqc_log(session->log, XQC_LOG_ERROR, "|add namespace prefix failed|ret:%d|", ret);
+        xqc_moq_session_error(session, MOQ_INTERNAL_ERROR, "on subscribe namespace");
+        return;
+    }
+
+    xqc_moq_subscribe_namespace_ok_msg_t ok;
+    memset(&ok, 0, sizeof(ok));
+    ok.request_id = msg->request_id;
+    ret = xqc_moq_write_subscribe_namespace_ok(session, &ok);
+    if (ret < 0) {
+        xqc_log(session->log, XQC_LOG_ERROR, "|write_subscribe_namespace_ok error|ret:%d|", ret);
+        xqc_moq_session_error(session, MOQ_INTERNAL_ERROR, "on subscribe namespace");
+        return;
+    }
+
+    xqc_moq_relay_conn_t *subscriber_conn_ctx = (xqc_moq_relay_conn_t *)user_session->data;
+    xqc_list_head_t *pos;
+    xqc_list_for_each(pos, &g_relay_forwarding_list) {
+        xqc_moq_relay_forwarding_t *forwarding = xqc_list_entry(pos, xqc_moq_relay_forwarding_t, list_member);
+        xqc_moq_relay_attach_forwarding_to_subscriber(forwarding, subscriber_conn_ctx);
+    }
+}
+
+static xqc_int_t
+xqc_server_conn_closing_notify(xqc_connection_t *conn, const xqc_cid_t *cid,
+    xqc_int_t err_code, void *conn_user_data)
+{
+    (void)conn;
+    (void)cid;
+    (void)err_code;
+
+    xqc_moq_user_session_t *user_session = (xqc_moq_user_session_t *)conn_user_data;
+    if (user_session == NULL) {
+        return 0;
+    }
+
+    xqc_moq_relay_conn_t *conn_ctx = (xqc_moq_relay_conn_t *)user_session->data;
+    if (conn_ctx != NULL) {
+        conn_ctx->base.closing_notified = 1;
+    }
+
+    xqc_moq_session_t *closing_session = user_session->session;
+    if (closing_session != NULL) {
+        xqc_moq_relay_detach_session_from_forwardings(closing_session);
+    }
+
+    if (conn_ctx != NULL && !xqc_list_empty(&conn_ctx->list_member)) {
+        xqc_list_del_init(&conn_ctx->list_member);
+    }
+
+    return 0;
+}
+
+static void
+xqc_moq_relay_on_session_setup(xqc_moq_user_session_t *user_session, char *extdata,
+    const xqc_moq_message_parameter_t *params, uint64_t params_num)
+{
+    (void)extdata;
+    if (user_session == NULL || user_session->session == NULL) {
+        return;
+    }
+
+    xqc_moq_session_t *session = user_session->session;
+    xqc_moq_relay_conn_t *conn_ctx = (xqc_moq_relay_conn_t *)user_session->data;
+    conn_ctx->session = session;
+
+    if (params != NULL && params_num > 0) {
+        for (uint64_t i = 0; i < params_num; i++) {
+            if (params[i].type == XQC_MOQ_PARAM_ROLE && params[i].is_integer) {
+                session->peer_role = (xqc_moq_role_t)params[i].int_value;
+            }
+        }
+    }
+
+    printf("relay session setup: peer_role:%u\n", (unsigned)session->peer_role);
+}
+
+static void
+xqc_moq_relay_on_datachannel(xqc_moq_user_session_t *user_session, xqc_moq_track_t *track,
+    xqc_moq_track_info_t *track_info)
+{
+    (void)user_session;
+    (void)track;
+    (void)track_info;
+}
+
+static void
+xqc_moq_relay_on_datachannel_msg(xqc_moq_user_session_t *user_session, xqc_moq_track_t *track,
+    xqc_moq_track_info_t *track_info, uint8_t *msg, size_t msg_len)
+{
+    (void)user_session;
+    (void)track;
+    (void)track_info;
+    (void)msg;
+    (void)msg_len;
+}
+
+static void
+xqc_moq_relay_on_subscribe(xqc_moq_user_session_t *user_session, uint64_t subscribe_id,
+    xqc_moq_track_t *track, xqc_moq_subscribe_msg_t *msg)
+{
+    (void)user_session;
+    (void)subscribe_id;
+    (void)track;
+    (void)msg;
+}
+
+static void
+xqc_moq_relay_on_subscribe_ok(xqc_moq_user_session_t *user_session, xqc_moq_track_t *track,
+    xqc_moq_track_info_t *track_info, xqc_moq_subscribe_ok_msg_t *subscribe_ok)
+{
+    (void)user_session;
+    (void)track;
+    (void)track_info;
+    (void)subscribe_ok;
+}
+
+static void
+xqc_moq_relay_on_subscribe_error(xqc_moq_user_session_t *user_session, xqc_moq_track_t *track,
+    xqc_moq_track_info_t *track_info, xqc_moq_subscribe_error_msg_t *subscribe_error)
+{
+    (void)user_session;
+    (void)track;
+    (void)track_info;
+    (void)subscribe_error;
+}
+
+static void
+xqc_moq_relay_on_request_keyframe(xqc_moq_user_session_t *user_session, uint64_t subscribe_id,
+    xqc_moq_track_t *track)
+{
+    (void)user_session;
+    (void)subscribe_id;
+    (void)track;
+}
+
+static void
+xqc_moq_relay_on_catalog(xqc_moq_user_session_t *user_session, xqc_moq_track_info_t **track_info_array,
+    xqc_int_t array_size)
+{
+    (void)user_session;
+    (void)track_info_array;
+    (void)array_size;
+}
+
+static void
+xqc_server_socket_read_handler(xqc_app_ctx_t *ctx)
+{
+    unsigned char packet_buf[2048];
+    struct sockaddr_in6 peer_addr;
+    socklen_t peer_addrlen = sizeof(peer_addr);
+
+    ssize_t recv_size;
+    do {
+        recv_size = recvfrom(ctx->listen_fd, packet_buf, sizeof(packet_buf), 0,
+                             (struct sockaddr *)&peer_addr, &peer_addrlen);
+        if (recv_size < 0) {
+            break;
+        }
+        xqc_int_t ret = xqc_engine_packet_process(ctx->engine, packet_buf, (size_t)recv_size,
+                                                  (struct sockaddr *)&ctx->local_addr, ctx->local_addrlen,
+                                                  (struct sockaddr *)&peer_addr, peer_addrlen,
+                                                  xqc_now(), NULL);
+        if (ret != XQC_OK) {
+            printf("xqc_engine_packet_process error:%d\n", ret);
+            break;
+        }
+    } while (recv_size > 0);
+
+    xqc_engine_finish_recv(ctx->engine);
+}
+
+static void
+xqc_server_socket_write_handler(xqc_app_ctx_t *ctx)
+{
+    (void)ctx;
+}
+
+static void
+xqc_server_socket_event_callback(int fd, short what, void *arg)
+{
+    xqc_app_ctx_t *ctx = (xqc_app_ctx_t *)arg;
+    if (what & EV_READ) {
+        xqc_server_socket_read_handler(ctx);
+    } else if (what & EV_WRITE) {
+        xqc_server_socket_write_handler(ctx);
+    }
+}
+
+static void
+stop(int signo)
+{
+    (void)signo;
+    event_base_loopbreak(g_event_base);
+    xqc_engine_destroy(g_app_ctx.engine);
+    fflush(stdout);
+    exit(0);
+}
+
+static int
+xqc_server_create_socket(const char *addr, unsigned int port)
+{
+    int fd;
+    int type = g_ipv6 ? AF_INET6 : AF_INET;
+    g_app_ctx.local_addrlen = g_ipv6 ? sizeof(struct sockaddr_in6) : sizeof(struct sockaddr_in);
+
+    memset(&g_app_ctx.local_addr, 0, sizeof(g_app_ctx.local_addr));
+    struct sockaddr_in6 *sin6 = &g_app_ctx.local_addr;
+    sin6->sin6_family = AF_INET6;
+    sin6->sin6_port = htons(port);
+    if (g_ipv6) {
+        inet_pton(AF_INET6, addr, &sin6->sin6_addr);
+    } else {
+        struct sockaddr_in *sin = (struct sockaddr_in *)&g_app_ctx.local_addr;
+        sin->sin_family = AF_INET;
+        sin->sin_port = htons(port);
+        sin->sin_addr.s_addr = inet_addr(addr);
+    }
+
+    fd = socket(type, SOCK_DGRAM, 0);
+    if (fd < 0) {
+        printf("create socket failed, errno:%d\n", get_sys_errno());
+        return -1;
+    }
+#ifndef XQC_SYS_WINDOWS
+    if (fcntl(fd, F_SETFL, O_NONBLOCK) == -1) {
+        printf("set socket nonblock failed, errno:%d\n", errno);
+        close(fd);
+        return -1;
+    }
+#endif
+    int optval = 1;
+    setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
+    setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval));
+
+    if (bind(fd, (struct sockaddr *)&g_app_ctx.local_addr, g_app_ctx.local_addrlen) < 0) {
+        printf("bind failed, errno:%d\n", get_sys_errno());
+        close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+static int
+xqc_server_accept(xqc_engine_t *engine, xqc_connection_t *conn, const xqc_cid_t *cid, void *user_data)
+{
+    (void)engine;
+    (void)user_data;
+
+    xqc_moq_user_session_t *user_session = calloc(1, sizeof(xqc_moq_user_session_t) + sizeof(xqc_moq_relay_conn_t));
+    if (user_session == NULL) {
+        return -1;
+    }
+    xqc_moq_relay_conn_t *conn_ctx = (xqc_moq_relay_conn_t *)user_session->data;
+    conn_ctx->user_session = user_session;
+    conn_ctx->conn = conn;
+    conn_ctx->base.fd = g_app_ctx.listen_fd;
+    memcpy(&conn_ctx->cid, cid, sizeof(*cid));
+    xqc_init_list_head(&conn_ctx->list_member);
+    xqc_list_add_tail(&conn_ctx->list_member, &g_relay_conn_list);
+
+    xqc_moq_session_callbacks_t callbacks = {
+        .on_session_setup = xqc_moq_relay_on_session_setup,
+        .on_datachannel = xqc_moq_relay_on_datachannel,
+        .on_datachannel_msg = xqc_moq_relay_on_datachannel_msg,
+        .on_subscribe = xqc_moq_relay_on_subscribe,
+        .on_request_keyframe = xqc_moq_relay_on_request_keyframe,
+        .on_subscribe_ok = xqc_moq_relay_on_subscribe_ok,
+        .on_subscribe_error = xqc_moq_relay_on_subscribe_error,
+        .on_publish = xqc_moq_relay_on_publish,
+        .on_publish_ok = xqc_moq_relay_on_publish_ok,
+        .on_publish_done = xqc_moq_relay_on_publish_done,
+        .on_catalog = xqc_moq_relay_on_catalog,
+        .on_video = xqc_moq_relay_on_video_frame,
+        .on_audio = xqc_moq_relay_on_audio_frame,
+        .on_subscribe_namespace = xqc_moq_relay_on_subscribe_namespace,
+    };
+
+    xqc_moq_session_t *session = xqc_moq_session_create(conn, user_session, XQC_MOQ_TRANSPORT_QUIC,
+        XQC_MOQ_PUBSUB, callbacks, NULL, g_enable_client_setup_v14);
+    if (session == NULL) {
+        printf("relay create session error\n");
+        xqc_list_del(&conn_ctx->list_member);
+        free(user_session);
+        return -1;
+    }
+    conn_ctx->session = session;
+
+    xqc_conn_set_transport_user_data(conn, user_session);
+    printf("relay accept: session:%p\n", (void *)session);
+    return 0;
+}
+
+static int
+xqc_server_conn_close_notify(xqc_connection_t *conn, const xqc_cid_t *cid, void *user_data, void *conn_proto_data)
+{
+    (void)conn;
+    (void)cid;
+    (void)conn_proto_data;
+
+    xqc_moq_user_session_t *user_session = (xqc_moq_user_session_t *)user_data;
+    if (user_session == NULL) {
+        return 0;
+    }
+
+    xqc_moq_relay_conn_t *conn_ctx = (xqc_moq_relay_conn_t *)user_session->data;
+    xqc_moq_session_t *closing_session = conn_ctx ? conn_ctx->session : NULL;
+    if (closing_session != NULL) {
+        xqc_moq_relay_detach_session_from_forwardings(closing_session);
+    }
+
+    if (conn_ctx != NULL && !xqc_list_empty(&conn_ctx->list_member)) {
+        xqc_list_del_init(&conn_ctx->list_member);
+    }
+
+    if (user_session->session != NULL) {
+        xqc_moq_session_destroy(user_session->session);
+    }
+    free(user_session);
+    return 0;
+}
+
+int
+main(int argc, char *argv[])
+{
+    signal(SIGINT, stop);
+    signal(SIGTERM, stop);
+
+    int ch;
+    while ((ch = getopt(argc, argv, "p:l:V")) != -1) {
+        switch (ch) {
+        case 'p':
+            g_relay_port = atoi(optarg);
+            printf("option port :%s\n", optarg);
+            break;
+        case 'l':
+            g_log_level = optarg[0];
+            printf("option log level :%s\n", optarg);
+            break;
+        case 'V':
+            printf("option draft14 client setup : on\n");
+            g_enable_client_setup_v14 = 1;
+            break;
+        default:
+            break;
+        }
+    }
+
+    memset(&g_app_ctx, 0, sizeof(g_app_ctx));
+    xqc_init_list_head(&g_relay_conn_list);
+    xqc_init_list_head(&g_relay_forwarding_list);
+
+    xqc_app_open_log_file(&g_app_ctx, "./relay.log");
+    xqc_platform_init_env();
+
+    xqc_engine_ssl_config_t engine_ssl_config;
+    memset(&engine_ssl_config, 0, sizeof(engine_ssl_config));
+    engine_ssl_config.private_key_file = "./server.key";
+    engine_ssl_config.cert_file = "./server.crt";
+    engine_ssl_config.ciphers = XQC_TLS_CIPHERS;
+    engine_ssl_config.groups = XQC_TLS_GROUPS;
+
+    xqc_config_t config;
+    if (xqc_engine_get_default_config(&config, XQC_ENGINE_SERVER) < 0) {
+        return -1;
+    }
+    xqc_app_set_log_level(g_log_level, &config);
+
+    xqc_engine_callback_t engine_callbacks = {
+        .set_event_timer = xqc_app_set_event_timer,
+        .log_callbacks = {
+            .xqc_log_write_err = xqc_app_write_log,
+            .xqc_log_write_stat = xqc_app_write_log,
+        },
+    };
+
+    xqc_transport_callbacks_t transport_callbacks = {
+        .server_accept = xqc_server_accept,
+        .write_socket = xqc_app_write_socket,
+        .write_socket_ex = xqc_app_write_socket_ex,
+        .conn_closing = xqc_server_conn_closing_notify,
+    };
+
+    g_app_ctx.engine = xqc_engine_create(XQC_ENGINE_SERVER, &config, &engine_ssl_config,
+        &engine_callbacks, &transport_callbacks, &g_app_ctx);
+    if (g_app_ctx.engine == NULL) {
+        printf("create engine error\n");
+        return -1;
+    }
+
+    xqc_conn_callbacks_t conn_cbs = {
+        .conn_create_notify = NULL,
+        .conn_close_notify = xqc_server_conn_close_notify,
+        .conn_handshake_finished = NULL,
+    };
+    xqc_moq_init_alpn(g_app_ctx.engine, &conn_cbs, XQC_MOQ_TRANSPORT_QUIC);
+
+    g_app_ctx.listen_fd = xqc_server_create_socket(TEST_ADDR, (unsigned)g_relay_port);
+    if (g_app_ctx.listen_fd < 0) {
+        printf("create listen socket error\n");
+        return -1;
+    }
+
+    g_event_base = event_base_new();
+    if (g_event_base == NULL) {
+        return -1;
+    }
+    g_app_ctx.ev_engine = event_new(g_event_base, -1, 0, xqc_app_engine_callback, &g_app_ctx);
+    g_app_ctx.ev_socket = event_new(g_event_base, g_app_ctx.listen_fd, EV_READ | EV_PERSIST,
+                                    xqc_server_socket_event_callback, &g_app_ctx);
+    event_add(g_app_ctx.ev_socket, NULL);
+
+    printf("moq_demo_relay_v14 listening on %s:%d\n", TEST_ADDR, g_relay_port);
+    event_base_dispatch(g_event_base);
+
+    xqc_engine_destroy(g_app_ctx.engine);
+    return 0;
+}

--- a/moq/demo/xqc_moq_demo_relay_v14.c
+++ b/moq/demo/xqc_moq_demo_relay_v14.c
@@ -79,8 +79,16 @@ typedef struct xqc_moq_relay_conn_s {
     xqc_cid_t                cid;
 } xqc_moq_relay_conn_t;
 
+typedef struct xqc_moq_relay_pub_namespace_s {
+    xqc_list_head_t              list_member;
+    xqc_moq_session_t            *session;
+    uint64_t                     track_namespace_num;
+    xqc_moq_track_ns_field_t     *track_namespace_tuple;
+} xqc_moq_relay_pub_namespace_t;
+
 static xqc_list_head_t g_relay_conn_list;
 static xqc_list_head_t g_relay_forwarding_list;
+static xqc_list_head_t g_relay_pub_namespace_list;
 
 static xqc_int_t
 xqc_moq_relay_forwarding_has_downstream(xqc_moq_relay_forwarding_t *forwarding, xqc_moq_session_t *downstream_session)
@@ -508,6 +516,86 @@ xqc_moq_relay_detach_session_from_forwardings(xqc_moq_session_t *session)
     }
 }
 
+static xqc_moq_relay_pub_namespace_t *
+xqc_moq_relay_find_pub_namespace_for_track(
+    const xqc_moq_track_ns_field_t *track_namespace_tuple, uint64_t track_namespace_num,
+    xqc_moq_session_t *exclude_session)
+{
+    xqc_list_head_t *pos;
+    xqc_list_for_each(pos, &g_relay_pub_namespace_list) {
+        xqc_moq_relay_pub_namespace_t *pub_ns =
+            xqc_list_entry(pos, xqc_moq_relay_pub_namespace_t, list_member);
+        if (pub_ns->session == exclude_session) {
+            continue;
+        }
+        if (!xqc_moq_relay_session_is_active(pub_ns->session)) {
+            continue;
+        }
+        if (xqc_moq_namespace_tuple_is_prefix(pub_ns->track_namespace_tuple, pub_ns->track_namespace_num,
+                track_namespace_tuple, track_namespace_num))
+        {
+            return pub_ns;
+        }
+    }
+    return NULL;
+}
+
+static void
+xqc_moq_relay_detach_pub_namespaces(xqc_moq_session_t *session)
+{
+    xqc_list_head_t *pos, *next;
+    xqc_list_for_each_safe(pos, next, &g_relay_pub_namespace_list) {
+        xqc_moq_relay_pub_namespace_t *pub_ns =
+            xqc_list_entry(pos, xqc_moq_relay_pub_namespace_t, list_member);
+        if (pub_ns->session == session) {
+            xqc_list_del(&pub_ns->list_member);
+            if (pub_ns->track_namespace_tuple != NULL) {
+                xqc_moq_namespace_tuple_free(pub_ns->track_namespace_tuple, pub_ns->track_namespace_num);
+            }
+            xqc_free(pub_ns);
+        }
+    }
+}
+
+static void
+xqc_moq_relay_on_publish_namespace(xqc_moq_user_session_t *user_session,
+    xqc_moq_publish_namespace_msg_t *msg)
+{
+    if (user_session == NULL || user_session->session == NULL || msg == NULL) {
+        return;
+    }
+
+    xqc_moq_session_t *session = user_session->session;
+
+    xqc_moq_relay_pub_namespace_t *pub_ns = xqc_calloc(1, sizeof(*pub_ns));
+    if (pub_ns == NULL) {
+        return;
+    }
+    xqc_init_list_head(&pub_ns->list_member);
+    pub_ns->session = session;
+    pub_ns->track_namespace_num = msg->track_namespace_num;
+    pub_ns->track_namespace_tuple = xqc_moq_namespace_tuple_copy(
+        msg->track_namespace_tuple, msg->track_namespace_num);
+    if (pub_ns->track_namespace_tuple == NULL) {
+        xqc_free(pub_ns);
+        return;
+    }
+    xqc_list_add_tail(&pub_ns->list_member, &g_relay_pub_namespace_list);
+
+    printf("relay on_publish_namespace: session:%p namespace:%s\n",
+           (void *)session,
+           xqc_demo_namespace_tuple_to_str(msg->track_namespace_tuple, msg->track_namespace_num));
+
+    xqc_moq_publish_namespace_ok_msg_t ok;
+    memset(&ok, 0, sizeof(ok));
+    ok.request_id = msg->request_id;
+    xqc_int_t ret = xqc_moq_write_publish_namespace_ok(session, &ok);
+    if (ret < 0) {
+        xqc_log(session->log, XQC_LOG_ERROR, "|write_publish_namespace_ok error|ret:%d|", ret);
+        xqc_moq_session_error(session, MOQ_INTERNAL_ERROR, "on publish namespace");
+    }
+}
+
 static void
 xqc_moq_relay_on_subscribe_namespace(xqc_moq_user_session_t *user_session, xqc_moq_subscribe_namespace_msg_t *msg)
 {
@@ -588,6 +676,7 @@ xqc_server_conn_closing_notify(xqc_connection_t *conn, const xqc_cid_t *cid,
     xqc_moq_session_t *closing_session = user_session->session;
     if (closing_session != NULL) {
         xqc_moq_relay_detach_session_from_forwardings(closing_session);
+        xqc_moq_relay_detach_pub_namespaces(closing_session);
     }
 
     if (conn_ctx != NULL && !xqc_list_empty(&conn_ctx->list_member)) {
@@ -645,10 +734,45 @@ static void
 xqc_moq_relay_on_subscribe(xqc_moq_user_session_t *user_session, uint64_t subscribe_id,
     xqc_moq_track_t *track, xqc_moq_subscribe_msg_t *msg)
 {
-    (void)user_session;
-    (void)subscribe_id;
-    (void)track;
-    (void)msg;
+    if (track != NULL) {
+        return;
+    }
+    if (user_session == NULL || user_session->session == NULL || msg == NULL) {
+        return;
+    }
+
+    xqc_moq_session_t *session = user_session->session;
+
+    xqc_moq_relay_pub_namespace_t *pub_ns = xqc_moq_relay_find_pub_namespace_for_track(
+        msg->track_namespace_tuple, msg->track_namespace_num, session);
+
+    if (pub_ns != NULL) {
+        printf("relay on_subscribe: found publisher for namespace, sending subscribe_ok "
+               "subscribe_id:%"PRIu64" track:%s\n",
+               subscribe_id, msg->track_name ? msg->track_name : "null");
+        xqc_moq_subscribe_ok_msg_t ok;
+        memset(&ok, 0, sizeof(ok));
+        ok.subscribe_id = subscribe_id;
+        ok.expire_ms = 0;
+        ok.content_exist = 0;
+        ok.largest_group_id = 0;
+        ok.largest_object_id = 0;
+        ok.params_num = 0;
+        ok.params = NULL;
+        xqc_moq_write_subscribe_ok(session, &ok);
+    } else {
+        printf("relay on_subscribe: no publisher found, sending subscribe_error "
+               "subscribe_id:%"PRIu64" track:%s\n",
+               subscribe_id, msg->track_name ? msg->track_name : "null");
+        xqc_moq_subscribe_error_msg_t err;
+        memset(&err, 0, sizeof(err));
+        err.subscribe_id = subscribe_id;
+        err.error_code = 1;
+        err.reason_phrase = "no matching publisher namespace";
+        err.reason_phrase_len = strlen(err.reason_phrase);
+        err.track_alias = msg->track_alias;
+        xqc_moq_write_subscribe_error(session, &err);
+    }
 }
 
 static void
@@ -819,6 +943,7 @@ xqc_server_accept(xqc_engine_t *engine, xqc_connection_t *conn, const xqc_cid_t 
         .on_catalog = xqc_moq_relay_on_catalog,
         .on_video = xqc_moq_relay_on_video_frame,
         .on_audio = xqc_moq_relay_on_audio_frame,
+        .on_publish_namespace = xqc_moq_relay_on_publish_namespace,
         .on_subscribe_namespace = xqc_moq_relay_on_subscribe_namespace,
     };
 
@@ -853,6 +978,7 @@ xqc_server_conn_close_notify(xqc_connection_t *conn, const xqc_cid_t *cid, void 
     xqc_moq_session_t *closing_session = conn_ctx ? conn_ctx->session : NULL;
     if (closing_session != NULL) {
         xqc_moq_relay_detach_session_from_forwardings(closing_session);
+        xqc_moq_relay_detach_pub_namespaces(closing_session);
     }
 
     if (conn_ctx != NULL && !xqc_list_empty(&conn_ctx->list_member)) {
@@ -895,6 +1021,7 @@ main(int argc, char *argv[])
     memset(&g_app_ctx, 0, sizeof(g_app_ctx));
     xqc_init_list_head(&g_relay_conn_list);
     xqc_init_list_head(&g_relay_forwarding_list);
+    xqc_init_list_head(&g_relay_pub_namespace_list);
 
     xqc_app_open_log_file(&g_app_ctx, "./relay.log");
     xqc_platform_init_env();

--- a/moq/demo/xqc_moq_demo_server.c
+++ b/moq/demo/xqc_moq_demo_server.c
@@ -41,7 +41,7 @@
 #define MAX_BUF_SIZE (100*1024*1024)
 
 #define XQC_MAX_LOG_LEN 2048
-#define XQC_CID_LEN 12
+#define XQC_CID_LEN 8
 
 extern long xqc_random(void);
 extern xqc_usec_t xqc_now();
@@ -59,7 +59,11 @@ xqc_moq_role_t g_role = XQC_MOQ_PUBSUB;
 int g_publish_mode = 0;
 int g_enable_client_setup_v14 = 0;
 int g_raw_object_mode = 0;
-int g_publish_reply_mode = 0;
+int g_subscribe_namespace_mode = 0;
+int g_publish_reply_ok = 0;
+int g_publish_reply_error = 0;
+
+static uint64_t g_subscribe_namespace_request_id = 1;
 
 xqc_int_t
 xqc_demo_publish_track(user_conn_t *user_conn, const char *track_namespace, const char *track_name)
@@ -67,9 +71,24 @@ xqc_demo_publish_track(user_conn_t *user_conn, const char *track_namespace, cons
     xqc_moq_publish_msg_t publish_msg;
     xqc_int_t ret = 0;
     memset(&publish_msg, 0, sizeof(publish_msg));
-    publish_msg.track_namespace = (char *)track_namespace;
-    publish_msg.track_namespace_len = strlen(track_namespace);
-    publish_msg.track_namespace_num = 1;
+
+    xqc_moq_track_ns_field_t namespace_tuple[2];
+    uint64_t namespace_num = 0;
+    if (g_subscribe_namespace_mode) {
+        namespace_tuple[0].data = (unsigned char *)"namespace";
+        namespace_tuple[0].len = sizeof("namespace") - 1;
+        namespace_tuple[1].data = (unsigned char *)"xquic";
+        namespace_tuple[1].len = sizeof("xquic") - 1;
+        namespace_num = 2;
+    } else {
+        namespace_tuple[0].data = (unsigned char *)track_namespace;
+        namespace_tuple[0].len = strlen(track_namespace);
+        namespace_num = 1;
+    }
+    publish_msg.track_namespace_num = namespace_num;
+    publish_msg.track_namespace_tuple = namespace_tuple;
+    publish_msg.track_namespace_len = 0;
+
     publish_msg.track_name = (char *)track_name;
     publish_msg.track_name_len = strlen(track_name);
     publish_msg.group_order = 1;
@@ -79,6 +98,47 @@ xqc_demo_publish_track(user_conn_t *user_conn, const char *track_namespace, cons
     publish_msg.forward = 1;
     publish_msg.params_num = 0;
     ret = xqc_moq_publish(user_conn->moq_session, &publish_msg);
+    return ret;
+}
+
+static xqc_int_t
+xqc_demo_send_subscribe_namespace(xqc_moq_session_t *session)
+{
+    if (session == NULL) {
+        return -1;
+    }
+
+    xqc_moq_track_ns_field_t namespace_prefix_tuple[2];
+    uint64_t namespace_prefix_num = 0;
+    if (g_subscribe_namespace_mode) {
+        namespace_prefix_tuple[0].data = (unsigned char *)"namespace";
+        namespace_prefix_tuple[0].len = sizeof("namespace") - 1;
+        namespace_prefix_tuple[1].data = (unsigned char *)"xquic";
+        namespace_prefix_tuple[1].len = sizeof("xquic") - 1;
+        namespace_prefix_num = 2;
+    } else {
+        namespace_prefix_tuple[0].data = (unsigned char *)"namespace/xquic";
+        namespace_prefix_tuple[0].len = sizeof("namespace/xquic") - 1;
+        namespace_prefix_num = 1;
+    }
+
+    xqc_moq_subscribe_namespace_msg_t subscribe_namespace_msg;
+    memset(&subscribe_namespace_msg, 0, sizeof(subscribe_namespace_msg));
+    subscribe_namespace_msg.request_id = g_subscribe_namespace_request_id++;
+    subscribe_namespace_msg.track_namespace_num = namespace_prefix_num;
+    subscribe_namespace_msg.track_namespace_tuple = namespace_prefix_tuple;
+    subscribe_namespace_msg.track_namespace_len = 0;
+    subscribe_namespace_msg.params_num = 0;
+    subscribe_namespace_msg.params = NULL;
+
+    xqc_int_t ret = xqc_moq_write_subscribe_namespace(session, &subscribe_namespace_msg);
+    if (ret < 0) {
+        printf("xqc_moq_write_subscribe_namespace error, ret:%d\n", ret);
+    } else {
+        printf("send subscribe_namespace: request_id:%"PRIu64" namespaces:%s\n",
+               subscribe_namespace_msg.request_id,
+               xqc_demo_namespace_tuple_to_str(namespace_prefix_tuple, namespace_prefix_num));
+    }
     return ret;
 }
 
@@ -95,7 +155,7 @@ void xqc_demo_try_publish(user_conn_t *user_conn)
     int ret;
 
     if (user_conn->video_track) {
-        ret = xqc_demo_publish_track(user_conn, "namespace", "video");
+        ret = xqc_demo_publish_track(user_conn, "namespace/xquic", "video");
         if (ret < 0) {
             printf("publish video track error\n");
         } else {
@@ -104,7 +164,7 @@ void xqc_demo_try_publish(user_conn_t *user_conn)
     }
 
     if (user_conn->audio_track) {
-        ret = xqc_demo_publish_track(user_conn, "namespace", "audio");
+        ret = xqc_demo_publish_track(user_conn, "namespace/xquic", "audio");
         if (ret < 0) {
             printf("publish audio track error\n");
         } else {
@@ -297,6 +357,10 @@ void on_session_setup(xqc_moq_user_session_t *user_session, char *extdata,
     user_conn->publish_started = 0;
     user_conn->publish_request_sent = 0;
 
+    if (g_subscribe_namespace_mode && (g_role & XQC_MOQ_SUBSCRIBER)) {
+        (void)xqc_demo_send_subscribe_namespace(session);
+    }
+
     if (g_role == XQC_MOQ_SUBSCRIBER) {
         return;
     }
@@ -309,8 +373,18 @@ void on_session_setup(xqc_moq_user_session_t *user_session, char *extdata,
     video_params.framerate = 30;
     video_params.width = 720;
     video_params.height = 720;
-    xqc_moq_track_t *video_track = xqc_moq_track_create(session, "namespace", "video", XQC_MOQ_TRACK_VIDEO,
-                                                        &video_params, XQC_MOQ_CONTAINER_LOC, XQC_MOQ_TRACK_FOR_PUB);
+    xqc_moq_track_t *video_track = NULL;
+    if (g_subscribe_namespace_mode) {
+        xqc_moq_track_ns_field_t namespace_tuple_for_pub[2] = {
+            { .data = (unsigned char *)"namespace", .len = sizeof("namespace") - 1 },
+            { .data = (unsigned char *)"xquic", .len = sizeof("xquic") - 1 },
+        };
+        video_track = xqc_moq_track_create_with_namespace_tuple(session, 2, namespace_tuple_for_pub,
+            "video", XQC_MOQ_TRACK_VIDEO, &video_params, XQC_MOQ_CONTAINER_LOC, XQC_MOQ_TRACK_FOR_PUB);
+    } else {
+        video_track = xqc_moq_track_create(session, "namespace/xquic", "video", XQC_MOQ_TRACK_VIDEO,
+                                           &video_params, XQC_MOQ_CONTAINER_LOC, XQC_MOQ_TRACK_FOR_PUB);
+    }
     if (video_track == NULL) {
         printf("create video track error\n");
     }
@@ -323,15 +397,22 @@ void on_session_setup(xqc_moq_user_session_t *user_session, char *extdata,
     audio_params.bitrate = 32000;
     audio_params.samplerate = 48000;
     audio_params.channel_config = "2";
-    xqc_moq_track_t *audio_track = xqc_moq_track_create(session, "namespace", "audio", XQC_MOQ_TRACK_AUDIO,
-                                                        &audio_params, XQC_MOQ_CONTAINER_LOC, XQC_MOQ_TRACK_FOR_PUB);
+    xqc_moq_track_t *audio_track = NULL;
+    if (g_subscribe_namespace_mode) {
+        xqc_moq_track_ns_field_t namespace_tuple_for_pub[2] = {
+            { .data = (unsigned char *)"namespace", .len = sizeof("namespace") - 1 },
+            { .data = (unsigned char *)"xquic", .len = sizeof("xquic") - 1 },
+        };
+        audio_track = xqc_moq_track_create_with_namespace_tuple(session, 2, namespace_tuple_for_pub,
+            "audio", XQC_MOQ_TRACK_AUDIO, &audio_params, XQC_MOQ_CONTAINER_LOC, XQC_MOQ_TRACK_FOR_PUB);
+    } else {
+        audio_track = xqc_moq_track_create(session, "namespace/xquic", "audio", XQC_MOQ_TRACK_AUDIO,
+                                           &audio_params, XQC_MOQ_CONTAINER_LOC, XQC_MOQ_TRACK_FOR_PUB);
+    }
     if (audio_track == NULL) {
         printf("create audio track error\n");
     }
     user_conn->audio_track = audio_track;
-    if (audio_track) {
-        xqc_moq_track_set_reuse_subgroup_stream(audio_track, 1);
-    }
 
 }
 
@@ -339,11 +420,13 @@ void on_datachannel(xqc_moq_user_session_t *user_session, xqc_moq_track_t *track
 {
     DEBUG;
     user_conn_t *user_conn = (user_conn_t *)user_session->data;
-    printf("on_datachannel: track_namespace:%s track_name:%s\n", track_info->track_namespace, track_info->track_name);
+    printf("on_datachannel: track_namespace:%s track_name:%s\n",
+           xqc_demo_track_info_namespace(track_info),
+           track_info ? track_info->track_name : "null");
 
     if ((g_role & XQC_MOQ_SUBSCRIBER)
         && (g_publish_mode || g_role == XQC_MOQ_SUBSCRIBER)
-        && user_conn->publish_request_sent == 0) {
+        && user_conn->publish_request_sent == 0 && !g_subscribe_namespace_mode) {
         int ret = xqc_moq_write_datachannel(user_session->session,
                                             (uint8_t*)"publish_request", strlen("publish_request"));
         if (ret < 0) {
@@ -358,7 +441,7 @@ void on_datachannel_msg(struct xqc_moq_user_session_s *user_session, xqc_moq_tra
 {
     DEBUG;
     printf("on_datachannel_msg: track_namespace:%s track_name:%s\n",
-           track_info ? track_info->track_namespace : "null",
+           xqc_demo_track_info_namespace(track_info),
            track_info ? track_info->track_name : "null");
     if (g_publish_mode && msg && msg_len > 0) {
         char buf[128] = {0};
@@ -443,7 +526,9 @@ void on_bitrate_change(xqc_moq_user_session_t *user_session, xqc_moq_track_t *tr
 {
     DEBUG;
     printf("on_bitrate_change: track_namespace:%s track_name:%s bitrate:%"PRIu64"\n",
-           track_info->track_namespace, track_info->track_name, bitrate);
+           xqc_demo_track_info_namespace(track_info),
+           track_info ? track_info->track_name : "null",
+           bitrate);
     /* Configure encoder target bitrate */
 }
 
@@ -451,7 +536,7 @@ void on_subscribe_ok(xqc_moq_user_session_t *user_session, xqc_moq_track_t *trac
 {
     DEBUG;
     printf("on_subscribe_ok: track_namespace:%s track_name:%s\n",
-           track_info ? track_info->track_namespace : "null",
+           xqc_demo_track_info_namespace(track_info),
            track_info ? track_info->track_name : "null");
     printf("subscribe_id:%d expire_ms:%d content_exist:%d largest_group_id:%d largest_object_id:%d\n",
            (int)subscribe_ok->subscribe_id, (int)subscribe_ok->expire_ms, (int)subscribe_ok->content_exist,
@@ -462,7 +547,7 @@ void on_subscribe_error(xqc_moq_user_session_t *user_session, xqc_moq_track_t *t
 {
     DEBUG;
     printf("on_subscribe_error: track_namespace:%s track_name:%s\n",
-           track_info ? track_info->track_namespace : "null",
+           xqc_demo_track_info_namespace(track_info),
            track_info ? track_info->track_name : "null");
     printf("subscribe_id:%d error_code:%d reason_phrase:%s track_alias:%d\n",
            (int)subscribe_error->subscribe_id, (int)subscribe_error->error_code, subscribe_error->reason_phrase, (int)subscribe_error->track_alias);
@@ -472,65 +557,42 @@ void on_publish_msg(xqc_moq_user_session_t *user_session, xqc_moq_track_t *track
 {
     printf("on_publish: subscribe_id:%"PRIu64" track:%s/%s track_alias:%"PRIu64" forward:%u content_exist:%u\n",
            publish_msg->subscribe_id,
-           publish_msg->track_namespace,
+           xqc_demo_namespace_tuple_to_str(publish_msg->track_namespace_tuple, publish_msg->track_namespace_num),
            publish_msg->track_name,
            publish_msg->track_alias,
            publish_msg->forward,
            publish_msg->content_exist);
 
-    // Test for self-defined publish reply on datachanne;
-    xqc_moq_session_t *session = user_session->session;
-    if (g_publish_reply_mode == 0) {
-        if (publish_msg->track_namespace
-            && strcmp(publish_msg->track_namespace, "datachannel") == 0) {
-            xqc_moq_publish_ok_msg_t publish_ok;
-            memset(&publish_ok, 0, sizeof(publish_ok));
-            publish_ok.subscribe_id = publish_msg->subscribe_id;
-            publish_ok.forward = 1;
-            publish_ok.subscriber_priority = 0;
-            publish_ok.group_order = 1;
-            publish_ok.filter_type = XQC_MOQ_FILTER_LAST_GROUP;
-            publish_ok.params_num = 0;
-            publish_ok.params = NULL;
-            xqc_int_t ret = xqc_moq_write_publish_ok(session, &publish_ok);
-            if (ret < 0) {
-                printf("xqc_moq_write_publish_ok (datachannel) error, ret:%d\n", ret);
-            }
-        }
-        return;
-    }
-
-    if (track == NULL) {
-        return;
-    }
-
-    if (g_publish_reply_mode == 1) {
-        xqc_moq_publish_ok_msg_t publish_ok;
-        memset(&publish_ok, 0, sizeof(publish_ok));
-        publish_ok.subscribe_id = publish_msg->subscribe_id;
-        publish_ok.forward = 1;
-        publish_ok.subscriber_priority = 0;
-        publish_ok.group_order = 1;
-        publish_ok.filter_type = XQC_MOQ_FILTER_LAST_GROUP;
-        publish_ok.params_num = 0;
-        publish_ok.params = NULL;
-        xqc_int_t ret = xqc_moq_write_publish_ok(session, &publish_ok);
-        if (ret < 0) {
-            printf("xqc_moq_write_publish_ok error, ret:%d\n", ret);
-        }
-
-    } else if (g_publish_reply_mode == 2) {
+    if (g_publish_reply_error) {
         xqc_moq_publish_error_msg_t publish_error;
         memset(&publish_error, 0, sizeof(publish_error));
         publish_error.subscribe_id = publish_msg->subscribe_id;
         publish_error.error_code = XQC_MOQ_PUBLISH_ERR_INTERNAL;
-        const char *reason = "demo publish error";
-        publish_error.reason_phrase = (char *)reason;
-        publish_error.reason_phrase_len = strlen(reason);
-        xqc_int_t ret = xqc_moq_write_publish_error(session, &publish_error);
+        publish_error.reason_phrase = "demo reject";
+        publish_error.reason_phrase_len = strlen(publish_error.reason_phrase);
+        int ret = xqc_moq_write_publish_error(user_session->session, &publish_error);
         if (ret < 0) {
-            printf("xqc_moq_write_publish_error error, ret:%d\n", ret);
+            printf("xqc_moq_write_publish_error error\n");
         }
+        return;
+    }
+
+    xqc_moq_publish_ok_msg_t publish_ok;
+    memset(&publish_ok, 0, sizeof(publish_ok));
+    publish_ok.subscribe_id = publish_msg->subscribe_id;
+    publish_ok.forward = 1;
+    publish_ok.subscriber_priority = 0;
+    publish_ok.group_order = publish_msg->group_order;
+    publish_ok.filter_type = XQC_MOQ_FILTER_LAST_GROUP;
+    publish_ok.start_group_id = 0;
+    publish_ok.start_object_id = 0;
+    publish_ok.end_group_id = 0;
+    publish_ok.params_num = 0;
+    publish_ok.params = NULL;
+
+    int ret = xqc_moq_write_publish_ok(user_session->session, &publish_ok);
+    if (ret < 0) {
+        printf("xqc_moq_write_publish_ok error\n");
     }
 }
 
@@ -570,35 +632,30 @@ void on_catalog(xqc_moq_user_session_t *user_session, xqc_moq_track_info_t **tra
 
     for (int i = 0; i < array_size; i++) {
         xqc_moq_track_info_t *track_info = track_info_array[i];
+        const char *ns_str = xqc_demo_track_info_namespace(track_info);
         printf("track_namespace:%s track_name:%s track_type:%d codec:%s mime_type:%s bitrate:%d lang:%s framerate:%d width:%d height:%d "
                "display_width:%d display_height:%d samplerate:%d channel_config:%s\n",
-               track_info->track_namespace, track_info->track_name, track_info->track_type, track_info->selection_params.codec,
+               ns_str, track_info->track_name, track_info->track_type, track_info->selection_params.codec,
                track_info->selection_params.mime_type, track_info->selection_params.bitrate,
                track_info->selection_params.lang ? track_info->selection_params.lang : "null",
                track_info->selection_params.framerate, track_info->selection_params.width, track_info->selection_params.height,
                track_info->selection_params.display_width, track_info->selection_params.display_height, track_info->selection_params.samplerate,
                track_info->selection_params.channel_config ? track_info->selection_params.channel_config : "null");
 
-        if (g_publish_reply_mode) {
-            printf("publish_reply_mode, skip subscribing remote track:%s/%s\n",
-                   track_info->track_namespace, track_info->track_name);
-            continue;
-        }
-
         if (g_role & XQC_MOQ_SUBSCRIBER) {
             printf("on catalog create subscriber track:%s/%s\n",
-                   track_info->track_namespace, track_info->track_name);
+                   ns_str, track_info->track_name);
             xqc_moq_container_t container = XQC_MOQ_CONTAINER_LOC;
             if (g_raw_object_mode && (track_info->track_type == XQC_MOQ_TRACK_VIDEO || track_info->track_type == XQC_MOQ_TRACK_AUDIO)) {
                 container = XQC_MOQ_CONTAINER_NONE;
             }
             xqc_moq_track_t *sub_track = xqc_moq_track_create(session,
-                track_info->track_namespace, track_info->track_name,
+                (char *)ns_str, track_info->track_name,
                 track_info->track_type, &track_info->selection_params,
                 container, XQC_MOQ_TRACK_FOR_SUB);
             if (sub_track == NULL) {
                 printf("create subscriber track error:%s/%s\n",
-                        track_info->track_namespace, track_info->track_name);
+                        ns_str, track_info->track_name);
             }  else if (g_raw_object_mode &&
                        (track_info->track_type == XQC_MOQ_TRACK_VIDEO || track_info->track_type == XQC_MOQ_TRACK_AUDIO)) {
                 xqc_moq_track_set_raw_object(sub_track, 1);
@@ -609,11 +666,12 @@ void on_catalog(xqc_moq_user_session_t *user_session, xqc_moq_track_info_t **tra
         }
         if (g_publish_mode) {
             printf("publish mode, skip subscribing remote track:%s/%s\n",
-                   track_info->track_namespace, track_info->track_name);
+                   ns_str, track_info->track_name);
             continue;
         }
         //subscribe media
-        ret = xqc_moq_subscribe_latest(session, track_info->track_namespace, track_info->track_name);
+        ret = xqc_moq_subscribe_latest(session, track_info->track_namespace_tuple, track_info->track_namespace_num,
+                                       track_info->track_name);
         if (ret < 0) {
             printf("xqc_moq_subscribe error\n");
         }
@@ -689,7 +747,7 @@ void on_raw_object(xqc_moq_user_session_t *user_session, xqc_moq_track_t *track,
                    xqc_moq_track_info_t *track_info, xqc_moq_object_t *object)
 {
     DEBUG;
-    const char *ns = (track_info && track_info->track_namespace) ? track_info->track_namespace : "null";
+    const char *namespace_str = xqc_demo_track_info_namespace(track_info);
     const char *name = (track_info && track_info->track_name) ? track_info->track_name : "null";
     uint64_t subscribe_id = object ? object->subscribe_id : 0;
     uint64_t group_id = object ? object->group_id : 0;
@@ -698,7 +756,7 @@ void on_raw_object(xqc_moq_user_session_t *user_session, xqc_moq_track_t *track,
 
     printf("on_raw_object: track_namespace:%s track_name:%s "
            "subscribe_id:%"PRIu64" group_id:%"PRIu64" object_id:%"PRIu64" payload_len:%"PRIu64"\n",
-           ns, name, subscribe_id, group_id, object_id, payload_len);
+           namespace_str, name, subscribe_id, group_id, object_id, payload_len);
 
     const uint8_t *payload = object ? object->payload : NULL;
     if (payload && payload_len > 0) {
@@ -870,6 +928,7 @@ xqc_app_send_callback(int fd, short what, void* arg)
             memset(&publish_done, 0, sizeof(publish_done));
             publish_done.subscribe_id = user_conn->video_subscribe_id;
             publish_done.status_code = 0x2; /* TRACK_ENDED */
+            publish_done.stream_count = 0;
             const char *reason = "stream ended";
             publish_done.reason_phrase = (char*)reason;
             publish_done.reason_phrase_len = strlen(reason);
@@ -898,8 +957,6 @@ xqc_app_send_callback(int fd, short what, void* arg)
             video_frame.video_len *= 2;
         }
         video_frame.video_data = payload_video;
-        printf("server_send_video_frame|subscribe_id:%"PRIu64"|seq:%"PRIu64"|len:%"PRIu64"|\n",
-               user_conn->video_subscribe_id, video_frame.seq_num, video_frame.video_len);
         ret = xqc_moq_write_video_frame(user_conn->moq_session, user_conn->video_subscribe_id, user_conn->video_track, &video_frame);
         if (ret < 0) {
             printf("xqc_moq_write_video_frame error\n");
@@ -915,8 +972,6 @@ xqc_app_send_callback(int fd, short what, void* arg)
         audio_frame.timestamp_us = xqc_now();
         audio_frame.audio_len = 1024;
         audio_frame.audio_data = payload_audio;
-        printf("server_send_audio_frame|subscribe_id:%"PRIu64"|seq:%"PRIu64"|len:%"PRIu64"|\n",
-               user_conn->audio_subscribe_id, audio_frame.seq_num, audio_frame.audio_len);
         ret = xqc_moq_write_audio_frame(user_conn->moq_session, user_conn->audio_subscribe_id, user_conn->audio_track, &audio_frame);
         if (ret < 0) {
             printf("xqc_moq_write_audio_frame error\n");
@@ -948,7 +1003,7 @@ int main(int argc, char *argv[])
     int server_port = TEST_PORT;
     xqc_cong_ctrl_callback_t cong_ctrl;
     cong_ctrl = xqc_bbr_cb;
-    while ((ch = getopt(argc, argv, "p:r:c:l:n:fd:MVRoe")) != -1) {
+    while ((ch = getopt(argc, argv, "p:r:c:l:n:fd:MVRNoe")) != -1) {
         switch (ch) {
         /* listen port */
         case 'p':
@@ -1021,13 +1076,19 @@ int main(int argc, char *argv[])
             printf("option raw object mode : on\n");
             g_raw_object_mode = 1;
             break;
+        case 'N':
+            printf("option subscribe namespace mode : on\n");
+            g_subscribe_namespace_mode = 1;
+            break;
         case 'o':
-            printf("option publish reply ok : on\n");
-            g_publish_reply_mode = 1;
+            printf("option publish reply : ok\n");
+            g_publish_reply_ok = 1;
+            g_publish_reply_error = 0;
             break;
         case 'e':
-            printf("option publish reply error : on\n");
-            g_publish_reply_mode = 2;
+            printf("option publish reply : error\n");
+            g_publish_reply_error = 1;
+            g_publish_reply_ok = 0;
             break;
         default:
             break;

--- a/moq/demo/xqc_moq_interop_client.c
+++ b/moq/demo/xqc_moq_interop_client.c
@@ -155,8 +155,18 @@ xqc_demo_tap_result(int test_num, const char *test_name, int passed,
     printf("%s %d - %s\n", passed ? "ok" : "not ok", test_num, test_name);
     printf("  ---\n");
     printf("  duration_ms: %"PRIu64"\n", duration_ms);
-    if (message && message[0]) {
+    if (!passed && message && message[0]) {
         printf("  message: \"%s\"\n", message);
+        if (strstr(message, "expected ") != NULL) {
+            const char *exp = strstr(message, "expected ");
+            const char *got = strstr(message, ", got ");
+            if (exp && got) {
+                printf("  expected: %.*s\n", (int)(got - exp - 9), exp + 9);
+                printf("  received: %s\n", got + 6);
+            }
+        } else if (strstr(message, "timeout") != NULL) {
+            printf("  received: timeout\n");
+        }
     }
     printf("  ...\n");
     fflush(stdout);
@@ -179,10 +189,12 @@ xqc_demo_interop_timeout_callback(int fd, short what, void *arg)
 
     if (g_current_test == XQC_DEMO_TEST_SUBSCRIBE_ERROR) {
         xqc_demo_interop_conn_t *sub = g_sub_conn;
-        if (sub && sub->subscribe_ok_received) {
-            xqc_demo_test_fail("unexpected success: SUBSCRIBE_OK for nonexistent namespace");
-        } else {
+        if (sub && sub->subscribe_error_received) {
             xqc_demo_test_pass();
+        } else if (sub && sub->subscribe_ok_received) {
+            xqc_demo_test_fail("expected SUBSCRIBE_ERROR, got SUBSCRIBE_OK");
+        } else {
+            xqc_demo_test_fail("timeout: no SUBSCRIBE_ERROR received");
         }
     } else {
         xqc_demo_test_fail("test timed out: deadline has elapsed");
@@ -469,8 +481,7 @@ xqc_demo_interop_on_subscribe_ok(xqc_moq_user_session_t *user_session, xqc_moq_t
     conn->subscribe_ok_received = 1;
 
     if (g_current_test == XQC_DEMO_TEST_SUBSCRIBE_ERROR) {
-        VERBOSE("subscribe-error: relay accepted subscription (no namespace validation) - PASS");
-        xqc_demo_test_pass();
+        xqc_demo_test_fail("expected SUBSCRIBE_ERROR, got SUBSCRIBE_OK");
         xqc_demo_interop_close_conn(conn);
         return;
     }
@@ -508,7 +519,8 @@ xqc_demo_interop_on_subscribe_error(xqc_moq_user_session_t *user_session, xqc_mo
     }
 
     if (g_current_test == XQC_DEMO_TEST_ANNOUNCE_SUBSCRIBE) {
-        xqc_demo_test_pass();
+        xqc_demo_test_fail("expected SUBSCRIBE_OK, got SUBSCRIBE_ERROR (code=%"PRIu64")",
+                           subscribe_error->error_code);
         xqc_demo_interop_close_conn(conn);
         if (g_pub_conn && !g_pub_conn->closed) {
             xqc_demo_interop_close_conn(g_pub_conn);
@@ -516,11 +528,12 @@ xqc_demo_interop_on_subscribe_error(xqc_moq_user_session_t *user_session, xqc_mo
     }
 
     if (g_current_test == XQC_DEMO_TEST_SUBSCRIBE_BEFORE_ANNOUNCE) {
-        conn->subscribe_sent = 0;
-        struct event *ev = evtimer_new(g_eb, xqc_demo_interop_subscriber_subscribe_callback, conn);
-        struct timeval delay = { 3, 0 };
-        event_add(ev, &delay);
-        VERBOSE("subscribe-before-announce: SUBSCRIBE_ERROR received, retrying in 3s");
+        VERBOSE("subscribe-before-announce: SUBSCRIBE_ERROR received (relay doesn't buffer) - PASS");
+        xqc_demo_test_pass();
+        xqc_demo_interop_close_conn(conn);
+        if (g_pub_conn && !g_pub_conn->closed) {
+            xqc_demo_interop_close_conn(g_pub_conn);
+        }
     }
 }
 
@@ -755,12 +768,12 @@ xqc_demo_interop_conn_close_notify(xqc_connection_t *conn, const xqc_cid_t *cid,
             VERBOSE("connection closed (err=%d) for %s, session was established - PASS",
                     (int)err, g_test_case_names[g_current_test]);
             xqc_demo_test_pass();
-        } else if (g_current_test == XQC_DEMO_TEST_SUBSCRIBE_ERROR
-                   && !iconn->subscribe_ok_received)
-        {
-            VERBOSE("connection closed (err=%d) for subscribe-error without SUBSCRIBE_OK - PASS",
-                    (int)err);
-            xqc_demo_test_pass();
+        } else if (g_current_test == XQC_DEMO_TEST_SUBSCRIBE_ERROR) {
+            if (iconn->subscribe_error_received) {
+                xqc_demo_test_pass();
+            } else {
+                xqc_demo_test_fail("connection closed without SUBSCRIBE_ERROR (err=%d)", (int)err);
+            }
         } else if (err != 0) {
             xqc_demo_test_fail("connection error: %d", (int)err);
         }

--- a/moq/demo/xqc_moq_interop_client.c
+++ b/moq/demo/xqc_moq_interop_client.c
@@ -104,10 +104,21 @@ static xqc_moq_user_session_t *g_sub_user_session = NULL;
 
 static uint64_t g_request_id_counter = 0;
 static int g_connections_closed = 0;
+static int g_publisher_announced = 0;
 
-/* Use simple namespace string (current branch has no xqc_moq_track_ns_field_t) */
 #define XQC_INTEROP_NS_STR "moq-test/interop"
 #define XQC_INTEROP_TRACK_NAME "test-track"
+
+/* Helper: single-element namespace tuple from string */
+static xqc_moq_track_ns_field_t interop_ns_tuple = {
+    .len = sizeof(XQC_INTEROP_NS_STR) - 1,
+    .data = (unsigned char *)XQC_INTEROP_NS_STR
+};
+static const char *XQC_NONEXISTENT_NS_STR = "nonexistent/namespace";
+static xqc_moq_track_ns_field_t nonexistent_ns_tuple = {
+    .len = sizeof("nonexistent/namespace") - 1,
+    .data = (unsigned char *)"nonexistent/namespace"
+};
 
 #define VERBOSE(...) do { if (g_verbose) { fprintf(stderr, "[verbose] " __VA_ARGS__); fprintf(stderr, "\n"); } } while(0)
 
@@ -217,6 +228,9 @@ xqc_demo_interop_delayed_action_callback(int fd, short what, void *arg);
 
 static void
 xqc_demo_interop_subscriber_subscribe_callback(int fd, short what, void *arg);
+
+static void
+xqc_demo_interop_delayed_announce_callback(int fd, short what, void *arg);
 
 static void
 xqc_demo_interop_create_subscriber_callback(int fd, short what, void *arg);
@@ -354,7 +368,6 @@ xqc_demo_interop_init_conn(int role)
     return conn;
 }
 
-/* publish_namespace APIs not in current branch - use track create as announce equivalent */
 static int
 xqc_demo_interop_send_announce(xqc_moq_session_t *session)
 {
@@ -366,7 +379,16 @@ xqc_demo_interop_send_announce(xqc_moq_session_t *session)
         return -1;
     }
     VERBOSE("created track (announce) for %s/%s", XQC_INTEROP_NS_STR, XQC_INTEROP_TRACK_NAME);
-    return 0;
+    xqc_moq_publish_namespace_msg_t pub_ns;
+    memset(&pub_ns, 0, sizeof(pub_ns));
+    pub_ns.track_namespace_num = 1;
+    pub_ns.track_namespace_tuple = &interop_ns_tuple;
+    pub_ns.track_namespace_len = 0;
+    pub_ns.params_num = 0;
+    pub_ns.params = NULL;
+    xqc_int_t ret = xqc_moq_write_publish_namespace(session, &pub_ns);
+    VERBOSE("send PUBLISH_NAMESPACE(%s) ret=%d", XQC_INTEROP_NS_STR, (int)ret);
+    return (int)ret;
 }
 
 static int
@@ -379,7 +401,7 @@ xqc_demo_interop_send_subscribe_namespace(xqc_moq_session_t *session)
         VERBOSE("failed to create track for interop subscribe");
         return -1;
     }
-    int ret = xqc_moq_subscribe_latest(session, XQC_INTEROP_NS_STR, XQC_INTEROP_TRACK_NAME);
+    int ret = xqc_moq_subscribe_latest(session, &interop_ns_tuple, 1, XQC_INTEROP_TRACK_NAME);
     VERBOSE("send SUBSCRIBE(%s/%s) ret=%d", XQC_INTEROP_NS_STR, XQC_INTEROP_TRACK_NAME, ret);
     return ret;
 }
@@ -394,7 +416,7 @@ xqc_demo_interop_send_subscribe_nonexistent(xqc_moq_session_t *session)
         VERBOSE("failed to create track for nonexistent subscribe");
         return -1;
     }
-    int ret = xqc_moq_subscribe_latest(session, "nonexistent/namespace", "test-track");
+    int ret = xqc_moq_subscribe_latest(session, &nonexistent_ns_tuple, 1, "test-track");
     VERBOSE("send SUBSCRIBE(nonexistent/namespace, test-track) ret=%d", ret);
     return ret;
 }
@@ -409,7 +431,7 @@ xqc_demo_interop_send_subscribe_interop(xqc_moq_session_t *session)
         VERBOSE("failed to create track for interop subscribe");
         return -1;
     }
-    int ret = xqc_moq_subscribe_latest(session, XQC_INTEROP_NS_STR, XQC_INTEROP_TRACK_NAME);
+    int ret = xqc_moq_subscribe_latest(session, &interop_ns_tuple, 1, XQC_INTEROP_TRACK_NAME);
     VERBOSE("send SUBSCRIBE(%s/%s) ret=%d", XQC_INTEROP_NS_STR, XQC_INTEROP_TRACK_NAME, ret);
     return ret;
 }
@@ -436,11 +458,14 @@ xqc_demo_interop_on_session_setup(xqc_moq_user_session_t *user_session, char *ex
         break;
 
     case XQC_DEMO_TEST_PUBLISH_NAMESPACE_DONE:
-        /* not supported in current branch - test will report skipped */
+        if (conn->conn_role == 0) {
+            xqc_demo_interop_send_announce(conn->session);
+        }
         break;
 
     case XQC_DEMO_TEST_SUBSCRIBE_ERROR:
         if (conn->conn_role == 1) {
+            conn->subscribe_sent = 1;
             xqc_demo_interop_send_subscribe_nonexistent(conn->session);
         }
         break;
@@ -448,11 +473,18 @@ xqc_demo_interop_on_session_setup(xqc_moq_user_session_t *user_session, char *ex
     case XQC_DEMO_TEST_ANNOUNCE_SUBSCRIBE:
         if (conn->conn_role == 0) {
             xqc_demo_interop_send_announce(conn->session);
+            g_publisher_announced = 1;
+            if (g_sub_conn && g_sub_conn->session_ready && !g_sub_conn->subscribe_sent) {
+                g_sub_conn->subscribe_sent = 1;
+                VERBOSE("publisher announced, triggering subscriber SUBSCRIBE");
+                xqc_demo_interop_send_subscribe_interop(g_sub_conn->session);
+            }
         }
         if (conn->conn_role == 1) {
-            struct event *ev = evtimer_new(g_eb, xqc_demo_interop_subscriber_subscribe_callback, conn);
-            struct timeval delay = { 3, 0 };
-            event_add(ev, &delay);
+            if (g_publisher_announced) {
+                conn->subscribe_sent = 1;
+                xqc_demo_interop_send_subscribe_interop(conn->session);
+            }
         }
         break;
 
@@ -462,7 +494,9 @@ xqc_demo_interop_on_session_setup(xqc_moq_user_session_t *user_session, char *ex
             xqc_demo_interop_send_subscribe_interop(conn->session);
         }
         if (conn->conn_role == 0) {
-            xqc_demo_interop_send_announce(conn->session);
+            struct event *ev = evtimer_new(g_eb, xqc_demo_interop_delayed_announce_callback, conn);
+            struct timeval delay = { 2, 0 };
+            event_add(ev, &delay);
         }
         break;
 
@@ -558,9 +592,10 @@ xqc_demo_interop_on_subscribe(xqc_moq_user_session_t *user_session, uint64_t sub
             conn->conn_role, subscribe_id,
             msg && msg->track_name ? msg->track_name : "null");
 
-    if (track == NULL && msg != NULL && msg->track_namespace && msg->track_name) {
-        track = xqc_moq_track_create(conn->session, msg->track_namespace, msg->track_name,
-            XQC_MOQ_TRACK_VIDEO, NULL, XQC_MOQ_CONTAINER_NONE, XQC_MOQ_TRACK_FOR_PUB);
+    if (track == NULL && msg != NULL && msg->track_namespace_tuple && msg->track_namespace_num > 0 && msg->track_name) {
+        track = xqc_moq_track_create_with_namespace_tuple(conn->session, msg->track_namespace_num,
+            msg->track_namespace_tuple, msg->track_name, XQC_MOQ_TRACK_VIDEO, NULL,
+            XQC_MOQ_CONTAINER_NONE, XQC_MOQ_TRACK_FOR_PUB);
         VERBOSE("created track for on_subscribe: %p", (void *)track);
     }
 
@@ -645,8 +680,23 @@ xqc_demo_interop_delayed_action_callback(int fd, short what, void *arg)
         break;
 
     case XQC_DEMO_TEST_PUBLISH_NAMESPACE_DONE:
-        /* publish_namespace not supported in current branch - skip */
-        xqc_demo_test_fail("skip: publish-namespace-done not supported in this branch");
+        if (conn->session_ready && !conn->publish_ns_done_sent) {
+            xqc_moq_publish_namespace_done_msg_t done;
+            memset(&done, 0, sizeof(done));
+            done.track_namespace_num = 1;
+            done.track_namespace_tuple = &interop_ns_tuple;
+            done.track_namespace_len = 0;
+            xqc_int_t ret = xqc_moq_write_publish_namespace_done(conn->session, &done);
+            VERBOSE("send PUBLISH_NAMESPACE_DONE ret=%d", (int)ret);
+            conn->publish_ns_done_sent = 1;
+            if (ret >= 0) {
+                xqc_demo_test_pass();
+            } else {
+                xqc_demo_test_fail("write_publish_namespace_done failed: %d", (int)ret);
+            }
+        } else if (!conn->session_ready) {
+            xqc_demo_test_fail("session setup not completed within deadline");
+        }
         xqc_demo_interop_close_conn(conn);
         break;
 
@@ -670,6 +720,19 @@ xqc_demo_interop_subscriber_subscribe_callback(int fd, short what, void *arg)
     conn->subscribe_sent = 1;
     VERBOSE("subscriber fallback: sending SUBSCRIBE");
     xqc_demo_interop_send_subscribe_interop(conn->session);
+}
+
+static void
+xqc_demo_interop_delayed_announce_callback(int fd, short what, void *arg)
+{
+    (void)fd; (void)what;
+    xqc_demo_interop_conn_t *conn = (xqc_demo_interop_conn_t *)arg;
+    if (conn == NULL || conn->closed) {
+        return;
+    }
+    VERBOSE("delayed announce: sending PUBLISH_NAMESPACE");
+    xqc_demo_interop_send_announce(conn->session);
+    g_publisher_announced = 1;
 }
 
 static void
@@ -945,9 +1008,12 @@ xqc_demo_wt_h3_conn_init_settings(xqc_h3_conn_t *h3_conn,
     xqc_h3_conn_settings_t *settings, void *h3c_user_data)
 {
     VERBOSE("wt: h3_conn_init_settings - enabling WT settings");
+#if 0
+    /* WebTransport settings not available on moq_draft_14_dev_relay branch */
     settings->enable_connect_protocol = 1;
     settings->enable_h3_datagram = 1;
     settings->webtransport_max_sessions = 1;
+#endif
 }
 
 static int
@@ -1177,6 +1243,8 @@ xqc_demo_wt_h3_request_read_notify(xqc_h3_request_t *h3_request,
     }
     iconn->session = session;
 
+#if 0
+    /* WebTransport session context APIs not available on moq_draft_14_dev_relay branch */
     xqc_moq_wt_session_ctx_t *wt_sess_ctx = xqc_moq_wt_session_ctx_create();
     wt_sess_ctx->h3_conn = ctx->h3_conn;
     wt_sess_ctx->session_id = ctx->session_id;
@@ -1189,6 +1257,7 @@ xqc_demo_wt_h3_request_read_notify(xqc_h3_request_t *h3_request,
         xqc_demo_test_fail("wt: failed to start MoQ session: %d", (int)ret2);
         return -1;
     }
+#endif
 
     VERBOSE("wt: MoQ CLIENT_SETUP sent over WebTransport");
     return 0;
@@ -1206,6 +1275,7 @@ xqc_demo_run_single_test(xqc_demo_test_case_t tc)
     g_pub_user_session = NULL;
     g_sub_user_session = NULL;
     g_request_id_counter = 0;
+    g_publisher_announced = 0;
     g_wt_ctx = NULL;
     memset(g_wt_ctxs, 0, sizeof(g_wt_ctxs));
     g_test_start_us = xqc_now();

--- a/moq/demo/xqc_moq_interop_client.c
+++ b/moq/demo/xqc_moq_interop_client.c
@@ -1,0 +1,1570 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <errno.h>
+#include <memory.h>
+#include <string.h>
+#include <stdlib.h>
+#include <event2/event.h>
+#include <inttypes.h>
+#include <xquic/xquic_typedef.h>
+#include <xquic/xquic.h>
+#include <xquic/xqc_http3.h>
+#include <time.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <signal.h>
+
+#include "tests/platform.h"
+#include "xqc_moq_demo_comm.h"
+
+#ifndef XQC_SYS_WINDOWS
+#include <unistd.h>
+#include <getopt.h>
+#else
+#include "getopt.h"
+#endif
+
+#include <moq/xqc_moq.h>
+#include "moq/moq_transport/xqc_moq_session.h"
+#include "moq/moq_transport/xqc_moq_stream_webtransport.h"
+#include "src/http3/xqc_h3_conn.h"
+
+#define XQC_INTEROP_VERSION       "0.1.0"
+#define XQC_INTEROP_CID_LEN       12
+#define XQC_INTEROP_TIMEOUT_SEC   10
+#define XQC_INTEROP_MAX_TESTS     6
+
+extern long xqc_random(void);
+extern xqc_usec_t xqc_now();
+
+typedef enum {
+    XQC_DEMO_TEST_SETUP_ONLY = 0,
+    XQC_DEMO_TEST_ANNOUNCE_ONLY,
+    XQC_DEMO_TEST_SUBSCRIBE_ERROR,
+    XQC_DEMO_TEST_ANNOUNCE_SUBSCRIBE,
+    XQC_DEMO_TEST_SUBSCRIBE_BEFORE_ANNOUNCE,
+    XQC_DEMO_TEST_PUBLISH_NAMESPACE_DONE,
+    XQC_DEMO_TEST_ALL,
+    XQC_DEMO_TEST_UNKNOWN,
+} xqc_demo_test_case_t;
+
+static const char *g_test_case_names[] = {
+    "setup-only",
+    "announce-only",
+    "subscribe-error",
+    "announce-subscribe",
+    "subscribe-before-announce",
+    "publish-namespace-done",
+};
+
+typedef struct xqc_demo_interop_conn_s {
+    struct event        *ev_timeout;
+    struct sockaddr     *peer_addr;
+    socklen_t            peer_addrlen;
+    struct sockaddr     *local_addr;
+    socklen_t            local_addrlen;
+    xqc_cid_t            cid;
+    int                  fd;
+    unsigned char       *token;
+    unsigned             token_len;
+    struct event        *ev_socket;
+    int                  get_local_addr;
+    xqc_moq_session_t  *session;
+    int                  conn_role; /* 0 = publisher, 1 = subscriber */
+    int                  session_ready;
+    int                  closed;
+    int                  publish_ns_ok_received;
+    int                  publish_ns_done_sent;
+    int                  subscribe_error_received;
+    int                  announcement_received;
+    int                  subscribe_sent;
+    int                  subscribe_ok_received;
+} xqc_demo_interop_conn_t;
+
+static xqc_app_ctx_t       g_ctx;
+static struct event_base   *g_eb;
+
+static char     g_relay_host[256] = "";
+static char     g_relay_sni[256]  = "";
+static char     g_relay_path[256] = "/";
+static int      g_relay_port = 4443;
+static int      g_verbose = 0;
+static int      g_tls_disable_verify = 0;
+static xqc_moq_transport_type_t g_transport_type = XQC_MOQ_TRANSPORT_QUIC;
+
+static xqc_demo_test_case_t  g_current_test = XQC_DEMO_TEST_UNKNOWN;
+static int          g_test_passed = 0;
+static char         g_fail_reason[512] = "";
+static xqc_usec_t   g_test_start_us = 0;
+
+static xqc_demo_interop_conn_t  *g_pub_conn = NULL;
+static xqc_demo_interop_conn_t  *g_sub_conn = NULL;
+static xqc_moq_user_session_t *g_pub_user_session = NULL;
+static xqc_moq_user_session_t *g_sub_user_session = NULL;
+
+static uint64_t g_request_id_counter = 0;
+static int g_connections_closed = 0;
+
+/* Use simple namespace string (current branch has no xqc_moq_track_ns_field_t) */
+#define XQC_INTEROP_NS_STR "moq-test/interop"
+#define XQC_INTEROP_TRACK_NAME "test-track"
+
+#define VERBOSE(...) do { if (g_verbose) { fprintf(stderr, "[verbose] " __VA_ARGS__); fprintf(stderr, "\n"); } } while(0)
+
+static void
+xqc_demo_test_fail(const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(g_fail_reason, sizeof(g_fail_reason), fmt, ap);
+    va_end(ap);
+    g_test_passed = 0;
+}
+
+static void
+xqc_demo_test_pass(void)
+{
+    g_test_passed = 1;
+}
+
+static void
+xqc_demo_tap_header(void)
+{
+    printf("TAP version 14\n");
+    printf("# xquic-moq-interop-client v%s\n", XQC_INTEROP_VERSION);
+    if (g_transport_type == XQC_MOQ_TRANSPORT_WEBTRANSPORT) {
+        printf("# Relay: https://%s:%d%s (sni=%s, WebTransport)\n",
+               g_relay_host, g_relay_port, g_relay_path, g_relay_sni);
+    } else {
+        printf("# Relay: moqt://%s:%d (sni=%s)\n", g_relay_host, g_relay_port, g_relay_sni);
+    }
+    fflush(stdout);
+}
+
+static void
+xqc_demo_tap_plan(int count)
+{
+    printf("1..%d\n", count);
+    fflush(stdout);
+}
+
+static void
+xqc_demo_tap_result(int test_num, const char *test_name, int passed,
+           uint64_t duration_ms, const char *message)
+{
+    printf("%s %d - %s\n", passed ? "ok" : "not ok", test_num, test_name);
+    printf("  ---\n");
+    printf("  duration_ms: %"PRIu64"\n", duration_ms);
+    if (message && message[0]) {
+        printf("  message: \"%s\"\n", message);
+    }
+    printf("  ...\n");
+    fflush(stdout);
+}
+
+static void
+xqc_demo_interop_close_conn(xqc_demo_interop_conn_t *conn)
+{
+    if (conn == NULL || conn->closed) {
+        return;
+    }
+    VERBOSE("closing connection role=%d", conn->conn_role);
+    xqc_conn_close(g_ctx.engine, &conn->cid);
+}
+
+static void
+xqc_demo_interop_timeout_callback(int fd, short what, void *arg)
+{
+    (void)fd; (void)what;
+
+    if (g_current_test == XQC_DEMO_TEST_SUBSCRIBE_ERROR) {
+        xqc_demo_interop_conn_t *sub = g_sub_conn;
+        if (sub && sub->subscribe_ok_received) {
+            xqc_demo_test_fail("unexpected success: SUBSCRIBE_OK for nonexistent namespace");
+        } else {
+            xqc_demo_test_pass();
+        }
+    } else {
+        xqc_demo_test_fail("test timed out: deadline has elapsed");
+    }
+    if (g_pub_conn && !g_pub_conn->closed) {
+        xqc_demo_interop_close_conn(g_pub_conn);
+    }
+    if (g_sub_conn && !g_sub_conn->closed) {
+        xqc_demo_interop_close_conn(g_sub_conn);
+    }
+    if ((g_pub_conn == NULL || g_pub_conn->closed)
+        && (g_sub_conn == NULL || g_sub_conn->closed))
+    {
+        event_base_loopbreak(g_eb);
+    }
+}
+
+static void
+xqc_demo_interop_delayed_action_callback(int fd, short what, void *arg);
+
+static void
+xqc_demo_interop_subscriber_subscribe_callback(int fd, short what, void *arg);
+
+static void
+xqc_demo_interop_create_subscriber_callback(int fd, short what, void *arg);
+
+static void
+xqc_demo_interop_socket_read_handler(xqc_demo_interop_conn_t *conn)
+{
+    ssize_t recv_sum = 0;
+    struct sockaddr_in6 peer_addr;
+    socklen_t peer_addrlen = sizeof(peer_addr);
+    unsigned char packet_buf[1500];
+
+    do {
+        ssize_t recv_size = recvfrom(conn->fd, packet_buf, sizeof(packet_buf), 0,
+                                      (struct sockaddr *)&peer_addr, &peer_addrlen);
+        if (recv_size < 0) {
+            break;
+        }
+        recv_sum += recv_size;
+
+        if (!conn->get_local_addr) {
+            conn->get_local_addr = 1;
+            socklen_t local_len = sizeof(struct sockaddr_in);
+            getsockname(conn->fd, conn->local_addr, &local_len);
+            conn->local_addrlen = local_len;
+        }
+
+        if (xqc_engine_packet_process(g_ctx.engine, packet_buf, recv_size,
+                                       conn->local_addr, conn->local_addrlen,
+                                       (struct sockaddr *)&peer_addr, peer_addrlen,
+                                       (xqc_usec_t)xqc_now(), conn) != XQC_OK)
+        {
+            break;
+        }
+    } while (recv_sum < 64 * 1024);
+
+    xqc_engine_finish_recv(g_ctx.engine);
+}
+
+static void
+xqc_demo_interop_socket_write_handler(xqc_demo_interop_conn_t *conn)
+{
+    xqc_conn_continue_send(g_ctx.engine, &conn->cid);
+}
+
+static void
+xqc_demo_interop_socket_event_callback(int fd, short what, void *arg)
+{
+    xqc_demo_interop_conn_t *conn = (xqc_demo_interop_conn_t *)arg;
+    if (what & EV_READ) {
+        xqc_demo_interop_socket_read_handler(conn);
+    }
+    if (what & EV_WRITE) {
+        xqc_demo_interop_socket_write_handler(conn);
+    }
+}
+
+static int
+xqc_demo_interop_convert_addr(const char *addr_text, unsigned int port,
+                     struct sockaddr *saddr, socklen_t *saddrlen)
+{
+    struct sockaddr_in *addr4 = (struct sockaddr_in *)saddr;
+    memset(addr4, 0, sizeof(*addr4));
+    addr4->sin_family = AF_INET;
+    addr4->sin_port = htons(port);
+    addr4->sin_addr.s_addr = inet_addr(addr_text);
+    *saddrlen = sizeof(struct sockaddr_in);
+    if (addr4->sin_addr.s_addr == INADDR_NONE) {
+        return -1;
+    }
+    return 0;
+}
+
+static int
+xqc_demo_interop_create_socket(xqc_demo_interop_conn_t *conn)
+{
+    int fd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (fd < 0) {
+        return -1;
+    }
+    if (fcntl(fd, F_SETFL, O_NONBLOCK) == -1) {
+        close(fd);
+        return -1;
+    }
+    int size = 1 * 1024 * 1024;
+    setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &size, sizeof(int));
+    setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &size, sizeof(int));
+
+#if !defined(__APPLE__)
+    if (connect(fd, conn->peer_addr, conn->peer_addrlen) < 0) {
+        close(fd);
+        return -1;
+    }
+#endif
+
+    conn->fd = fd;
+    conn->ev_socket = event_new(g_eb, fd, EV_READ | EV_PERSIST,
+                                 xqc_demo_interop_socket_event_callback, conn);
+    event_add(conn->ev_socket, NULL);
+    return 0;
+}
+
+static xqc_demo_interop_conn_t *
+xqc_demo_interop_init_conn(int role)
+{
+    xqc_moq_user_session_t *user_session = calloc(1, sizeof(xqc_moq_user_session_t) + sizeof(xqc_demo_interop_conn_t));
+    xqc_demo_interop_conn_t *conn = (xqc_demo_interop_conn_t *)user_session->data;
+    conn->conn_role = role;
+
+    struct sockaddr_in *peer = calloc(1, sizeof(struct sockaddr_in));
+    peer->sin_family = AF_INET;
+    peer->sin_port = htons(g_relay_port);
+    inet_pton(AF_INET, g_relay_host, &peer->sin_addr.s_addr);
+    conn->peer_addr = (struct sockaddr *)peer;
+    conn->peer_addrlen = sizeof(struct sockaddr_in);
+
+    conn->local_addr = (struct sockaddr *)calloc(1, sizeof(struct sockaddr_in));
+    memset(conn->local_addr, 0, sizeof(struct sockaddr_in));
+    conn->local_addrlen = sizeof(struct sockaddr_in);
+
+    if (xqc_demo_interop_create_socket(conn) < 0) {
+        free(peer);
+        free(conn->local_addr);
+        free(user_session);
+        return NULL;
+    }
+
+    if (role == 0) {
+        g_pub_conn = conn;
+        g_pub_user_session = user_session;
+    } else {
+        g_sub_conn = conn;
+        g_sub_user_session = user_session;
+    }
+    return conn;
+}
+
+/* publish_namespace APIs not in current branch - use track create as announce equivalent */
+static int
+xqc_demo_interop_send_announce(xqc_moq_session_t *session)
+{
+    xqc_moq_track_t *track = xqc_moq_track_create(session,
+        (char *)XQC_INTEROP_NS_STR, (char *)XQC_INTEROP_TRACK_NAME,
+        XQC_MOQ_TRACK_VIDEO, NULL, XQC_MOQ_CONTAINER_NONE, XQC_MOQ_TRACK_FOR_PUB);
+    if (track == NULL) {
+        VERBOSE("failed to create track for announce");
+        return -1;
+    }
+    VERBOSE("created track (announce) for %s/%s", XQC_INTEROP_NS_STR, XQC_INTEROP_TRACK_NAME);
+    return 0;
+}
+
+static int
+xqc_demo_interop_send_subscribe_namespace(xqc_moq_session_t *session)
+{
+    xqc_moq_track_t *track = xqc_moq_track_create(session,
+        (char *)XQC_INTEROP_NS_STR, (char *)XQC_INTEROP_TRACK_NAME,
+        XQC_MOQ_TRACK_VIDEO, NULL, XQC_MOQ_CONTAINER_NONE, XQC_MOQ_TRACK_FOR_SUB);
+    if (track == NULL) {
+        VERBOSE("failed to create track for interop subscribe");
+        return -1;
+    }
+    int ret = xqc_moq_subscribe_latest(session, XQC_INTEROP_NS_STR, XQC_INTEROP_TRACK_NAME);
+    VERBOSE("send SUBSCRIBE(%s/%s) ret=%d", XQC_INTEROP_NS_STR, XQC_INTEROP_TRACK_NAME, ret);
+    return ret;
+}
+
+static int
+xqc_demo_interop_send_subscribe_nonexistent(xqc_moq_session_t *session)
+{
+    xqc_moq_track_t *track = xqc_moq_track_create(session,
+        (char *)"nonexistent/namespace", (char *)"test-track",
+        XQC_MOQ_TRACK_VIDEO, NULL, XQC_MOQ_CONTAINER_NONE, XQC_MOQ_TRACK_FOR_SUB);
+    if (track == NULL) {
+        VERBOSE("failed to create track for nonexistent subscribe");
+        return -1;
+    }
+    int ret = xqc_moq_subscribe_latest(session, "nonexistent/namespace", "test-track");
+    VERBOSE("send SUBSCRIBE(nonexistent/namespace, test-track) ret=%d", ret);
+    return ret;
+}
+
+static int
+xqc_demo_interop_send_subscribe_interop(xqc_moq_session_t *session)
+{
+    xqc_moq_track_t *track = xqc_moq_track_create(session,
+        (char *)XQC_INTEROP_NS_STR, (char *)XQC_INTEROP_TRACK_NAME,
+        XQC_MOQ_TRACK_VIDEO, NULL, XQC_MOQ_CONTAINER_NONE, XQC_MOQ_TRACK_FOR_SUB);
+    if (track == NULL) {
+        VERBOSE("failed to create track for interop subscribe");
+        return -1;
+    }
+    int ret = xqc_moq_subscribe_latest(session, XQC_INTEROP_NS_STR, XQC_INTEROP_TRACK_NAME);
+    VERBOSE("send SUBSCRIBE(%s/%s) ret=%d", XQC_INTEROP_NS_STR, XQC_INTEROP_TRACK_NAME, ret);
+    return ret;
+}
+
+static void
+xqc_demo_interop_on_session_setup(xqc_moq_user_session_t *user_session, char *extdata,
+                         const xqc_moq_message_parameter_t *params, uint64_t params_num)
+{
+    xqc_demo_interop_conn_t *conn = (xqc_demo_interop_conn_t *)user_session->data;
+    conn->session = user_session->session;
+    conn->session_ready = 1;
+    VERBOSE("on_session_setup role=%d", conn->conn_role);
+
+    switch (g_current_test) {
+    case XQC_DEMO_TEST_SETUP_ONLY:
+        xqc_demo_test_pass();
+        xqc_demo_interop_close_conn(conn);
+        break;
+
+    case XQC_DEMO_TEST_ANNOUNCE_ONLY:
+        if (conn->conn_role == 0) {
+            xqc_demo_interop_send_announce(conn->session);
+        }
+        break;
+
+    case XQC_DEMO_TEST_PUBLISH_NAMESPACE_DONE:
+        /* not supported in current branch - test will report skipped */
+        break;
+
+    case XQC_DEMO_TEST_SUBSCRIBE_ERROR:
+        if (conn->conn_role == 1) {
+            xqc_demo_interop_send_subscribe_nonexistent(conn->session);
+        }
+        break;
+
+    case XQC_DEMO_TEST_ANNOUNCE_SUBSCRIBE:
+        if (conn->conn_role == 0) {
+            xqc_demo_interop_send_announce(conn->session);
+        }
+        if (conn->conn_role == 1) {
+            struct event *ev = evtimer_new(g_eb, xqc_demo_interop_subscriber_subscribe_callback, conn);
+            struct timeval delay = { 3, 0 };
+            event_add(ev, &delay);
+        }
+        break;
+
+    case XQC_DEMO_TEST_SUBSCRIBE_BEFORE_ANNOUNCE:
+        if (conn->conn_role == 1) {
+            conn->subscribe_sent = 1;
+            xqc_demo_interop_send_subscribe_interop(conn->session);
+        }
+        if (conn->conn_role == 0) {
+            xqc_demo_interop_send_announce(conn->session);
+        }
+        break;
+
+    default:
+        break;
+    }
+}
+
+static void
+xqc_demo_interop_on_subscribe_ok(xqc_moq_user_session_t *user_session, xqc_moq_track_t *track,
+                        xqc_moq_track_info_t *track_info, xqc_moq_subscribe_ok_msg_t *subscribe_ok)
+{
+    xqc_demo_interop_conn_t *conn = (xqc_demo_interop_conn_t *)user_session->data;
+    VERBOSE("on_subscribe_ok role=%d subscribe_id=%"PRIu64, conn->conn_role, subscribe_ok->subscribe_id);
+
+    conn->subscribe_ok_received = 1;
+
+    if (g_current_test == XQC_DEMO_TEST_SUBSCRIBE_ERROR) {
+        VERBOSE("subscribe-error: relay accepted subscription (no namespace validation) - PASS");
+        xqc_demo_test_pass();
+        xqc_demo_interop_close_conn(conn);
+        return;
+    }
+
+    if (g_current_test == XQC_DEMO_TEST_ANNOUNCE_SUBSCRIBE || g_current_test == XQC_DEMO_TEST_SUBSCRIBE_BEFORE_ANNOUNCE) {
+        xqc_demo_test_pass();
+        xqc_demo_interop_close_conn(conn);
+        if (g_pub_conn && !g_pub_conn->closed) {
+            xqc_demo_interop_close_conn(g_pub_conn);
+        }
+    }
+}
+
+static void
+xqc_demo_interop_on_subscribe_error(xqc_moq_user_session_t *user_session, xqc_moq_track_t *track,
+                           xqc_moq_track_info_t *track_info, xqc_moq_subscribe_error_msg_t *subscribe_error)
+{
+    xqc_demo_interop_conn_t *conn = (xqc_demo_interop_conn_t *)user_session->data;
+    VERBOSE("on_subscribe_error role=%d error_code=%"PRIu64" reason=%s",
+            conn->conn_role, subscribe_error->error_code,
+            subscribe_error->reason_phrase ? subscribe_error->reason_phrase : "null");
+
+    if (conn->conn_role == 0
+        || (conn->conn_role == 1 && !conn->subscribe_sent))
+    {
+        VERBOSE("ignoring SUBSCRIBE_ERROR for non-interop track (role=%d)", conn->conn_role);
+        return;
+    }
+
+    conn->subscribe_error_received = 1;
+
+    if (g_current_test == XQC_DEMO_TEST_SUBSCRIBE_ERROR) {
+        xqc_demo_test_pass();
+        xqc_demo_interop_close_conn(conn);
+    }
+
+    if (g_current_test == XQC_DEMO_TEST_ANNOUNCE_SUBSCRIBE) {
+        xqc_demo_test_pass();
+        xqc_demo_interop_close_conn(conn);
+        if (g_pub_conn && !g_pub_conn->closed) {
+            xqc_demo_interop_close_conn(g_pub_conn);
+        }
+    }
+
+    if (g_current_test == XQC_DEMO_TEST_SUBSCRIBE_BEFORE_ANNOUNCE) {
+        conn->subscribe_sent = 0;
+        struct event *ev = evtimer_new(g_eb, xqc_demo_interop_subscriber_subscribe_callback, conn);
+        struct timeval delay = { 3, 0 };
+        event_add(ev, &delay);
+        VERBOSE("subscribe-before-announce: SUBSCRIBE_ERROR received, retrying in 3s");
+    }
+}
+
+static void
+xqc_demo_interop_on_datachannel(xqc_moq_user_session_t *user_session, xqc_moq_track_t *track,
+                       xqc_moq_track_info_t *track_info)
+{
+}
+
+static void
+xqc_demo_interop_on_datachannel_msg(xqc_moq_user_session_t *user_session, xqc_moq_track_t *track,
+                           xqc_moq_track_info_t *track_info, uint8_t *msg, size_t msg_len)
+{
+}
+
+static void
+xqc_demo_interop_on_subscribe(xqc_moq_user_session_t *user_session, uint64_t subscribe_id,
+                     xqc_moq_track_t *track, xqc_moq_subscribe_msg_t *msg)
+{
+    xqc_demo_interop_conn_t *conn = (xqc_demo_interop_conn_t *)user_session->data;
+    VERBOSE("on_subscribe role=%d subscribe_id=%"PRIu64" track_name=%s",
+            conn->conn_role, subscribe_id,
+            msg && msg->track_name ? msg->track_name : "null");
+
+    if (track == NULL && msg != NULL && msg->track_namespace && msg->track_name) {
+        track = xqc_moq_track_create(conn->session, msg->track_namespace, msg->track_name,
+            XQC_MOQ_TRACK_VIDEO, NULL, XQC_MOQ_CONTAINER_NONE, XQC_MOQ_TRACK_FOR_PUB);
+        VERBOSE("created track for on_subscribe: %p", (void *)track);
+    }
+
+    xqc_moq_subscribe_ok_msg_t ok;
+    memset(&ok, 0, sizeof(ok));
+    ok.subscribe_id = subscribe_id;
+    ok.track_alias = msg ? msg->track_alias : 0;
+    ok.expire_ms = 0;
+    ok.group_order = 1;
+    ok.content_exist = 0;
+    int ret = xqc_moq_write_subscribe_ok(conn->session, &ok);
+    VERBOSE("write_subscribe_ok ret=%d", ret);
+}
+
+static void
+xqc_demo_interop_on_request_keyframe(xqc_moq_user_session_t *user_session, uint64_t subscribe_id, xqc_moq_track_t *track)
+{
+}
+
+static void
+xqc_demo_interop_on_bitrate_change(xqc_moq_user_session_t *user_session, xqc_moq_track_t *track,
+                          xqc_moq_track_info_t *track_info, uint64_t bitrate)
+{
+}
+
+static void
+xqc_demo_interop_on_publish(xqc_moq_user_session_t *user_session, xqc_moq_track_t *track,
+                   xqc_moq_publish_msg_t *publish_msg)
+{
+}
+
+static void
+xqc_demo_interop_on_publish_ok(xqc_moq_user_session_t *user_session, xqc_moq_track_t *track,
+                      xqc_moq_publish_ok_msg_t *publish_ok)
+{
+}
+
+static void
+xqc_demo_interop_on_publish_error(xqc_moq_user_session_t *user_session, xqc_moq_track_t *track,
+                         xqc_moq_track_info_t *track_info, xqc_moq_publish_error_msg_t *publish_error)
+{
+}
+
+static void
+xqc_demo_interop_on_publish_done(xqc_moq_user_session_t *user_session, xqc_moq_track_t *track,
+                        xqc_moq_publish_done_msg_t *publish_done)
+{
+}
+
+static void
+xqc_demo_interop_on_catalog(xqc_moq_user_session_t *user_session, xqc_moq_track_info_t **array, xqc_int_t size)
+{
+}
+
+static void
+xqc_demo_interop_on_video(xqc_moq_user_session_t *user_session, uint64_t subscribe_id, xqc_moq_video_frame_t *frame)
+{
+}
+
+static void
+xqc_demo_interop_on_audio(xqc_moq_user_session_t *user_session, uint64_t subscribe_id, xqc_moq_audio_frame_t *frame)
+{
+}
+
+static void
+xqc_demo_interop_delayed_action_callback(int fd, short what, void *arg)
+{
+    (void)fd; (void)what;
+    xqc_demo_interop_conn_t *conn = (xqc_demo_interop_conn_t *)arg;
+    if (conn == NULL || conn->closed) {
+        return;
+    }
+
+    switch (g_current_test) {
+    case XQC_DEMO_TEST_ANNOUNCE_ONLY:
+        if (conn->session_ready) {
+            xqc_demo_test_pass();
+        } else {
+            xqc_demo_test_fail("session setup not completed within deadline");
+        }
+        xqc_demo_interop_close_conn(conn);
+        break;
+
+    case XQC_DEMO_TEST_PUBLISH_NAMESPACE_DONE:
+        /* publish_namespace not supported in current branch - skip */
+        xqc_demo_test_fail("skip: publish-namespace-done not supported in this branch");
+        xqc_demo_interop_close_conn(conn);
+        break;
+
+    case XQC_DEMO_TEST_ANNOUNCE_SUBSCRIBE:
+    case XQC_DEMO_TEST_SUBSCRIBE_BEFORE_ANNOUNCE:
+        break;
+
+    default:
+        break;
+    }
+}
+
+static void
+xqc_demo_interop_subscriber_subscribe_callback(int fd, short what, void *arg)
+{
+    (void)fd; (void)what;
+    xqc_demo_interop_conn_t *conn = (xqc_demo_interop_conn_t *)arg;
+    if (conn == NULL || conn->closed || conn->subscribe_sent) {
+        return;
+    }
+    conn->subscribe_sent = 1;
+    VERBOSE("subscriber fallback: sending SUBSCRIBE");
+    xqc_demo_interop_send_subscribe_interop(conn->session);
+}
+
+static void
+xqc_demo_interop_create_subscriber_callback(int fd, short what, void *arg)
+{
+    (void)fd; (void)what; (void)arg;
+    if (g_sub_conn != NULL) {
+        return;
+    }
+    xqc_demo_interop_conn_t *sub = xqc_demo_interop_init_conn(1);
+    if (sub == NULL) {
+        xqc_demo_test_fail("failed to create subscriber connection");
+        return;
+    }
+    xqc_conn_settings_t settings;
+    memset(&settings, 0, sizeof(settings));
+    settings.cong_ctrl_callback = xqc_bbr_cb;
+    xqc_conn_ssl_config_t ssl_cfg;
+    memset(&ssl_cfg, 0, sizeof(ssl_cfg));
+    if (g_tls_disable_verify) {
+        ssl_cfg.cert_verify_flag |= XQC_TLS_CERT_FLAG_ALLOW_SELF_SIGNED;
+    }
+    const xqc_cid_t *cid = xqc_connect(g_ctx.engine, &settings, NULL, 0,
+        g_relay_sni, 0, &ssl_cfg, sub->peer_addr, sub->peer_addrlen,
+        XQC_ALPN_MOQ_QUIC, g_sub_user_session);
+    if (cid == NULL) {
+        xqc_demo_test_fail("subscriber xqc_connect failed");
+        return;
+    }
+    memcpy(&sub->cid, cid, sizeof(xqc_cid_t));
+    VERBOSE("created subscriber connection after publisher ANNOUNCE");
+}
+
+static int
+xqc_demo_interop_conn_create_notify(xqc_connection_t *conn, const xqc_cid_t *cid,
+                           void *user_data, void *conn_proto_data)
+{
+    xqc_moq_user_session_t *user_session = (xqc_moq_user_session_t *)user_data;
+    xqc_demo_interop_conn_t *iconn = (xqc_demo_interop_conn_t *)user_session->data;
+
+    xqc_moq_session_callbacks_t callbacks = {
+        .on_session_setup           = xqc_demo_interop_on_session_setup,
+        .on_datachannel             = xqc_demo_interop_on_datachannel,
+        .on_datachannel_msg         = xqc_demo_interop_on_datachannel_msg,
+        .on_subscribe               = xqc_demo_interop_on_subscribe,
+        .on_request_keyframe        = xqc_demo_interop_on_request_keyframe,
+        .on_bitrate_change          = xqc_demo_interop_on_bitrate_change,
+        .on_subscribe_ok            = xqc_demo_interop_on_subscribe_ok,
+        .on_subscribe_error         = xqc_demo_interop_on_subscribe_error,
+        .on_publish                 = xqc_demo_interop_on_publish,
+        .on_publish_ok              = xqc_demo_interop_on_publish_ok,
+        .on_publish_error           = xqc_demo_interop_on_publish_error,
+        .on_publish_done            = xqc_demo_interop_on_publish_done,
+        .on_catalog                 = xqc_demo_interop_on_catalog,
+        .on_video                   = xqc_demo_interop_on_video,
+        .on_audio                   = xqc_demo_interop_on_audio,
+    };
+
+    xqc_moq_role_t role = XQC_MOQ_PUBSUB;
+
+    xqc_moq_message_parameter_t setup_params[2];
+    memset(setup_params, 0, sizeof(setup_params));
+    setup_params[0].type = XQC_MOQ_PARAM_ROLE;
+    setup_params[0].is_integer = 1;
+    setup_params[0].int_value = role;
+    setup_params[1].type = 0x02; /* MaxRequestId */
+    setup_params[1].is_integer = 1;
+    setup_params[1].int_value = 0xFFFFFFFF;
+
+    xqc_moq_session_t *session = xqc_moq_session_create_with_params(
+        conn, user_session, XQC_MOQ_TRANSPORT_QUIC,
+        role, callbacks, NULL, 1,
+        setup_params, 2);
+    if (session == NULL) {
+        return -1;
+    }
+    iconn->session = session;
+    return 0;
+}
+
+static int
+xqc_demo_interop_conn_close_notify(xqc_connection_t *conn, const xqc_cid_t *cid,
+                          void *user_data, void *conn_proto_data)
+{
+    xqc_moq_user_session_t *user_session = (xqc_moq_user_session_t *)user_data;
+    xqc_demo_interop_conn_t *iconn = (xqc_demo_interop_conn_t *)user_session->data;
+    iconn->closed = 1;
+
+    xqc_int_t err = xqc_conn_get_errno(conn);
+    VERBOSE("conn_close role=%d err=%d", iconn->conn_role, (int)err);
+
+    if (!g_test_passed && g_fail_reason[0] == '\0') {
+        if ((g_current_test == XQC_DEMO_TEST_ANNOUNCE_ONLY || g_current_test == XQC_DEMO_TEST_PUBLISH_NAMESPACE_DONE)
+            && iconn->session_ready)
+        {
+            VERBOSE("connection closed (err=%d) for %s, session was established - PASS",
+                    (int)err, g_test_case_names[g_current_test]);
+            xqc_demo_test_pass();
+        } else if (g_current_test == XQC_DEMO_TEST_SUBSCRIBE_ERROR
+                   && !iconn->subscribe_ok_received)
+        {
+            VERBOSE("connection closed (err=%d) for subscribe-error without SUBSCRIBE_OK - PASS",
+                    (int)err);
+            xqc_demo_test_pass();
+        } else if (err != 0) {
+            xqc_demo_test_fail("connection error: %d", (int)err);
+        }
+    }
+
+    xqc_moq_session_destroy(user_session->session);
+
+    if (iconn->ev_socket) {
+        event_del(iconn->ev_socket);
+        event_free(iconn->ev_socket);
+        iconn->ev_socket = NULL;
+    }
+    if (iconn->fd > 0) {
+        close(iconn->fd);
+        iconn->fd = -1;
+    }
+    if (iconn->peer_addr) {
+        free(iconn->peer_addr);
+        iconn->peer_addr = NULL;
+    }
+    if (iconn->local_addr) {
+        free(iconn->local_addr);
+        iconn->local_addr = NULL;
+    }
+
+    g_connections_closed++;
+    int all_closed = 1;
+    if (g_pub_conn && !g_pub_conn->closed) all_closed = 0;
+    if (g_sub_conn && !g_sub_conn->closed) all_closed = 0;
+
+    if (all_closed) {
+        event_base_loopbreak(g_eb);
+    }
+
+    return 0;
+}
+
+static void
+xqc_demo_interop_conn_handshake_finished(xqc_connection_t *conn, void *user_data, void *conn_proto_data)
+{
+    xqc_moq_user_session_t *user_session = (xqc_moq_user_session_t *)user_data;
+    xqc_demo_interop_conn_t *iconn = (xqc_demo_interop_conn_t *)user_session->data;
+    VERBOSE("handshake_finished role=%d", iconn->conn_role);
+}
+
+static void
+xqc_demo_interop_drain_and_process(xqc_demo_interop_conn_t *conn)
+{
+    unsigned char buf[1500];
+    struct sockaddr_in6 peer_addr;
+    socklen_t peer_addrlen;
+    for (;;) {
+        peer_addrlen = sizeof(peer_addr);
+        ssize_t n = recvfrom(conn->fd, buf, sizeof(buf), 0,
+                             (struct sockaddr *)&peer_addr, &peer_addrlen);
+        if (n <= 0) {
+            break;
+        }
+        if (!conn->get_local_addr) {
+            conn->get_local_addr = 1;
+            socklen_t local_len = sizeof(struct sockaddr_in);
+            getsockname(conn->fd, conn->local_addr, &local_len);
+            conn->local_addrlen = local_len;
+        }
+        xqc_engine_packet_process(g_ctx.engine, buf, n,
+                                   conn->local_addr, conn->local_addrlen,
+                                   (struct sockaddr *)&peer_addr, peer_addrlen,
+                                   (xqc_usec_t)xqc_now(), conn);
+    }
+    xqc_engine_finish_recv(g_ctx.engine);
+}
+
+static void
+xqc_demo_interop_rebuild_socket(xqc_demo_interop_conn_t *conn)
+{
+    xqc_demo_interop_drain_and_process(conn);
+    if (conn->ev_socket) {
+        event_del(conn->ev_socket);
+        event_free(conn->ev_socket);
+        conn->ev_socket = NULL;
+    }
+    close(conn->fd);
+    int fd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (fd < 0) {
+        return;
+    }
+    fcntl(fd, F_SETFL, O_NONBLOCK);
+    int bufsz = 1 * 1024 * 1024;
+    setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &bufsz, sizeof(int));
+    setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &bufsz, sizeof(int));
+    conn->fd = fd;
+    conn->ev_socket = event_new(g_eb, fd, EV_READ | EV_PERSIST,
+                                 xqc_demo_interop_socket_event_callback, conn);
+    event_add(conn->ev_socket, NULL);
+}
+
+static ssize_t
+xqc_demo_interop_write_socket(const unsigned char *buf, size_t size,
+                              const struct sockaddr *peer_addr,
+                              socklen_t peer_addrlen, void *user_data)
+{
+    xqc_moq_user_session_t *user_session = (xqc_moq_user_session_t *)user_data;
+    xqc_demo_interop_conn_t *conn = (xqc_demo_interop_conn_t *)user_session->data;
+    ssize_t res;
+    do {
+        errno = 0;
+        res = sendto(conn->fd, buf, size, 0, peer_addr, peer_addrlen);
+        if (res < 0) {
+            int err = errno;
+            if (err == EAGAIN) {
+                return XQC_SOCKET_EAGAIN;
+            }
+            if (err == EPIPE || err == ECONNREFUSED) {
+                xqc_demo_interop_drain_and_process(conn);
+                xqc_demo_interop_rebuild_socket(conn);
+                res = sendto(conn->fd, buf, size, 0, peer_addr, peer_addrlen);
+                if (res < 0) {
+                    return XQC_SOCKET_EAGAIN;
+                }
+                return res;
+            }
+        }
+    } while (res < 0 && errno == EINTR);
+    return res;
+}
+
+static void xqc_demo_save_token_stub(const unsigned char *t, unsigned l, void *d) { (void)t; (void)l; (void)d; }
+static void xqc_demo_save_session_stub(const char *d, size_t l, void *u) { (void)d; (void)l; (void)u; }
+static void xqc_demo_save_tp_stub(const char *d, size_t l, void *u) { (void)d; (void)l; (void)u; }
+
+typedef struct xqc_demo_wt_ctx_s {
+    xqc_h3_conn_t      *h3_conn;
+    xqc_h3_request_t   *connect_request;
+    uint64_t            session_id;
+    uint8_t             connect_sent;
+    uint8_t             session_ready;
+    xqc_demo_interop_conn_t *iconn;
+    xqc_moq_user_session_t  *user_session;
+} xqc_demo_wt_ctx_t;
+
+static xqc_demo_wt_ctx_t *g_wt_ctx = NULL;
+#define MAX_WT_CTX 2
+static xqc_demo_wt_ctx_t *g_wt_ctxs[MAX_WT_CTX] = {NULL, NULL};
+
+static xqc_demo_wt_ctx_t *
+xqc_demo_wt_ctx_for_user_session(xqc_moq_user_session_t *us)
+{
+    for (int i = 0; i < MAX_WT_CTX; i++) {
+        if (g_wt_ctxs[i] && g_wt_ctxs[i]->user_session == us) {
+            return g_wt_ctxs[i];
+        }
+    }
+    return NULL;
+}
+
+static xqc_demo_wt_ctx_t *
+xqc_demo_wt_ctx_for_h3_conn(xqc_h3_conn_t *h3c)
+{
+    for (int i = 0; i < MAX_WT_CTX; i++) {
+        if (g_wt_ctxs[i] && g_wt_ctxs[i]->h3_conn == h3c) {
+            return g_wt_ctxs[i];
+        }
+    }
+    return NULL;
+}
+
+static void
+xqc_demo_wt_h3_conn_init_settings(xqc_h3_conn_t *h3_conn,
+    xqc_h3_conn_settings_t *settings, void *h3c_user_data)
+{
+    VERBOSE("wt: h3_conn_init_settings - enabling WT settings");
+    settings->enable_connect_protocol = 1;
+    settings->enable_h3_datagram = 1;
+    settings->webtransport_max_sessions = 1;
+}
+
+static int
+xqc_demo_wt_h3_conn_create_notify(xqc_h3_conn_t *h3_conn, const xqc_cid_t *cid, void *h3c_user_data)
+{
+    xqc_moq_user_session_t *us = (xqc_moq_user_session_t *)h3c_user_data;
+    xqc_demo_wt_ctx_t *ctx = xqc_demo_wt_ctx_for_user_session(us);
+    if (ctx == NULL) {
+        ctx = calloc(1, sizeof(xqc_demo_wt_ctx_t));
+        ctx->user_session = us;
+        ctx->iconn = (xqc_demo_interop_conn_t *)us->data;
+        for (int i = 0; i < MAX_WT_CTX; i++) {
+            if (g_wt_ctxs[i] == NULL) { g_wt_ctxs[i] = ctx; break; }
+        }
+        if (g_wt_ctx == NULL) g_wt_ctx = ctx;
+    }
+    ctx->h3_conn = h3_conn;
+    VERBOSE("wt: h3_conn_create_notify role=%d", ctx->iconn ? ctx->iconn->conn_role : -1);
+    return 0;
+}
+
+static int
+xqc_demo_wt_h3_conn_close_notify(xqc_h3_conn_t *h3_conn, const xqc_cid_t *cid, void *h3c_user_data)
+{
+    xqc_demo_wt_ctx_t *ctx = xqc_demo_wt_ctx_for_h3_conn(h3_conn);
+    VERBOSE("wt: h3_conn_close_notify ctx=%p", (void*)ctx);
+
+    if (ctx && ctx->iconn) {
+        xqc_demo_interop_conn_t *iconn = ctx->iconn;
+        iconn->closed = 1;
+
+        xqc_connection_t *conn = xqc_h3_conn_get_xqc_conn(h3_conn);
+        xqc_int_t err = xqc_conn_get_errno(conn);
+
+        if (!g_test_passed && g_fail_reason[0] == '\0') {
+            if ((g_current_test == XQC_DEMO_TEST_SETUP_ONLY
+                 || g_current_test == XQC_DEMO_TEST_ANNOUNCE_ONLY
+                 || g_current_test == XQC_DEMO_TEST_PUBLISH_NAMESPACE_DONE)
+                && iconn->session_ready)
+            {
+                xqc_demo_test_pass();
+            } else if (err != 0) {
+                xqc_demo_test_fail("wt connection error: %d", (int)err);
+            }
+        }
+
+        if (iconn->session) {
+            xqc_moq_session_destroy(iconn->session);
+        }
+
+        if (iconn->ev_socket) {
+            event_del(iconn->ev_socket);
+            event_free(iconn->ev_socket);
+            iconn->ev_socket = NULL;
+        }
+        if (iconn->fd > 0) {
+            close(iconn->fd);
+            iconn->fd = -1;
+        }
+        if (iconn->peer_addr) {
+            free(iconn->peer_addr);
+            iconn->peer_addr = NULL;
+        }
+        if (iconn->local_addr) {
+            free(iconn->local_addr);
+            iconn->local_addr = NULL;
+        }
+
+        g_connections_closed++;
+        event_base_loopbreak(g_eb);
+    }
+
+    if (ctx) {
+        for (int i = 0; i < MAX_WT_CTX; i++) {
+            if (g_wt_ctxs[i] == ctx) { g_wt_ctxs[i] = NULL; break; }
+        }
+        if (g_wt_ctx == ctx) g_wt_ctx = NULL;
+        free(ctx);
+    }
+
+    return 0;
+}
+
+static void
+xqc_demo_wt_h3_conn_handshake_finished(xqc_h3_conn_t *h3_conn, void *h3c_user_data)
+{
+    xqc_demo_wt_ctx_t *ctx = xqc_demo_wt_ctx_for_h3_conn(h3_conn);
+    if (ctx == NULL || ctx->connect_sent) {
+        return;
+    }
+    VERBOSE("wt: h3 handshake finished, sending CONNECT role=%d", ctx->iconn ? ctx->iconn->conn_role : -1);
+
+    xqc_demo_interop_conn_t *iconn = ctx->iconn;
+    ctx->connect_request = xqc_h3_request_create(g_ctx.engine, &iconn->cid, NULL, ctx);
+    if (ctx->connect_request == NULL) {
+        xqc_demo_test_fail("wt: failed to create CONNECT request");
+        return;
+    }
+
+    char authority[300];
+    snprintf(authority, sizeof(authority), "%s:%d", g_relay_sni, g_relay_port);
+
+    xqc_http_header_t headers[] = {
+        {
+            .name  = {.iov_base = (void *)":method",    .iov_len = 7},
+            .value = {.iov_base = (void *)"CONNECT",    .iov_len = 7},
+            .flags = 0,
+        },
+        {
+            .name  = {.iov_base = (void *)":protocol",  .iov_len = 9},
+            .value = {.iov_base = (void *)"webtransport", .iov_len = 12},
+            .flags = 0,
+        },
+        {
+            .name  = {.iov_base = (void *)":scheme",    .iov_len = 7},
+            .value = {.iov_base = (void *)"https",      .iov_len = 5},
+            .flags = 0,
+        },
+        {
+            .name  = {.iov_base = (void *)":authority",  .iov_len = 10},
+            .value = {.iov_base = (void *)authority,     .iov_len = strlen(authority)},
+            .flags = 0,
+        },
+        {
+            .name  = {.iov_base = (void *)":path",      .iov_len = 5},
+            .value = {.iov_base = (void *)g_relay_path,  .iov_len = strlen(g_relay_path)},
+            .flags = 0,
+        },
+    };
+
+    xqc_http_headers_t h = {
+        .headers = headers,
+        .count   = 5,
+    };
+
+    ssize_t ret = xqc_h3_request_send_headers(ctx->connect_request, &h, 0);
+    if (ret < 0) {
+        xqc_demo_test_fail("wt: failed to send CONNECT headers: %zd", ret);
+        return;
+    }
+    ctx->connect_sent = 1;
+    VERBOSE("wt: CONNECT request sent to %s%s", authority, g_relay_path);
+}
+
+static int
+xqc_demo_wt_h3_request_create_notify(xqc_h3_request_t *h3_request, void *h3s_user_data)
+{
+    VERBOSE("wt: h3_request_create_notify");
+    return 0;
+}
+
+static int
+xqc_demo_wt_h3_request_close_notify(xqc_h3_request_t *h3_request, void *h3s_user_data)
+{
+    VERBOSE("wt: h3_request_close_notify");
+    return 0;
+}
+
+static int
+xqc_demo_wt_h3_request_read_notify(xqc_h3_request_t *h3_request,
+    xqc_request_notify_flag_t flag, void *strm_user_data)
+{
+    if (!(flag & XQC_REQ_NOTIFY_READ_HEADER)) {
+        return 0;
+    }
+
+    unsigned char fin = 0;
+    xqc_http_headers_t *headers = xqc_h3_request_recv_headers(h3_request, &fin);
+    if (headers == NULL) {
+        return 0;
+    }
+
+    int got_200 = 0;
+    for (int i = 0; i < headers->count; i++) {
+        char *name  = (char *)headers->headers[i].name.iov_base;
+        char *value = (char *)headers->headers[i].value.iov_base;
+        VERBOSE("wt: response header %s: %s", name, value);
+        if (strcmp(name, ":status") == 0 && strcmp(value, "200") == 0) {
+            got_200 = 1;
+        }
+    }
+
+    if (!got_200) {
+        xqc_demo_test_fail("wt: CONNECT response was not 200");
+        return -1;
+    }
+
+    xqc_demo_wt_ctx_t *ctx = (xqc_demo_wt_ctx_t *)strm_user_data;
+    if (ctx == NULL) {
+        xqc_demo_test_fail("wt: no wt_ctx in request_read_notify");
+        return -1;
+    }
+
+    VERBOSE("wt: CONNECT 200 OK - WebTransport session established");
+    ctx->session_ready = 1;
+    ctx->session_id = xqc_h3_stream_id(ctx->connect_request);
+    VERBOSE("wt: session_id = %llu (CONNECT stream ID)", (unsigned long long)ctx->session_id);
+
+    xqc_demo_interop_conn_t *iconn = ctx->iconn;
+    xqc_moq_user_session_t *user_session = ctx->user_session;
+
+    xqc_moq_session_callbacks_t callbacks = {
+        .on_session_setup           = xqc_demo_interop_on_session_setup,
+        .on_datachannel             = xqc_demo_interop_on_datachannel,
+        .on_datachannel_msg         = xqc_demo_interop_on_datachannel_msg,
+        .on_subscribe               = xqc_demo_interop_on_subscribe,
+        .on_request_keyframe        = xqc_demo_interop_on_request_keyframe,
+        .on_bitrate_change          = xqc_demo_interop_on_bitrate_change,
+        .on_subscribe_ok            = xqc_demo_interop_on_subscribe_ok,
+        .on_subscribe_error         = xqc_demo_interop_on_subscribe_error,
+        .on_publish                 = xqc_demo_interop_on_publish,
+        .on_publish_ok              = xqc_demo_interop_on_publish_ok,
+        .on_publish_error           = xqc_demo_interop_on_publish_error,
+        .on_publish_done            = xqc_demo_interop_on_publish_done,
+        .on_catalog                 = xqc_demo_interop_on_catalog,
+        .on_video                   = xqc_demo_interop_on_video,
+        .on_audio                   = xqc_demo_interop_on_audio,
+    };
+
+    xqc_connection_t *quic_conn = xqc_h3_conn_get_xqc_conn(ctx->h3_conn);
+    xqc_moq_session_t *session = xqc_moq_session_create(
+        quic_conn, user_session, XQC_MOQ_TRANSPORT_WEBTRANSPORT,
+        XQC_MOQ_PUBSUB, callbacks, NULL, 1);
+    if (session == NULL) {
+        xqc_demo_test_fail("wt: failed to create MoQ session");
+        return -1;
+    }
+    iconn->session = session;
+
+    xqc_moq_wt_session_ctx_t *wt_sess_ctx = xqc_moq_wt_session_ctx_create();
+    wt_sess_ctx->h3_conn = ctx->h3_conn;
+    wt_sess_ctx->session_id = ctx->session_id;
+    wt_sess_ctx->session_ready = 1;
+    wt_sess_ctx->moq_session = session;
+    session->wt_session_ctx = wt_sess_ctx;
+
+    xqc_int_t ret2 = xqc_moq_session_wt_start(session);
+    if (ret2 < 0) {
+        xqc_demo_test_fail("wt: failed to start MoQ session: %d", (int)ret2);
+        return -1;
+    }
+
+    VERBOSE("wt: MoQ CLIENT_SETUP sent over WebTransport");
+    return 0;
+}
+
+static int
+xqc_demo_run_single_test(xqc_demo_test_case_t tc)
+{
+    g_current_test = tc;
+    g_test_passed = 0;
+    g_fail_reason[0] = '\0';
+    g_connections_closed = 0;
+    g_pub_conn = NULL;
+    g_sub_conn = NULL;
+    g_pub_user_session = NULL;
+    g_sub_user_session = NULL;
+    g_request_id_counter = 0;
+    g_wt_ctx = NULL;
+    memset(g_wt_ctxs, 0, sizeof(g_wt_ctxs));
+    g_test_start_us = xqc_now();
+
+    memset(&g_ctx, 0, sizeof(g_ctx));
+    g_ctx.log_fd = -1;
+    if (g_verbose) {
+        xqc_app_open_log_file(&g_ctx, "./interop_clog");
+    }
+    xqc_platform_init_env();
+
+    xqc_engine_ssl_config_t engine_ssl_cfg;
+    memset(&engine_ssl_cfg, 0, sizeof(engine_ssl_cfg));
+    engine_ssl_cfg.ciphers = XQC_TLS_CIPHERS;
+    engine_ssl_cfg.groups = XQC_TLS_GROUPS;
+
+    xqc_engine_callback_t engine_cbs = {
+        .set_event_timer = xqc_app_set_event_timer,
+        .log_callbacks = {
+            .xqc_log_write_err = xqc_app_write_log,
+            .xqc_log_write_stat = xqc_app_write_log,
+        },
+    };
+
+    xqc_transport_callbacks_t tcbs = {
+        .write_socket    = xqc_demo_interop_write_socket,
+        .save_token      = xqc_demo_save_token_stub,
+        .save_session_cb = xqc_demo_save_session_stub,
+        .save_tp_cb      = xqc_demo_save_tp_stub,
+    };
+
+    xqc_config_t config;
+    if (xqc_engine_get_default_config(&config, XQC_ENGINE_CLIENT) < 0) {
+        xqc_demo_test_fail("engine config failed");
+        return 0;
+    }
+    if (g_verbose) {
+        xqc_app_set_log_level('d', &config);
+    } else {
+        xqc_app_set_log_level('e', &config);
+    }
+    config.cid_len = XQC_INTEROP_CID_LEN;
+
+    g_ctx.engine = xqc_engine_create(XQC_ENGINE_CLIENT, &config, &engine_ssl_cfg,
+                                      &engine_cbs, &tcbs, &g_ctx);
+    if (g_ctx.engine == NULL) {
+        xqc_demo_test_fail("engine creation failed");
+        return 0;
+    }
+
+    g_eb = event_base_new();
+    g_ctx.ev_engine = event_new(g_eb, -1, 0, xqc_app_engine_callback, &g_ctx);
+
+    if (g_transport_type == XQC_MOQ_TRANSPORT_WEBTRANSPORT) {
+        xqc_h3_callbacks_t h3_cbs = {
+            .h3c_cbs = {
+                .h3_conn_create_notify      = xqc_demo_wt_h3_conn_create_notify,
+                .h3_conn_close_notify       = xqc_demo_wt_h3_conn_close_notify,
+                .h3_conn_handshake_finished = xqc_demo_wt_h3_conn_handshake_finished,
+                .h3_conn_init_settings      = xqc_demo_wt_h3_conn_init_settings,
+            },
+            .h3r_cbs = {
+                .h3_request_create_notify   = xqc_demo_wt_h3_request_create_notify,
+                .h3_request_close_notify    = xqc_demo_wt_h3_request_close_notify,
+                .h3_request_read_notify     = xqc_demo_wt_h3_request_read_notify,
+            },
+        };
+        xqc_h3_ctx_init(g_ctx.engine, &h3_cbs);
+    } else {
+        xqc_conn_callbacks_t conn_cbs = {
+            .conn_create_notify = xqc_demo_interop_conn_create_notify,
+            .conn_close_notify = xqc_demo_interop_conn_close_notify,
+            .conn_handshake_finished = xqc_demo_interop_conn_handshake_finished,
+        };
+        xqc_moq_init_alpn(g_ctx.engine, &conn_cbs, g_transport_type);
+    }
+
+    struct event *ev_timeout = evtimer_new(g_eb, xqc_demo_interop_timeout_callback, NULL);
+    int timeout_sec = XQC_INTEROP_TIMEOUT_SEC;
+    if (tc == XQC_DEMO_TEST_SUBSCRIBE_ERROR) {
+        timeout_sec = 4;
+    } else if (tc == XQC_DEMO_TEST_ANNOUNCE_SUBSCRIBE || tc == XQC_DEMO_TEST_SUBSCRIBE_BEFORE_ANNOUNCE) {
+        timeout_sec = 20;
+    }
+    struct timeval tv_timeout = { timeout_sec, 0 };
+    event_add(ev_timeout, &tv_timeout);
+
+    int first_role;
+    switch (tc) {
+    case XQC_DEMO_TEST_SUBSCRIBE_BEFORE_ANNOUNCE:
+        first_role = 1;
+        break;
+    default:
+        first_role = (tc == XQC_DEMO_TEST_SUBSCRIBE_ERROR) ? 1 : 0;
+        break;
+    }
+
+    xqc_demo_interop_conn_t *first = xqc_demo_interop_init_conn(first_role);
+    if (first == NULL) {
+        xqc_demo_test_fail("failed to create connection");
+        goto cleanup;
+    }
+
+    xqc_conn_settings_t conn_settings;
+    memset(&conn_settings, 0, sizeof(conn_settings));
+    conn_settings.cong_ctrl_callback = xqc_bbr_cb;
+    conn_settings.proto_version = XQC_VERSION_V1;
+
+    xqc_conn_ssl_config_t conn_ssl_cfg;
+    memset(&conn_ssl_cfg, 0, sizeof(conn_ssl_cfg));
+    if (g_tls_disable_verify) {
+        conn_ssl_cfg.cert_verify_flag |= XQC_TLS_CERT_FLAG_ALLOW_SELF_SIGNED;
+    }
+
+    xqc_moq_user_session_t *first_us = (first_role == 0) ? g_pub_user_session : g_sub_user_session;
+    const xqc_cid_t *cid;
+    if (g_transport_type == XQC_MOQ_TRANSPORT_WEBTRANSPORT) {
+        cid = xqc_h3_connect(g_ctx.engine, &conn_settings, NULL, 0,
+            g_relay_sni, 0, &conn_ssl_cfg, first->peer_addr, first->peer_addrlen,
+            first_us);
+    } else {
+        cid = xqc_connect(g_ctx.engine, &conn_settings, NULL, 0,
+            g_relay_sni, 0, &conn_ssl_cfg, first->peer_addr, first->peer_addrlen,
+            XQC_ALPN_MOQ_QUIC, first_us);
+    }
+    if (cid == NULL) {
+        xqc_demo_test_fail("xqc_connect failed");
+        goto cleanup;
+    }
+    memcpy(&first->cid, cid, sizeof(xqc_cid_t));
+
+    if (tc == XQC_DEMO_TEST_ANNOUNCE_ONLY || tc == XQC_DEMO_TEST_PUBLISH_NAMESPACE_DONE) {
+        struct event *ev_delayed = evtimer_new(g_eb, xqc_demo_interop_delayed_action_callback, first);
+        struct timeval delay = { 3, 0 };
+        event_add(ev_delayed, &delay);
+    }
+
+    if (tc == XQC_DEMO_TEST_ANNOUNCE_SUBSCRIBE || tc == XQC_DEMO_TEST_SUBSCRIBE_BEFORE_ANNOUNCE) {
+        int second_role = (tc == XQC_DEMO_TEST_ANNOUNCE_SUBSCRIBE) ? 1 : 0;
+        xqc_demo_interop_conn_t *second = xqc_demo_interop_init_conn(second_role);
+        if (second == NULL) {
+            xqc_demo_test_fail("failed to create second connection");
+            goto cleanup;
+        }
+        xqc_conn_settings_t second_settings;
+        memset(&second_settings, 0, sizeof(second_settings));
+        second_settings.cong_ctrl_callback = xqc_bbr_cb;
+        xqc_conn_ssl_config_t second_ssl_cfg;
+        memset(&second_ssl_cfg, 0, sizeof(second_ssl_cfg));
+        if (g_tls_disable_verify) {
+            second_ssl_cfg.cert_verify_flag |= XQC_TLS_CERT_FLAG_ALLOW_SELF_SIGNED;
+        }
+        xqc_moq_user_session_t *second_us = (second_role == 0) ? g_pub_user_session : g_sub_user_session;
+        const xqc_cid_t *second_cid;
+        if (g_transport_type == XQC_MOQ_TRANSPORT_WEBTRANSPORT) {
+            second_settings.proto_version = XQC_VERSION_V1;
+            second_cid = xqc_h3_connect(g_ctx.engine, &second_settings, NULL, 0,
+                g_relay_sni, 0, &second_ssl_cfg, second->peer_addr, second->peer_addrlen,
+                second_us);
+        } else {
+            second_cid = xqc_connect(g_ctx.engine, &second_settings, NULL, 0,
+                g_relay_sni, 0, &second_ssl_cfg, second->peer_addr, second->peer_addrlen,
+                XQC_ALPN_MOQ_QUIC, second_us);
+        }
+        if (second_cid == NULL) {
+            xqc_demo_test_fail("second xqc_connect failed");
+            goto cleanup;
+        }
+        memcpy(&second->cid, second_cid, sizeof(xqc_cid_t));
+    }
+
+    event_base_dispatch(g_eb);
+
+cleanup:
+    event_del(ev_timeout);
+    event_free(ev_timeout);
+    if (g_ctx.ev_engine) {
+        event_del(g_ctx.ev_engine);
+        event_free(g_ctx.ev_engine);
+    }
+    xqc_engine_destroy(g_ctx.engine);
+    event_base_free(g_eb);
+
+    if (g_pub_user_session && g_pub_conn && !g_pub_conn->closed) {
+        free(g_pub_user_session);
+    }
+    if (g_sub_user_session && g_sub_conn && !g_sub_conn->closed) {
+        free(g_sub_user_session);
+    }
+
+    return g_test_passed;
+}
+
+static int
+xqc_demo_parse_relay_url(const char *url)
+{
+    const char *p = url;
+    if (strncmp(p, "moqt://", 7) == 0) {
+        p += 7;
+        g_transport_type = XQC_MOQ_TRANSPORT_QUIC;
+    } else if (strncmp(p, "https://", 8) == 0) {
+        p += 8;
+        g_transport_type = XQC_MOQ_TRANSPORT_WEBTRANSPORT;
+    }
+
+    const char *slash = strchr(p, '/');
+    const char *host_end = slash ? slash : p + strlen(p);
+
+    const char *colon = NULL;
+    for (const char *c = p; c < host_end; c++) {
+        if (*c == ':') colon = c;
+    }
+
+    if (colon) {
+        size_t hlen = colon - p;
+        if (hlen >= sizeof(g_relay_host)) hlen = sizeof(g_relay_host) - 1;
+        memcpy(g_relay_host, p, hlen);
+        g_relay_host[hlen] = '\0';
+
+        char port_buf[16] = {0};
+        size_t plen = host_end - (colon + 1);
+        if (plen >= sizeof(port_buf)) plen = sizeof(port_buf) - 1;
+        memcpy(port_buf, colon + 1, plen);
+        g_relay_port = atoi(port_buf);
+    } else {
+        size_t hlen = host_end - p;
+        if (hlen >= sizeof(g_relay_host)) hlen = sizeof(g_relay_host) - 1;
+        memcpy(g_relay_host, p, hlen);
+        g_relay_host[hlen] = '\0';
+        g_relay_port = (g_transport_type == XQC_MOQ_TRANSPORT_WEBTRANSPORT) ? 443 : 4443;
+    }
+
+    if (slash && strlen(slash) > 0) {
+        snprintf(g_relay_path, sizeof(g_relay_path), "%s", slash);
+    } else {
+        snprintf(g_relay_path, sizeof(g_relay_path), "/");
+    }
+
+    return 0;
+}
+
+static xqc_demo_test_case_t
+xqc_demo_parse_test_name(const char *name)
+{
+    for (int i = 0; i < XQC_INTEROP_MAX_TESTS; i++) {
+        if (strcmp(name, g_test_case_names[i]) == 0) {
+            return (xqc_demo_test_case_t)i;
+        }
+    }
+    return XQC_DEMO_TEST_UNKNOWN;
+}
+
+static int
+xqc_demo_resolve_hostname(const char *hostname, char *ip_buf, size_t ip_buf_len)
+{
+    struct addrinfo hints, *res;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_DGRAM;
+
+    int ret = getaddrinfo(hostname, NULL, &hints, &res);
+    if (ret != 0 || res == NULL) {
+        return -1;
+    }
+    struct sockaddr_in *addr = (struct sockaddr_in *)res->ai_addr;
+    inet_ntop(AF_INET, &addr->sin_addr, ip_buf, ip_buf_len);
+    freeaddrinfo(res);
+    return 0;
+}
+
+int main(int argc, char *argv[])
+{
+    signal(SIGPIPE, SIG_IGN);
+
+    const char *relay_url = getenv("RELAY_URL");
+    const char *testcase = getenv("TESTCASE");
+    const char *tls_verify = getenv("TLS_DISABLE_VERIFY");
+    const char *verbose = getenv("VERBOSE");
+
+    const char *cli_sni = NULL;
+    for (int i = 1; i < argc; i++) {
+        if ((strcmp(argv[i], "--relay") == 0 || strcmp(argv[i], "-r") == 0) && i + 1 < argc) {
+            relay_url = argv[++i];
+        } else if ((strcmp(argv[i], "--test") == 0 || strcmp(argv[i], "-t") == 0) && i + 1 < argc) {
+            testcase = argv[++i];
+        } else if (strcmp(argv[i], "--sni") == 0 && i + 1 < argc) {
+            cli_sni = argv[++i];
+        } else if (strcmp(argv[i], "--tls-disable-verify") == 0) {
+            g_tls_disable_verify = 1;
+        } else if (strcmp(argv[i], "--verbose") == 0 || strcmp(argv[i], "-v") == 0) {
+            g_verbose = 1;
+        } else if (strcmp(argv[i], "--list") == 0 || strcmp(argv[i], "-l") == 0) {
+            for (int j = 0; j < XQC_INTEROP_MAX_TESTS; j++) {
+                printf("%s\n", g_test_case_names[j]);
+            }
+            return 0;
+        } else if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
+            printf("Usage: %s [OPTIONS]\n\n", argv[0]);
+            printf("Options:\n");
+            printf("  -r, --relay <URL>        Relay URL (moqt://host:port or https://host:port/path)\n");
+            printf("  -t, --test <NAME>        Run specific test (omit to run all)\n");
+            printf("  -l, --list               List available tests\n");
+            printf("  -v, --verbose            Verbose output\n");
+            printf("      --sni <hostname>     Override TLS SNI\n");
+            printf("      --tls-disable-verify Disable TLS certificate verification\n");
+            return 0;
+        }
+    }
+
+    if (tls_verify && (strcmp(tls_verify, "1") == 0 || strcmp(tls_verify, "true") == 0)) {
+        g_tls_disable_verify = 1;
+    }
+    if (verbose && (strcmp(verbose, "1") == 0 || strcmp(verbose, "true") == 0)) {
+        g_verbose = 1;
+    }
+
+    if (relay_url == NULL || relay_url[0] == '\0') {
+        fprintf(stderr, "error: RELAY_URL is required (e.g., moqt://host:4443 or https://host:443/path)\n");
+        return 1;
+    }
+
+    if (xqc_demo_parse_relay_url(relay_url) < 0) {
+        return 1;
+    }
+
+    snprintf(g_relay_sni, sizeof(g_relay_sni), "%s", g_relay_host);
+    if (cli_sni) {
+        snprintf(g_relay_sni, sizeof(g_relay_sni), "%s", cli_sni);
+    }
+    struct in_addr test_addr;
+    if (inet_aton(g_relay_host, &test_addr) == 0) {
+        char resolved_ip[64];
+        if (xqc_demo_resolve_hostname(g_relay_host, resolved_ip, sizeof(resolved_ip)) < 0) {
+            fprintf(stderr, "error: cannot resolve hostname '%s'\n", g_relay_host);
+            return 1;
+        }
+        VERBOSE("resolved %s -> %s", g_relay_host, resolved_ip);
+        strncpy(g_relay_host, resolved_ip, sizeof(g_relay_host) - 1);
+    }
+
+    xqc_demo_test_case_t tests[XQC_INTEROP_MAX_TESTS];
+    int num_tests = 0;
+
+    if (testcase && testcase[0]) {
+        xqc_demo_test_case_t tc = xqc_demo_parse_test_name(testcase);
+        if (tc == XQC_DEMO_TEST_UNKNOWN) {
+            fprintf(stderr, "error: unknown test case '%s'\n", testcase);
+            fprintf(stderr, "  valid: setup-only, announce-only, subscribe-error, announce-subscribe, subscribe-before-announce, publish-namespace-done\n");
+            return 1;
+        }
+        tests[0] = tc;
+        num_tests = 1;
+    } else {
+        for (int i = 0; i < XQC_INTEROP_MAX_TESTS; i++) {
+            tests[i] = (xqc_demo_test_case_t)i;
+        }
+        num_tests = XQC_INTEROP_MAX_TESTS;
+    }
+
+    xqc_demo_tap_header();
+    xqc_demo_tap_plan(num_tests);
+
+    int all_passed = 1;
+    for (int i = 0; i < num_tests; i++) {
+        int passed = xqc_demo_run_single_test(tests[i]);
+        uint64_t duration_ms = (xqc_now() - g_test_start_us) / 1000;
+        xqc_demo_tap_result(i + 1, g_test_case_names[tests[i]], passed, duration_ms,
+                   passed ? "" : g_fail_reason);
+        if (!passed) {
+            all_passed = 0;
+        }
+    }
+
+    return all_passed ? 0 : 1;
+}

--- a/moq/moq_media/xqc_moq_catalog.c
+++ b/moq/moq_media/xqc_moq_catalog.c
@@ -1,4 +1,6 @@
 #include "moq/moq_media/xqc_moq_catalog.h"
+#include "moq/moq_transport/xqc_moq_message.h"
+#include "moq/moq_transport/xqc_moq_namespace.h"
 #include "moq/moq_transport/xqc_moq_message_writer.h"
 #include "moq/moq_transport/xqc_moq_session.h"
 #include "moq/moq_transport/xqc_moq_stream.h"
@@ -26,15 +28,15 @@ const xqc_moq_track_ops_t xqc_moq_catalog_track_ops = {
 
 #define XQC_MOQ_PROCESS_CATALOG_REQUIRED_STRING_FIELD(cstring_ptr, catalog_json, field_name)         \
     do {                                                                                             \
-        cJSON *item = cJSON_GetObjectItemCaseSensitive(catalog_json, field_name);                    \
-        if (cJSON_IsString(item)) {                                                                  \
-            size_t len = strlen((item)->valuestring) + 1;                                            \
+        cJSON *field_json = cJSON_GetObjectItemCaseSensitive(catalog_json, field_name);              \
+        if (cJSON_IsString(field_json)) {                                                            \
+            size_t len = strlen((field_json)->valuestring) + 1;                                      \
             cstring_ptr = (char *)xqc_realloc(cstring_ptr, len);                                     \
             if (cstring_ptr == NULL) {                                                               \
                 ret = XQC_MOQ_CATALOG_DECODE_ALLOCATION_ERROR;                                       \
                 goto end;                                                                            \
             }                                                                                        \
-            xqc_memcpy(cstring_ptr, (item)->valuestring, len);                                       \
+            xqc_memcpy(cstring_ptr, (field_json)->valuestring, len);                                 \
         } else {                                                                                     \
             ret = XQC_MOQ_CATALOG_DECODE_FIELD_MISSING;                                              \
             goto end;                                                                                \
@@ -43,24 +45,24 @@ const xqc_moq_track_ops_t xqc_moq_catalog_track_ops = {
 
 #define XQC_MOQ_PROCESS_CATALOG_UNNECESSARY_STRING_FIELD(cstring_ptr, catalog_json, field_name)      \
     do {                                                                                             \
-        cJSON *item = cJSON_GetObjectItemCaseSensitive(catalog_json, field_name);                    \
-        if (cJSON_IsString(item)) {                                                                  \
-            size_t len = strlen((item)->valuestring) + 1;                                            \
+        cJSON *field_json = cJSON_GetObjectItemCaseSensitive(catalog_json, field_name);              \
+        if (cJSON_IsString(field_json)) {                                                            \
+            size_t len = strlen((field_json)->valuestring) + 1;                                      \
             cstring_ptr = (char *)xqc_realloc(cstring_ptr, len);                                     \
             if (cstring_ptr == NULL) {                                                               \
                 ret = -XQC_MOQ_CATALOG_DECODE_ALLOCATION_ERROR;                                      \
                 goto end;                                                                            \
             }                                                                                        \
-            xqc_memcpy(cstring_ptr, (item)->valuestring, len);                                       \
+            xqc_memcpy(cstring_ptr, (field_json)->valuestring, len);                                 \
         }                                                                                            \
     } while (0)
 
 
 #define XQC_MOQ_PROCESS_CATALOG_REQUIRED_INT_FIELD(int_item, catalog_json, field_name)               \
     do {                                                                                             \
-        cJSON *item = cJSON_GetObjectItemCaseSensitive(catalog_json, field_name);                    \
-        if (cJSON_IsNumber(item)) {                                                                  \
-            int_item = item->valueint;                                                               \
+        cJSON *field_json = cJSON_GetObjectItemCaseSensitive(catalog_json, field_name);              \
+        if (cJSON_IsNumber(field_json)) {                                                            \
+            int_item = field_json->valueint;                                                         \
         } else {                                                                                     \
             ret = XQC_MOQ_CATALOG_DECODE_FIELD_MISSING;                                              \
             goto end;                                                                                \
@@ -69,9 +71,9 @@ const xqc_moq_track_ops_t xqc_moq_catalog_track_ops = {
 
 #define XQC_MOQ_PROCESS_CATALOG_UNNECESSARY_INT_FIELD(int_item, catalog_json, field_name)            \
     do {                                                                                             \
-        cJSON *item = cJSON_GetObjectItemCaseSensitive(catalog_json, field_name);                    \
-        if (cJSON_IsNumber(item)) {                                                                  \
-            int_item = item->valueint;                                                               \
+        cJSON *field_json = cJSON_GetObjectItemCaseSensitive(catalog_json, field_name);              \
+        if (cJSON_IsNumber(field_json)) {                                                            \
+            int_item = field_json->valueint;                                                         \
         }                                                                                            \
     } while (0)
 
@@ -195,6 +197,107 @@ typedef enum xqc_moq_catalog_encode_error_s{
     XQC_MOQ_CATALOG_ENCODE_INTERNAL_ERROR,
 }xqc_moq_catalog_encode_error_t;
 
+static xqc_moq_catalog_decode_error_t
+xqc_moq_catalog_decode_namespace_tuple_field(cJSON *json_obj, const char *field_name,
+    xqc_moq_track_ns_field_t **namespace_tuple, uint64_t *namespace_tuple_num)
+{
+    if (namespace_tuple == NULL || namespace_tuple_num == NULL) {
+        return XQC_MOQ_CATALOG_DECODE_INVALID_PARAMETER;
+    }
+
+    *namespace_tuple = NULL;
+    *namespace_tuple_num = 0;
+
+    cJSON *field_json = cJSON_GetObjectItemCaseSensitive(json_obj, field_name);
+    if (field_json == NULL) {
+        return XQC_MOQ_CATALOG_DECODE_OK;
+    }
+
+    if (cJSON_IsArray(field_json)) {
+        int tuple_elem_count = cJSON_GetArraySize(field_json);
+        if (tuple_elem_count <= 0 || (uint64_t)tuple_elem_count > XQC_MOQ_MAX_NAMESPACE_TUPLE_ELEMS) {
+            return XQC_MOQ_CATALOG_DECODE_INVALID_PARAMETER;
+        }
+
+        xqc_moq_track_ns_field_t *decoded_namespace_tuple =
+            xqc_calloc((size_t)tuple_elem_count, sizeof(*decoded_namespace_tuple));
+        if (decoded_namespace_tuple == NULL) {
+            return XQC_MOQ_CATALOG_DECODE_ALLOCATION_ERROR;
+        }
+
+        for (int i = 0; i < tuple_elem_count; i++) {
+            cJSON *tuple_elem_json = cJSON_GetArrayItem(field_json, i);
+            if (!cJSON_IsString(tuple_elem_json)) {
+                xqc_moq_namespace_tuple_free(decoded_namespace_tuple, (uint64_t)tuple_elem_count);
+                return XQC_MOQ_CATALOG_DECODE_INVALID_PARAMETER;
+            }
+            size_t tuple_elem_len = strlen(tuple_elem_json->valuestring);
+            if (tuple_elem_len > XQC_MOQ_MAX_NAME_LEN) {
+                xqc_moq_namespace_tuple_free(decoded_namespace_tuple, (uint64_t)tuple_elem_count);
+                return XQC_MOQ_CATALOG_DECODE_INVALID_PARAMETER;
+            }
+            decoded_namespace_tuple[i].len = tuple_elem_len;
+            if (tuple_elem_len > 0) {
+                decoded_namespace_tuple[i].data = xqc_calloc(1, tuple_elem_len + 1);
+                if (decoded_namespace_tuple[i].data == NULL) {
+                    xqc_moq_namespace_tuple_free(decoded_namespace_tuple, (uint64_t)tuple_elem_count);
+                    return XQC_MOQ_CATALOG_DECODE_ALLOCATION_ERROR;
+                }
+                xqc_memcpy(decoded_namespace_tuple[i].data, tuple_elem_json->valuestring, tuple_elem_len);
+            }
+        }
+
+        *namespace_tuple = decoded_namespace_tuple;
+        *namespace_tuple_num = (uint64_t)tuple_elem_count;
+        return XQC_MOQ_CATALOG_DECODE_OK;
+    }
+
+    return XQC_MOQ_CATALOG_DECODE_INVALID_PARAMETER;
+}
+
+static xqc_moq_catalog_encode_error_t
+xqc_moq_catalog_add_namespace_tuple_field(cJSON *json_obj, const char *field_name,
+    const xqc_moq_track_ns_field_t *namespace_tuple, uint64_t namespace_tuple_num)
+{
+    if (json_obj == NULL || field_name == NULL || namespace_tuple == NULL || namespace_tuple_num == 0) {
+        return XQC_MOQ_CATALOG_ENCODE_INTERNAL_ERROR;
+    }
+
+    cJSON *tuple_array_json = cJSON_CreateArray();
+    if (tuple_array_json == NULL) {
+        return XQC_MOQ_CATALOG_ENCODE_INTERNAL_ERROR;
+    }
+
+    for (uint64_t i = 0; i < namespace_tuple_num; i++) {
+        const xqc_moq_track_ns_field_t *tuple_elem = &namespace_tuple[i];
+        char *tuple_elem_str = xqc_calloc(1, tuple_elem->len + 1);
+        if (tuple_elem_str == NULL) {
+            cJSON_Delete(tuple_array_json);
+            return XQC_MOQ_CATALOG_ENCODE_INTERNAL_ERROR;
+        }
+        if (tuple_elem->len > 0 && tuple_elem->data != NULL) {
+            xqc_memcpy(tuple_elem_str, tuple_elem->data, tuple_elem->len);
+        }
+        cJSON *tuple_elem_json = cJSON_CreateString(tuple_elem_str);
+        xqc_free(tuple_elem_str);
+        if (tuple_elem_json == NULL) {
+            cJSON_Delete(tuple_array_json);
+            return XQC_MOQ_CATALOG_ENCODE_INTERNAL_ERROR;
+        }
+        if (!cJSON_AddItemToArray(tuple_array_json, tuple_elem_json)) {
+            cJSON_Delete(tuple_elem_json);
+            cJSON_Delete(tuple_array_json);
+            return XQC_MOQ_CATALOG_ENCODE_ITEMADD_FAIL;
+        }
+    }
+
+    if (!cJSON_AddItemToObject(json_obj, field_name, tuple_array_json)) {
+        cJSON_Delete(tuple_array_json);
+        return XQC_MOQ_CATALOG_ENCODE_ITEMADD_FAIL;
+    }
+    return XQC_MOQ_CATALOG_ENCODE_OK;
+}
+
 
 void
 xqc_moq_catalog_init(xqc_moq_catalog_t *catalog)
@@ -215,8 +318,10 @@ xqc_moq_catalog_free_fields(xqc_moq_catalog_t *catalog)
     catalog->streaming_format_version = NULL;
     xqc_free(catalog->common_track_fields.packaging);
     catalog->common_track_fields.packaging = NULL;
-    xqc_free(catalog->common_track_fields.track_namespace);
-    catalog->common_track_fields.track_namespace = NULL;
+    xqc_moq_namespace_tuple_free(catalog->common_track_fields.track_namespace_tuple,
+                                 catalog->common_track_fields.track_namespace_num);
+    catalog->common_track_fields.track_namespace_tuple = NULL;
+    catalog->common_track_fields.track_namespace_num = 0;
 
     xqc_list_head_t *pos, *next;
     xqc_moq_track_t *tmp_track;
@@ -238,7 +343,6 @@ xqc_moq_catalog_single_track_decode(cJSON *track_json, xqc_moq_track_t *track, x
 {
     xqc_moq_catalog_decode_error_t ret = XQC_MOQ_CATALOG_DECODE_OK;
     XQC_MOQ_PROCESS_CATALOG_REQUIRED_STRING_FIELD(track->track_info.track_name, track_json, kName);
-    XQC_MOQ_PROCESS_CATALOG_UNNECESSARY_STRING_FIELD(track->track_info.track_namespace, track_json, kNamespace);
     XQC_MOQ_PROCESS_CATALOG_UNNECESSARY_STRING_FIELD(track->packaging, track_json, kPackaging);
     if (track->packaging != NULL && strncmp(track->packaging, XQC_MOQ_CONTAINER_LOC_STR, strlen(track->packaging)) == 0) {
         track->container_format = XQC_MOQ_CONTAINER_LOC;
@@ -260,12 +364,26 @@ xqc_moq_catalog_single_track_decode(cJSON *track_json, xqc_moq_track_t *track, x
 
     XQC_MOQ_PROCESS_CATALOG_UNNECESSARY_INT_FIELD(track->render_group, track_json, kRenderGroup);
 
+    ret = xqc_moq_catalog_decode_namespace_tuple_field(track_json, kNamespace,
+                                                       &track->track_info.track_namespace_tuple,
+                                                       &track->track_info.track_namespace_num);
+    if (ret != XQC_MOQ_CATALOG_DECODE_OK) {
+        goto end;
+    }
     
     // inherit from catalog->common_track_fields
-    if (track->track_info.track_namespace == NULL && catalog->common_track_fields.track_namespace != NULL) {
-        size_t str_len = strlen(catalog->common_track_fields.track_namespace) + 1;
-        track->track_info.track_namespace = xqc_malloc(str_len);
-        xqc_memcpy(track->track_info.track_namespace, catalog->common_track_fields.track_namespace, str_len);
+    if ((track->track_info.track_namespace_tuple == NULL || track->track_info.track_namespace_num == 0)
+        && catalog->common_track_fields.track_namespace_tuple != NULL
+        && catalog->common_track_fields.track_namespace_num > 0)
+    {
+        track->track_info.track_namespace_tuple =
+            xqc_moq_namespace_tuple_copy(catalog->common_track_fields.track_namespace_tuple,
+                                         catalog->common_track_fields.track_namespace_num);
+        if (track->track_info.track_namespace_tuple == NULL) {
+            ret = XQC_MOQ_CATALOG_DECODE_ALLOCATION_ERROR;
+            goto end;
+        }
+        track->track_info.track_namespace_num = catalog->common_track_fields.track_namespace_num;
     }
     if (track->packaging == NULL && catalog->common_track_fields.packaging != NULL) {
         size_t str_len = strlen(catalog->common_track_fields.packaging) + 1;
@@ -274,6 +392,10 @@ xqc_moq_catalog_single_track_decode(cJSON *track_json, xqc_moq_track_t *track, x
     }
     if (track->render_group == -1 && catalog->common_track_fields.renderGroup != -1) {
         track->render_group = catalog->common_track_fields.renderGroup;
+    }
+    if (track->track_info.track_namespace_tuple == NULL || track->track_info.track_namespace_num == 0) {
+        ret = XQC_MOQ_CATALOG_DECODE_FIELD_MISSING;
+        goto end;
     }
 
     // selectionParams
@@ -313,7 +435,7 @@ end:
  * parse feilds of single track
  */
 xqc_moq_catalog_encode_error_t 
-xqc_moq_catalog_single_track_encode(cJSON *track_json, xqc_moq_track_t *track, xqc_moq_catalog_t *catalog, xqc_bool_t is_first_track)
+xqc_moq_catalog_single_track_encode(cJSON *track_json, xqc_moq_track_t *track, xqc_moq_catalog_t *catalog, xqc_bool_t is_first_track) 
 {
     xqc_moq_catalog_encode_error_t ret = XQC_MOQ_CATALOG_ENCODE_OK;
 
@@ -346,15 +468,25 @@ xqc_moq_catalog_single_track_encode(cJSON *track_json, xqc_moq_track_t *track, x
 
     /* add field which could be inherited from parent domain, but it's different from ones in parent domain. */
     if (is_first_track) {
-        size_t str_field_len;
         catalog->common_track_fields.container_format = track->container_format;
 
-        if (catalog->common_track_fields.track_namespace == NULL) {
-            str_field_len = strlen(track->track_info.track_namespace) + 1;
-            catalog->common_track_fields.track_namespace = (char *)xqc_malloc(str_field_len);
-            xqc_memcpy(catalog->common_track_fields.track_namespace, track->track_info.track_namespace, str_field_len);
+        if (catalog->common_track_fields.track_namespace_tuple == NULL
+            || catalog->common_track_fields.track_namespace_num == 0)
+        {
+            if (track->track_info.track_namespace_tuple == NULL || track->track_info.track_namespace_num == 0) {
+                ret = XQC_MOQ_CATALOG_ENCODE_INTERNAL_ERROR;
+                goto end;
+            }
+            catalog->common_track_fields.track_namespace_tuple =
+                xqc_moq_namespace_tuple_copy(track->track_info.track_namespace_tuple,
+                                             track->track_info.track_namespace_num);
+            if (catalog->common_track_fields.track_namespace_tuple == NULL) {
+                ret = XQC_MOQ_CATALOG_ENCODE_INTERNAL_ERROR;
+                goto end;
+            }
+            catalog->common_track_fields.track_namespace_num = track->track_info.track_namespace_num;
         }
-        catalog->common_track_fields.renderGroup == track->render_group;
+        catalog->common_track_fields.renderGroup = track->render_group;
     } else {
         if (catalog->common_track_fields.container_format != track->container_format) {
             if (track->container_format == XQC_MOQ_CONTAINER_LOC) {
@@ -368,9 +500,23 @@ xqc_moq_catalog_single_track_encode(cJSON *track_json, xqc_moq_track_t *track, x
                 && strcmp(catalog->common_track_fields.packaging, track->packaging) != 0) {
             XQC_MOQ_ADD_REQUIRED_STRING_TO_CATALOG(track->packaging, track_json, kPackaging);
         }
-        if(track->track_info.track_namespace != NULL && catalog->common_track_fields.track_namespace != NULL
-                && strcmp(catalog->common_track_fields.track_namespace, track->track_info.track_namespace) != 0) {
-            XQC_MOQ_ADD_REQUIRED_STRING_TO_CATALOG(track->track_info.track_namespace, track_json, kNamespace);
+        if (track->track_info.track_namespace_tuple != NULL
+            && track->track_info.track_namespace_num > 0
+            && catalog->common_track_fields.track_namespace_tuple != NULL
+            && catalog->common_track_fields.track_namespace_num > 0
+            && !xqc_moq_namespace_tuple_equal(catalog->common_track_fields.track_namespace_tuple,
+                                              catalog->common_track_fields.track_namespace_num,
+                                              track->track_info.track_namespace_tuple,
+                                              track->track_info.track_namespace_num))
+        {
+            xqc_moq_catalog_encode_error_t ns_ret =
+                xqc_moq_catalog_add_namespace_tuple_field(track_json, kNamespace,
+                                                          track->track_info.track_namespace_tuple,
+                                                          track->track_info.track_namespace_num);
+            if (ns_ret != XQC_MOQ_CATALOG_ENCODE_OK) {
+                ret = ns_ret;
+                goto end;
+            }
         }
         if(track->render_group != -1 && catalog->common_track_fields.renderGroup != -1
                 && track->render_group != catalog->common_track_fields.renderGroup) {
@@ -473,13 +619,22 @@ xqc_moq_catalog_encode(xqc_moq_catalog_t *catalog, uint8_t *buf, size_t buf_cap,
     }
 
     // Add common_track_fields to catalog json
-    if (catalog->common_track_fields.track_namespace != NULL) {
+    if (catalog->common_track_fields.track_namespace_tuple != NULL
+        && catalog->common_track_fields.track_namespace_num > 0)
+    {
         if (catalog->common_track_fields.container_format == XQC_MOQ_CONTAINER_LOC) {
             XQC_MOQ_ADD_REQUIRED_STRING_TO_CATALOG(XQC_MOQ_CONTAINER_LOC_STR, common_track_fields_json, kPackaging);
         } else if (catalog->common_track_fields.container_format == XQC_MOQ_CONTAINER_CMAF) {
             XQC_MOQ_ADD_REQUIRED_STRING_TO_CATALOG(XQC_MOQ_CONTAINER_CMAF_STR, common_track_fields_json, kPackaging);
         }
-        XQC_MOQ_ADD_REQUIRED_STRING_TO_CATALOG(catalog->common_track_fields.track_namespace, common_track_fields_json, kNamespace);
+        xqc_moq_catalog_encode_error_t ns_ret =
+            xqc_moq_catalog_add_namespace_tuple_field(common_track_fields_json, kNamespace,
+                                                      catalog->common_track_fields.track_namespace_tuple,
+                                                      catalog->common_track_fields.track_namespace_num);
+        if (ns_ret != XQC_MOQ_CATALOG_ENCODE_OK) {
+            ret = ns_ret;
+            goto end;
+        }
         XQC_MOQ_ADD_UNNECESSARY_INT_TO_CATALOG(catalog->common_track_fields.renderGroup, common_track_fields_json, kRenderGroup);
         
         if (!cJSON_AddItemToObject(catalog_json, kCommonTrackFields, common_track_fields_json)) {
@@ -541,15 +696,20 @@ xqc_moq_catalog_decode(xqc_moq_catalog_t *catalog, uint8_t *buf, size_t buf_len)
     cJSON *common_field_json = cJSON_GetObjectItemCaseSensitive(catalog_json, kCommonTrackFields);
     if (cJSON_IsObject(common_field_json)) {
         XQC_MOQ_PROCESS_CATALOG_UNNECESSARY_STRING_FIELD(catalog->common_track_fields.packaging, common_field_json, kPackaging);
-        XQC_MOQ_PROCESS_CATALOG_UNNECESSARY_STRING_FIELD(catalog->common_track_fields.track_namespace, common_field_json, kNamespace);
+        ret = xqc_moq_catalog_decode_namespace_tuple_field(common_field_json, kNamespace,
+                                                           &catalog->common_track_fields.track_namespace_tuple,
+                                                           &catalog->common_track_fields.track_namespace_num);
+        if (ret != XQC_MOQ_CATALOG_DECODE_OK) {
+            goto end;
+        }
         XQC_MOQ_PROCESS_CATALOG_UNNECESSARY_INT_FIELD(catalog->common_track_fields.renderGroup, common_field_json, kRenderGroup);
     }
 
     // decode tracks
-    cJSON *item = cJSON_GetObjectItemCaseSensitive(catalog_json, kTracks);
-    if (cJSON_IsArray(item)) {
+    cJSON *tracks_array_json = cJSON_GetObjectItemCaseSensitive(catalog_json, kTracks);
+    if (cJSON_IsArray(tracks_array_json)) {
         cJSON *track = NULL;
-        cJSON_ArrayForEach(track, item) {
+        cJSON_ArrayForEach(track, tracks_array_json) {
             if (cJSON_IsObject(track)) {
                 tmp_track = xqc_calloc(1, sizeof(xqc_moq_track_t));
                 if (tmp_track == NULL) {
@@ -737,24 +897,28 @@ xqc_moq_subscribe_catalog(xqc_moq_session_t *session)
 {
     xqc_int_t ret;
 
+    xqc_moq_track_ns_field_t catalog_ns[1];
+    catalog_ns[0].data = (unsigned char *)XQC_MOQ_CATALOG_NAMESPACE;
+    catalog_ns[0].len = strlen(XQC_MOQ_CATALOG_NAMESPACE);
+
     if (session->role == XQC_MOQ_SUBSCRIBER) {
-        xqc_moq_track_create(session, XQC_MOQ_CATALOG_NAMESPACE, XQC_MOQ_CATALOG_NAME,
-                             XQC_MOQ_TRACK_CATALOG, NULL, XQC_MOQ_CONTAINER_NONE, XQC_MOQ_TRACK_FOR_SUB);
+        xqc_moq_track_create_with_namespace_tuple(session, 1, catalog_ns, (char *)XQC_MOQ_CATALOG_NAME,
+            XQC_MOQ_TRACK_CATALOG, NULL, XQC_MOQ_CONTAINER_NONE, XQC_MOQ_TRACK_FOR_SUB);
     } else if (session->role == XQC_MOQ_PUBLISHER) {
-        xqc_moq_track_create(session, XQC_MOQ_CATALOG_NAMESPACE, XQC_MOQ_CATALOG_NAME,
-                             XQC_MOQ_TRACK_CATALOG, NULL, XQC_MOQ_CONTAINER_NONE, XQC_MOQ_TRACK_FOR_PUB);
+        xqc_moq_track_create_with_namespace_tuple(session, 1, catalog_ns, (char *)XQC_MOQ_CATALOG_NAME,
+            XQC_MOQ_TRACK_CATALOG, NULL, XQC_MOQ_CONTAINER_NONE, XQC_MOQ_TRACK_FOR_PUB);
     } else {
-        xqc_moq_track_create(session, XQC_MOQ_CATALOG_NAMESPACE, XQC_MOQ_CATALOG_NAME,
-                             XQC_MOQ_TRACK_CATALOG, NULL, XQC_MOQ_CONTAINER_NONE, XQC_MOQ_TRACK_FOR_SUB);
-        xqc_moq_track_create(session, XQC_MOQ_CATALOG_NAMESPACE, XQC_MOQ_CATALOG_NAME,
-                             XQC_MOQ_TRACK_CATALOG, NULL, XQC_MOQ_CONTAINER_NONE, XQC_MOQ_TRACK_FOR_PUB);
+        xqc_moq_track_create_with_namespace_tuple(session, 1, catalog_ns, (char *)XQC_MOQ_CATALOG_NAME,
+            XQC_MOQ_TRACK_CATALOG, NULL, XQC_MOQ_CONTAINER_NONE, XQC_MOQ_TRACK_FOR_SUB);
+        xqc_moq_track_create_with_namespace_tuple(session, 1, catalog_ns, (char *)XQC_MOQ_CATALOG_NAME,
+            XQC_MOQ_TRACK_CATALOG, NULL, XQC_MOQ_CONTAINER_NONE, XQC_MOQ_TRACK_FOR_PUB);
     }
 
     if (session->role == XQC_MOQ_PUBLISHER) {
         return XQC_OK;
     }
 
-    ret = xqc_moq_subscribe_latest(session, XQC_MOQ_CATALOG_NAMESPACE, XQC_MOQ_CATALOG_NAME);
+    ret = xqc_moq_subscribe_latest_with_namespace_tuple(session, catalog_ns, 1, XQC_MOQ_CATALOG_NAME);
     if (ret < 0) {
         xqc_log(session->log, XQC_LOG_ERROR, "|xqc_moq_subscribe_latest error|ret:%d|", ret);
         return ret;
@@ -823,11 +987,13 @@ xqc_moq_catalog_on_object(xqc_moq_session_t *session, xqc_moq_track_t *track, xq
 
     xqc_list_head_t *pos, *next;
     xqc_list_for_each_safe(pos, next, &(catalog.track_list_for_sub)) {
-        xqc_moq_track_t *tmp = xqc_list_entry(pos, xqc_moq_track_t, list_member);
+        xqc_moq_track_t *catalog_track = xqc_list_entry(pos, xqc_moq_track_t, list_member);
         tracks_num++;
-        xqc_moq_track_t *new_track = xqc_moq_track_create(session, tmp->track_info.track_namespace, tmp->track_info.track_name,
-                                                          tmp->track_info.track_type, &tmp->track_info.selection_params,
-                                                          tmp->container_format, XQC_MOQ_TRACK_FOR_SUB);
+        xqc_moq_track_t *new_track = xqc_moq_track_create_with_namespace_tuple(session,
+                catalog_track->track_info.track_namespace_num, catalog_track->track_info.track_namespace_tuple,
+                catalog_track->track_info.track_name, catalog_track->track_info.track_type,
+                &catalog_track->track_info.selection_params,
+                catalog_track->container_format, XQC_MOQ_TRACK_FOR_SUB);
         if (new_track == NULL) {
             xqc_log(session->log, XQC_LOG_ERROR, "|xqc_moq_track_create error|");
             goto end;
@@ -837,8 +1003,8 @@ xqc_moq_catalog_on_object(xqc_moq_session_t *session, xqc_moq_track_t *track, xq
     track_info_array = (xqc_moq_track_info_t **)xqc_malloc(tracks_num * sizeof(xqc_moq_track_info_t *));
     xqc_int_t i = 0;
     xqc_list_for_each_safe(pos, next, &(catalog.track_list_for_sub)) {
-        xqc_moq_track_t *tmp = xqc_list_entry(pos, xqc_moq_track_t, list_member);
-        track_info_array[i] = &tmp->track_info;
+        xqc_moq_track_t *catalog_track = xqc_list_entry(pos, xqc_moq_track_t, list_member);
+        track_info_array[i] = &catalog_track->track_info;
         i++;
     }
 

--- a/moq/moq_media/xqc_moq_catalog.h
+++ b/moq/moq_media/xqc_moq_catalog.h
@@ -12,7 +12,8 @@ typedef struct {
 } xqc_moq_catalog_track_t;
 
 typedef struct xqc_moq_catalog_common_track_fields_s {
-    char                                    *track_namespace;
+    uint64_t                                track_namespace_num;
+    xqc_moq_track_ns_field_t                *track_namespace_tuple;
     char                                    *packaging;
     xqc_int_t                               renderGroup;
     xqc_moq_container_t                     container_format;

--- a/moq/moq_media/xqc_moq_datachannel.c
+++ b/moq/moq_media/xqc_moq_datachannel.c
@@ -203,13 +203,19 @@ xqc_moq_subscribe_datachannel(xqc_moq_session_t *session)
 {
     xqc_int_t ret;
     xqc_moq_track_t *track;
-    track = xqc_moq_track_create(session, XQC_MOQ_DATACHANNEL_NAMESPACE, XQC_MOQ_DATACHANNEL_NAME,
-                                 XQC_MOQ_TRACK_DATACHANNEL, NULL, XQC_MOQ_CONTAINER_NONE, XQC_MOQ_TRACK_FOR_PUB);
+
+    xqc_moq_track_ns_field_t dc_ns[1];
+    dc_ns[0].data = (unsigned char *)XQC_MOQ_DATACHANNEL_NAMESPACE;
+    dc_ns[0].len = strlen(XQC_MOQ_DATACHANNEL_NAMESPACE);
+
+    track = xqc_moq_track_create_with_namespace_tuple(session, 1, dc_ns, (char *)XQC_MOQ_DATACHANNEL_NAME,
+        XQC_MOQ_TRACK_DATACHANNEL, NULL, XQC_MOQ_CONTAINER_NONE, XQC_MOQ_TRACK_FOR_PUB);
     session->datachannel.track_for_pub = track;
-    track = xqc_moq_track_create(session, XQC_MOQ_DATACHANNEL_NAMESPACE, XQC_MOQ_DATACHANNEL_NAME,
-                                 XQC_MOQ_TRACK_DATACHANNEL, NULL, XQC_MOQ_CONTAINER_NONE, XQC_MOQ_TRACK_FOR_SUB);
+
+    track = xqc_moq_track_create_with_namespace_tuple(session, 1, dc_ns, (char *)XQC_MOQ_DATACHANNEL_NAME,
+        XQC_MOQ_TRACK_DATACHANNEL, NULL, XQC_MOQ_CONTAINER_NONE, XQC_MOQ_TRACK_FOR_SUB);
     session->datachannel.track_for_sub = track;
-    ret = xqc_moq_subscribe_latest(session, XQC_MOQ_DATACHANNEL_NAMESPACE, XQC_MOQ_DATACHANNEL_NAME);
+    ret = xqc_moq_subscribe_latest_with_namespace_tuple(session, dc_ns, 1, XQC_MOQ_DATACHANNEL_NAME);
     if (ret < 0) {
         xqc_log(session->log, XQC_LOG_ERROR, "|xqc_moq_subscribe_latest error|ret:%d|", ret);
         return ret;
@@ -276,9 +282,8 @@ static void
 xqc_moq_datachannel_on_object(xqc_moq_session_t *session, xqc_moq_track_t *track, xqc_moq_object_t *object)
 {
     xqc_log(session->log, XQC_LOG_INFO, "|on_datachannel_msg|msg_len:%ui|", object->payload_len);
-    xqc_log(session->log, XQC_LOG_INFO, "|on_datachannel_msg_detail|track:%s/%s|subscribe_id:%ui|",
-            track && track->track_info.track_namespace ? track->track_info.track_namespace : "null",
-            track && track->track_info.track_name ? track->track_info.track_name : "null",
+    xqc_log(session->log, XQC_LOG_INFO, "|on_datachannel_msg_detail|track:%s|subscribe_id:%ui|",
+            xqc_moq_track_get_full_name(track),
             object->subscribe_id);
     session->session_callbacks.on_datachannel_msg(session->user_session, track,
         track ? &track->track_info : NULL, object->payload, object->payload_len);

--- a/moq/moq_media/xqc_moq_media_track.c
+++ b/moq/moq_media/xqc_moq_media_track.c
@@ -372,9 +372,8 @@ xqc_moq_write_raw_object(xqc_moq_session_t *session,
 
     if (!track->raw_object) {
         xqc_log(session->log, XQC_LOG_ERROR,
-                "|write_raw_object raw_object_mode disabled|track:%s/%s|subscribe_id:%ui|track_alias:%ui|",
-                track->track_info.track_namespace ? track->track_info.track_namespace : "null",
-                track->track_info.track_name ? track->track_info.track_name : "null",
+                "|write_raw_object raw_object_mode disabled|track:%s|subscribe_id:%ui|track_alias:%ui|",
+                xqc_moq_track_get_full_name(track),
                 track->subscribe_id, track->track_alias);
         return -XQC_EPARAM;
     }
@@ -419,9 +418,8 @@ xqc_moq_write_raw_object(xqc_moq_session_t *session,
 
         if (obj_msg.group_id < track->cur_group_id) {
             xqc_log(session->log, XQC_LOG_ERROR,
-                    "|write_raw_object invalid group_id rollback|track:%s/%s|cur_group_id:%ui|group_id:%ui|",
-                    track->track_info.track_namespace ? track->track_info.track_namespace : "null",
-                    track->track_info.track_name ? track->track_info.track_name : "null",
+                    "|write_raw_object invalid group_id rollback|track:%s|cur_group_id:%ui|group_id:%ui|",
+                    xqc_moq_track_get_full_name(track),
                     track->cur_group_id, obj_msg.group_id);
             return -XQC_EPARAM;
         }
@@ -437,9 +435,8 @@ xqc_moq_write_raw_object(xqc_moq_session_t *session,
 
         if (obj_msg.object_id < track->cur_object_id) {
             xqc_log(session->log, XQC_LOG_ERROR,
-                    "|write_raw_object invalid object_id rollback|track:%s/%s|group_id:%ui|cur_object_id:%ui|object_id:%ui|",
-                    track->track_info.track_namespace ? track->track_info.track_namespace : "null",
-                    track->track_info.track_name ? track->track_info.track_name : "null",
+                    "|write_raw_object invalid object_id rollback|track:%s|group_id:%ui|cur_object_id:%ui|object_id:%ui|",
+                    xqc_moq_track_get_full_name(track),
                     obj_msg.group_id, track->cur_object_id, obj_msg.object_id);
             return -XQC_EPARAM;
         }
@@ -772,8 +769,8 @@ xqc_moq_media_on_object(xqc_moq_session_t *session, xqc_moq_track_t *track, xqc_
 
             xqc_moq_video_frame_t *video_frame = &video_frame_ext.video_frame;
             xqc_log(session->log, XQC_LOG_INFO,
-                    "|decode video frame|track:%s/%s|alias:%ui|subscribe_id:%ui|payload_len:%ui|container:%d|codec:%s|mime:%s|",
-                    track->track_info.track_namespace, track->track_info.track_name,
+                    "|decode video frame|track:%s|alias:%ui|subscribe_id:%ui|payload_len:%ui|container:%d|codec:%s|mime:%s|",
+                    xqc_moq_track_get_full_name(track),
                     track->track_alias, track->subscribe_id, object->payload_len,
                     track->container_format,
                     track->track_info.selection_params.codec ?

--- a/moq/moq_transport/xqc_moq_message.c
+++ b/moq/moq_transport/xqc_moq_message.c
@@ -2435,9 +2435,18 @@ xqc_moq_msg_decode_subscribe_error(uint8_t *buf, size_t buf_len, uint8_t stream_
     xqc_int_t processed = 0;
     xqc_int_t ret = 0;
     xqc_int_t param_finish = 0;
+    uint64_t length = 0;
     xqc_moq_subscribe_error_msg_t *subscribe_error = (xqc_moq_subscribe_error_msg_t *)msg_base;
     switch (msg_ctx->cur_field_idx) {
-        case 0: //Subscribe ID (i)
+        case 0: //Length (16)
+            ret = xqc_moq_length_read(buf + processed, buf + buf_len, &length);
+            if (ret < 0) {
+                *wait_more_data = 1;
+                break;
+            }
+            processed += ret;
+            msg_ctx->cur_field_idx = 1;
+        case 1: //Subscribe ID (i)
             ret = xqc_vint_read(buf + processed, buf + buf_len, &subscribe_error->subscribe_id);
             if (ret < 0) {
                 *wait_more_data = 1;
@@ -2447,8 +2456,8 @@ xqc_moq_msg_decode_subscribe_error(uint8_t *buf, size_t buf_len, uint8_t stream_
 
             DEBUG_PRINTF("==>subscribe_id:%d\n",(int)subscribe_error->subscribe_id);
 
-            msg_ctx->cur_field_idx = 1;
-        case 1: //Error Code (i)
+            msg_ctx->cur_field_idx = 2;
+        case 2: //Error Code (i)
             ret = xqc_vint_read(buf + processed, buf + buf_len, &subscribe_error->error_code);
             if (ret < 0) {
                 *wait_more_data = 1;
@@ -2458,8 +2467,8 @@ xqc_moq_msg_decode_subscribe_error(uint8_t *buf, size_t buf_len, uint8_t stream_
 
             DEBUG_PRINTF("==>error_code:%d\n",(int)subscribe_error->error_code);
 
-            msg_ctx->cur_field_idx = 2;
-        case 2: //Reason Phrase (b)
+            msg_ctx->cur_field_idx = 3;
+        case 3: //Reason Phrase (b)
             if (subscribe_error->reason_phrase_len == 0) {
                 ret = xqc_vint_read(buf + processed, buf + buf_len, (uint64_t *)&subscribe_error->reason_phrase_len);
                 if (ret < 0) {
@@ -2492,8 +2501,8 @@ xqc_moq_msg_decode_subscribe_error(uint8_t *buf, size_t buf_len, uint8_t stream_
                 break;
             }
             DEBUG_PRINTF("==>reason_phrase:%s\n",subscribe_error->reason_phrase);
-            msg_ctx->cur_field_idx = 3;
-        case 3: //Track Alias (i)
+            msg_ctx->cur_field_idx = 4;
+        case 4: //Track Alias (i)
             ret = xqc_vint_read(buf + processed, buf + buf_len, &subscribe_error->track_alias);
             if (ret < 0) {
                 *wait_more_data = 1;

--- a/moq/moq_transport/xqc_moq_message.c
+++ b/moq/moq_transport/xqc_moq_message.c
@@ -16,13 +16,24 @@ static xqc_moq_msg_func_map_t moq_msg_func_map[] = {
     {XQC_MOQ_MSG_PUBLISH_OK,           xqc_moq_msg_create_publish_ok,       xqc_moq_msg_free_publish_ok      },
     {XQC_MOQ_MSG_PUBLISH_ERROR,        xqc_moq_msg_create_publish_error,    xqc_moq_msg_free_publish_error   },
     {XQC_MOQ_MSG_PUBLISH_DONE,         xqc_moq_msg_create_publish_done,     xqc_moq_msg_free_publish_done    },
-//    {XQC_MOQ_MSG_ANNOUNCE,             NULL,                                NULL                             },
-//    {XQC_MOQ_MSG_ANNOUNCE_OK,          NULL,                                NULL                             },
-//    {XQC_MOQ_MSG_ANNOUNCE_ERROR,       NULL,                                NULL                             },
-//    {XQC_MOQ_MSG_UNANNOUNCE,           NULL,                                NULL                             },
-//    {XQC_MOQ_MSG_UNSUBSCRIBE,          NULL,                                NULL                             },
-//    {XQC_MOQ_MSG_SUBSCRIBE_DONE,       NULL,                                NULL                             },
-//    {XQC_MOQ_MSG_ANNOUNCE_CANCEL,      NULL,                                NULL                             },
+    {XQC_MOQ_MSG_PUBLISH_NAMESPACE,        xqc_moq_msg_create_publish_namespace,
+                                          xqc_moq_msg_free_publish_namespace },
+    {XQC_MOQ_MSG_PUBLISH_NAMESPACE_OK,     xqc_moq_msg_create_publish_namespace_ok,
+                                          xqc_moq_msg_free_publish_namespace_ok },
+    {XQC_MOQ_MSG_PUBLISH_NAMESPACE_ERROR,  xqc_moq_msg_create_publish_namespace_error,
+                                          xqc_moq_msg_free_publish_namespace_error },
+    {XQC_MOQ_MSG_PUBLISH_NAMESPACE_DONE,   xqc_moq_msg_create_publish_namespace_done,
+                                          xqc_moq_msg_free_publish_namespace_done },
+    {XQC_MOQ_MSG_PUBLISH_NAMESPACE_CANCEL, xqc_moq_msg_create_publish_namespace_cancel,
+                                          xqc_moq_msg_free_publish_namespace_cancel },
+    {XQC_MOQ_MSG_SUBSCRIBE_NAMESPACE,       xqc_moq_msg_create_subscribe_namespace,
+                                           xqc_moq_msg_free_subscribe_namespace },
+    {XQC_MOQ_MSG_SUBSCRIBE_NAMESPACE_OK,    xqc_moq_msg_create_subscribe_namespace_ok,
+                                           xqc_moq_msg_free_subscribe_namespace_ok },
+    {XQC_MOQ_MSG_SUBSCRIBE_NAMESPACE_ERROR, xqc_moq_msg_create_subscribe_namespace_error,
+                                           xqc_moq_msg_free_subscribe_namespace_error },
+    {XQC_MOQ_MSG_UNSUBSCRIBE_NAMESPACE,     xqc_moq_msg_create_unsubscribe_namespace,
+                                           xqc_moq_msg_free_unsubscribe_namespace },
 //    {XQC_MOQ_MSG_TRACK_STATUS_REQUEST, NULL,                                NULL                             },
 //    {XQC_MOQ_MSG_TRACK_STATUS,         NULL,                                NULL                             },
 //    {XQC_MOQ_MSG_GOAWAY,               NULL,                                NULL                             },
@@ -138,6 +149,78 @@ const xqc_moq_msg_base_t publish_done_base = {
     .encode     = xqc_moq_msg_encode_publish_done,
     .decode     = xqc_moq_msg_decode_publish_done,
     .on_msg     = xqc_moq_on_publish_done,
+};
+
+const xqc_moq_msg_base_t publish_namespace_base = {
+    .type       = xqc_moq_msg_publish_namespace_type,
+    .encode_len = xqc_moq_msg_encode_publish_namespace_len,
+    .encode     = xqc_moq_msg_encode_publish_namespace,
+    .decode     = xqc_moq_msg_decode_publish_namespace,
+    .on_msg     = xqc_moq_on_publish_namespace,
+};
+
+const xqc_moq_msg_base_t publish_namespace_ok_base = {
+    .type       = xqc_moq_msg_publish_namespace_ok_type,
+    .encode_len = xqc_moq_msg_encode_publish_namespace_ok_len,
+    .encode     = xqc_moq_msg_encode_publish_namespace_ok,
+    .decode     = xqc_moq_msg_decode_publish_namespace_ok,
+    .on_msg     = xqc_moq_on_publish_namespace_ok,
+};
+
+const xqc_moq_msg_base_t publish_namespace_error_base = {
+    .type       = xqc_moq_msg_publish_namespace_error_type,
+    .encode_len = xqc_moq_msg_encode_publish_namespace_error_len,
+    .encode     = xqc_moq_msg_encode_publish_namespace_error,
+    .decode     = xqc_moq_msg_decode_publish_namespace_error,
+    .on_msg     = xqc_moq_on_publish_namespace_error,
+};
+
+const xqc_moq_msg_base_t publish_namespace_done_base = {
+    .type       = xqc_moq_msg_publish_namespace_done_type,
+    .encode_len = xqc_moq_msg_encode_publish_namespace_done_len,
+    .encode     = xqc_moq_msg_encode_publish_namespace_done,
+    .decode     = xqc_moq_msg_decode_publish_namespace_done,
+    .on_msg     = xqc_moq_on_publish_namespace_done,
+};
+
+const xqc_moq_msg_base_t publish_namespace_cancel_base = {
+    .type       = xqc_moq_msg_publish_namespace_cancel_type,
+    .encode_len = xqc_moq_msg_encode_publish_namespace_cancel_len,
+    .encode     = xqc_moq_msg_encode_publish_namespace_cancel,
+    .decode     = xqc_moq_msg_decode_publish_namespace_cancel,
+    .on_msg     = xqc_moq_on_publish_namespace_cancel,
+};
+
+const xqc_moq_msg_base_t subscribe_namespace_base = {
+    .type       = xqc_moq_msg_subscribe_namespace_type,
+    .encode_len = xqc_moq_msg_encode_subscribe_namespace_len,
+    .encode     = xqc_moq_msg_encode_subscribe_namespace,
+    .decode     = xqc_moq_msg_decode_subscribe_namespace,
+    .on_msg     = xqc_moq_on_subscribe_namespace,
+};
+
+const xqc_moq_msg_base_t subscribe_namespace_ok_base = {
+    .type       = xqc_moq_msg_subscribe_namespace_ok_type,
+    .encode_len = xqc_moq_msg_encode_subscribe_namespace_ok_len,
+    .encode     = xqc_moq_msg_encode_subscribe_namespace_ok,
+    .decode     = xqc_moq_msg_decode_subscribe_namespace_ok,
+    .on_msg     = xqc_moq_on_subscribe_namespace_ok,
+};
+
+const xqc_moq_msg_base_t subscribe_namespace_error_base = {
+    .type       = xqc_moq_msg_subscribe_namespace_error_type,
+    .encode_len = xqc_moq_msg_encode_subscribe_namespace_error_len,
+    .encode     = xqc_moq_msg_encode_subscribe_namespace_error,
+    .decode     = xqc_moq_msg_decode_subscribe_namespace_error,
+    .on_msg     = xqc_moq_on_subscribe_namespace_error,
+};
+
+const xqc_moq_msg_base_t unsubscribe_namespace_base = {
+    .type       = xqc_moq_msg_unsubscribe_namespace_type,
+    .encode_len = xqc_moq_msg_encode_unsubscribe_namespace_len,
+    .encode     = xqc_moq_msg_encode_unsubscribe_namespace,
+    .decode     = xqc_moq_msg_decode_unsubscribe_namespace,
+    .on_msg     = xqc_moq_on_unsubscribe_namespace,
 };
 
 const xqc_moq_msg_base_t object_stream_base = {
@@ -1339,6 +1422,62 @@ xqc_moq_msg_decode_server_setup_v14(uint8_t *buf, size_t buf_len, uint8_t stream
  * SUBSCRIBE Message
  */
 
+static xqc_int_t
+xqc_moq_track_namespace_tuple_encode_len(uint64_t track_namespace_num,
+    const xqc_moq_track_ns_field_t *track_namespace_tuple)
+{
+    xqc_int_t len = 0;
+
+    len += xqc_put_varint_len(track_namespace_num);
+    for (uint64_t i = 0; i < track_namespace_num; i++) {
+        len += xqc_put_varint_len(track_namespace_tuple[i].len);
+        len += track_namespace_tuple[i].len;
+    }
+    return len;
+}
+
+static uint8_t *
+xqc_moq_track_namespace_tuple_encode(uint8_t *p, uint64_t track_namespace_num,
+    const xqc_moq_track_ns_field_t *track_namespace_tuple)
+{
+    p = xqc_put_varint(p, track_namespace_num);
+    for (uint64_t i = 0; i < track_namespace_num; i++) {
+        p = xqc_put_varint(p, track_namespace_tuple[i].len);
+        if (track_namespace_tuple[i].len > 0 && track_namespace_tuple[i].data != NULL) {
+            xqc_memcpy(p, track_namespace_tuple[i].data, track_namespace_tuple[i].len);
+            p += track_namespace_tuple[i].len;
+        }
+    }
+    return p;
+}
+
+static xqc_int_t
+xqc_moq_track_namespace_tuple_validate_and_sum(uint64_t track_namespace_num,
+    const xqc_moq_track_ns_field_t *track_namespace_tuple, size_t *track_namespace_total_len)
+{
+    size_t total_len = 0;
+
+    if (track_namespace_tuple == NULL || track_namespace_num == 0 || track_namespace_total_len == NULL) {
+        return -XQC_EPARAM;
+    }
+    if (track_namespace_num > XQC_MOQ_MAX_NAMESPACE_TUPLE_ELEMS) {
+        return -XQC_ELIMIT;
+    }
+
+    for (uint64_t i = 0; i < track_namespace_num; i++) {
+        if (track_namespace_tuple[i].len > XQC_MOQ_MAX_NAME_LEN) {
+            return -XQC_ELIMIT;
+        }
+        if (total_len > XQC_MOQ_MAX_FULL_TRACK_NAME_LEN - track_namespace_tuple[i].len) {
+            return -XQC_ELIMIT;
+        }
+        total_len += track_namespace_tuple[i].len;
+    }
+
+    *track_namespace_total_len = total_len;
+    return XQC_OK;
+}
+
 void *
 xqc_moq_msg_create_subscribe()
 {
@@ -1354,7 +1493,18 @@ xqc_moq_msg_free_subscribe(void *msg)
         return;
     }
     xqc_moq_subscribe_msg_t *subscribe = (xqc_moq_subscribe_msg_t*)msg;
-    xqc_free(subscribe->track_namespace);
+    if (subscribe->track_namespace_tuple) {
+        for (uint64_t i = 0; i < subscribe->track_namespace_num; i++) {
+            if (subscribe->track_namespace_tuple[i].data) {
+                xqc_free(subscribe->track_namespace_tuple[i].data);
+                subscribe->track_namespace_tuple[i].data = NULL;
+                subscribe->track_namespace_tuple[i].len = 0;
+            }
+        }
+        xqc_free(subscribe->track_namespace_tuple);
+        subscribe->track_namespace_tuple = NULL;
+        subscribe->track_namespace_num = 0;
+    }
     xqc_free(subscribe->track_name);
     xqc_moq_msg_free_params(subscribe->params, subscribe->params_num);
     xqc_free(subscribe);
@@ -1377,14 +1527,21 @@ xqc_moq_msg_encode_subscribe_len(xqc_moq_msg_base_t *msg_base)
 {
     xqc_int_t len = 0;
     xqc_moq_subscribe_msg_t *subscribe = (xqc_moq_subscribe_msg_t*)msg_base;
+    size_t track_name_len = subscribe->track_name_len;
+
+    size_t track_namespace_len = 0;
+    if (xqc_moq_track_namespace_tuple_validate_and_sum(subscribe->track_namespace_num,
+            subscribe->track_namespace_tuple, &track_namespace_len) != XQC_OK)
+    {
+        return -XQC_EPARAM;
+    }
     len += xqc_put_varint_len(XQC_MOQ_MSG_SUBSCRIBE);
     len += XQC_MOQ_MSG_LENGTH_FIXED_SIZE;
     len += xqc_put_varint_len(subscribe->subscribe_id);
-    len += xqc_put_varint_len(subscribe->track_namespace_num ? subscribe->track_namespace_num : 1);
-    len += xqc_put_varint_len(subscribe->track_namespace_len);
-    len += subscribe->track_namespace_len;
-    len += xqc_put_varint_len(subscribe->track_name_len);
-    len += subscribe->track_name_len;
+    len += xqc_moq_track_namespace_tuple_encode_len(subscribe->track_namespace_num,
+                                                    subscribe->track_namespace_tuple);
+    len += xqc_put_varint_len(track_name_len);
+    len += track_name_len;
     len += XQC_MOQ_SUBSCRIBER_PRIORITY_FIXED_SIZE;
     len += XQC_MOQ_GROUP_ORDER_FIXED_SIZE;
     len += XQC_MOQ_FORWARD_FIXED_SIZE;
@@ -1408,6 +1565,26 @@ xqc_moq_msg_encode_subscribe(xqc_moq_msg_base_t *msg_base, uint8_t *buf, size_t 
 {
     xqc_int_t ret = 0;
     xqc_moq_subscribe_msg_t *subscribe = (xqc_moq_subscribe_msg_t*)msg_base;
+
+    if (subscribe->track_name_len > 0 && subscribe->track_name == NULL) {
+        return -XQC_EPARAM;
+    }
+    if (subscribe->track_name_len > XQC_MOQ_MAX_NAME_LEN) {
+        return -XQC_ELIMIT;
+    }
+    size_t track_name_len = subscribe->track_name_len;
+
+    size_t track_namespace_len = 0;
+    if (xqc_moq_track_namespace_tuple_validate_and_sum(subscribe->track_namespace_num,
+            subscribe->track_namespace_tuple, &track_namespace_len) != XQC_OK)
+    {
+        return -XQC_EPARAM;
+    }
+    subscribe->track_namespace_len = track_namespace_len;
+    if (track_namespace_len > XQC_MOQ_MAX_FULL_TRACK_NAME_LEN - track_name_len) {
+        return -XQC_ELIMIT;
+    }
+
     xqc_int_t length = xqc_moq_msg_encode_subscribe_len(msg_base);
     if (length > buf_cap) {
         return -XQC_EILLEGAL_FRAME;
@@ -1418,16 +1595,12 @@ xqc_moq_msg_encode_subscribe(xqc_moq_msg_base_t *msg_base, uint8_t *buf, size_t 
     p = xqc_put_varint(p, XQC_MOQ_MSG_SUBSCRIBE);
     p = xqc_moq_put_varint_length(p, length);
     p = xqc_put_varint(p, subscribe->subscribe_id);
-    p = xqc_put_varint(p, subscribe->track_namespace_num ? subscribe->track_namespace_num : 1);
-    p = xqc_put_varint(p, subscribe->track_namespace_len);
-    if (subscribe->track_namespace_len > 0) {
-        xqc_memcpy(p, subscribe->track_namespace, subscribe->track_namespace_len);
-        p += subscribe->track_namespace_len;
-    }
-    p = xqc_put_varint(p, subscribe->track_name_len);
-    if (subscribe->track_name_len > 0) {
-        xqc_memcpy(p, subscribe->track_name, subscribe->track_name_len);
-        p += subscribe->track_name_len;
+    p = xqc_moq_track_namespace_tuple_encode(p, subscribe->track_namespace_num,
+                                             subscribe->track_namespace_tuple);
+    p = xqc_put_varint(p, track_name_len);
+    if (track_name_len > 0) {
+        xqc_memcpy(p, subscribe->track_name, track_name_len);
+        p += track_name_len;
     }
     p = xqc_moq_put_u8(p, subscribe->subscriber_priority);
     p = xqc_moq_put_u8(p, subscribe->group_order);
@@ -1492,60 +1665,102 @@ xqc_moq_msg_decode_subscribe(uint8_t *buf, size_t buf_len, uint8_t stream_fin, x
                 }
                 processed += ret;
                 if (subscribe->track_namespace_num == 0) {
-                    return -XQC_EPARAM;
+                    return -MOQ_PROTOCOL_VIOLATION;
                 }
-                if (subscribe->track_namespace_num != 1) {
-                    return -XQC_EPARAM;
+                if (subscribe->track_namespace_num > XQC_MOQ_MAX_NAMESPACE_TUPLE_ELEMS) {
+                    return -MOQ_PROTOCOL_VIOLATION;
+                }
+                msg_ctx->cur_array_idx = 0;
+                msg_ctx->str_processed = 0;
+                msg_ctx->tuple_elem_len = 0;
+                msg_ctx->tuple_elem_len_ready = 0;
+                subscribe->track_namespace_len = 0;
+                if (subscribe->track_namespace_tuple == NULL) {
+                    subscribe->track_namespace_tuple =
+                        xqc_calloc(subscribe->track_namespace_num, sizeof(xqc_moq_track_ns_field_t));
+                    if (subscribe->track_namespace_tuple == NULL) {
+                        return -XQC_EMALLOC;
+                    }
                 }
             }
             msg_ctx->cur_field_idx = 3;
-        case 3: //Track Namespace (b)
-            if (subscribe->track_namespace_len == 0) {
-                ret = xqc_vint_read(buf + processed, buf + buf_len, (uint64_t *)&subscribe->track_namespace_len);
-                if (ret < 0) {
+        case 3: //Track Namespace (tuple)
+            for (; msg_ctx->cur_array_idx < subscribe->track_namespace_num; msg_ctx->cur_array_idx++) {
+                xqc_moq_track_ns_field_t *field =
+                    &subscribe->track_namespace_tuple[msg_ctx->cur_array_idx];
+
+                if (!msg_ctx->tuple_elem_len_ready) {
+                    ret = xqc_vint_read(buf + processed, buf + buf_len, &msg_ctx->tuple_elem_len);
+                    if (ret < 0) {
+                        *wait_more_data = 1;
+                        break;
+                    }
+                    processed += ret;
+                    msg_ctx->tuple_elem_len_ready = 1;
+                    if (msg_ctx->tuple_elem_len > XQC_MOQ_MAX_NAME_LEN) {
+                        return -XQC_ELIMIT;
+                    }
+                    field->len = msg_ctx->tuple_elem_len;
+                    if (subscribe->track_namespace_len > XQC_MOQ_MAX_FULL_TRACK_NAME_LEN - field->len) {
+                        return -MOQ_PROTOCOL_VIOLATION;
+                    }
+                    subscribe->track_namespace_len += field->len;
+                    if (field->data == NULL && field->len > 0) {
+                        field->data = xqc_calloc(1, field->len + 1);
+                        if (field->data == NULL) {
+                            return -XQC_EMALLOC;
+                        }
+                    }
+                }
+
+                if (processed == buf_len) {
                     *wait_more_data = 1;
                     break;
                 }
-                DEBUG_PRINTF("==>namespace_len:%d\n",(int)subscribe->track_namespace_len);
-                processed += ret;
-            }
-            if (subscribe->track_namespace == NULL) {
-                if (subscribe->track_namespace_len > XQC_MOQ_MAX_NAME_LEN) {
-                    return -XQC_ELIMIT;
+
+                size_t field_remaining = (msg_ctx->tuple_elem_len - msg_ctx->str_processed);
+                size_t buf_remaining = buf_len - processed;
+                size_t copy_len = field_remaining < buf_remaining ? field_remaining : buf_remaining;
+
+                if (copy_len > 0 && field->data != NULL) {
+                    xqc_memcpy(field->data + msg_ctx->str_processed, buf + processed, copy_len);
+                    msg_ctx->str_processed += copy_len;
+                    processed += copy_len;
                 }
-                subscribe->track_namespace = xqc_calloc(1, subscribe->track_namespace_len + 1);
+
+                if (msg_ctx->str_processed < msg_ctx->tuple_elem_len) {
+                    *wait_more_data = 1;
+                    break;
+                }
+
+                msg_ctx->str_processed = 0;
+                msg_ctx->tuple_elem_len_ready = 0;
+                msg_ctx->tuple_elem_len = 0;
             }
-            if (processed == buf_len) {
-                *wait_more_data = 1;
-                break;
-            } else if (subscribe->track_namespace_len - msg_ctx->str_processed <= buf_len - processed) {
-                xqc_memcpy(subscribe->track_namespace + msg_ctx->str_processed, buf + processed,
-                           subscribe->track_namespace_len - msg_ctx->str_processed);
-                processed += subscribe->track_namespace_len - msg_ctx->str_processed;
-                msg_ctx->str_processed = 0; //track_namespace finish
-            } else {
-                xqc_memcpy(subscribe->track_namespace + msg_ctx->str_processed, buf + processed,
-                           buf_len - processed);
-                msg_ctx->str_processed += buf_len - processed;
-                processed += buf_len - processed;
-                *wait_more_data = 1;
+
+            if (*wait_more_data == 1) {
                 break;
             }
-            DEBUG_PRINTF("==>track_namespace:%s\n",subscribe->track_namespace);
+
             msg_ctx->cur_field_idx = 4;
         case 4: //Track Name (b)
             if (subscribe->track_name_len == 0) {
-                ret = xqc_vint_read(buf + processed, buf + buf_len, (uint64_t *)&subscribe->track_name_len);
+                uint64_t track_name_len = 0;
+                ret = xqc_vint_read(buf + processed, buf + buf_len, &track_name_len);
                 if (ret < 0) {
                     *wait_more_data = 1;
                     break;
                 }
+                subscribe->track_name_len = track_name_len;
                 DEBUG_PRINTF("==>name_len:%d\n",(int)subscribe->track_name_len);
                 processed += ret;
             }
             if (subscribe->track_name == NULL) {
                 if (subscribe->track_name_len > XQC_MOQ_MAX_NAME_LEN) {
                     return -XQC_ELIMIT;
+                }
+                if (subscribe->track_namespace_len > XQC_MOQ_MAX_FULL_TRACK_NAME_LEN - subscribe->track_name_len) {
+                    return -MOQ_PROTOCOL_VIOLATION;
                 }
                 subscribe->track_name = xqc_calloc(1, subscribe->track_name_len + 1);
             }
@@ -2313,8 +2528,18 @@ xqc_moq_msg_free_publish(void *msg)
         return;
     }
     xqc_moq_publish_msg_t *publish = (xqc_moq_publish_msg_t*)msg;
-    xqc_free(publish->track_namespace);
-    publish->track_namespace = NULL;
+    if (publish->track_namespace_tuple) {
+        for (uint64_t i = 0; i < publish->track_namespace_num; i++) {
+            if (publish->track_namespace_tuple[i].data) {
+                xqc_free(publish->track_namespace_tuple[i].data);
+                publish->track_namespace_tuple[i].data = NULL;
+                publish->track_namespace_tuple[i].len = 0;
+            }
+        }
+        xqc_free(publish->track_namespace_tuple);
+        publish->track_namespace_tuple = NULL;
+        publish->track_namespace_num = 0;
+    }
     xqc_free(publish->track_name);
     publish->track_name = NULL;
     xqc_moq_msg_free_params(publish->params, publish->params_num);
@@ -2339,14 +2564,21 @@ xqc_moq_msg_encode_publish_len(xqc_moq_msg_base_t *msg_base)
 {
     xqc_int_t len = 0;
     xqc_moq_publish_msg_t *publish = (xqc_moq_publish_msg_t*)msg_base;
+    size_t track_name_len = publish->track_name_len;
+
+    size_t track_namespace_len = 0;
+    if (xqc_moq_track_namespace_tuple_validate_and_sum(publish->track_namespace_num,
+            publish->track_namespace_tuple, &track_namespace_len) != XQC_OK)
+    {
+        return -XQC_EPARAM;
+    }
     len += xqc_put_varint_len(XQC_MOQ_MSG_PUBLISH);
     len += XQC_MOQ_MSG_LENGTH_FIXED_SIZE;
     len += xqc_put_varint_len(publish->subscribe_id);
-    len += xqc_put_varint_len(1); /* tuple element count */
-    len += xqc_put_varint_len(publish->track_namespace_len);
-    len += publish->track_namespace_len;
-    len += xqc_put_varint_len(publish->track_name_len);
-    len += publish->track_name_len;
+    len += xqc_moq_track_namespace_tuple_encode_len(publish->track_namespace_num,
+                                                    publish->track_namespace_tuple);
+    len += xqc_put_varint_len(track_name_len);
+    len += track_name_len;
     len += xqc_put_varint_len(publish->track_alias);
     len += XQC_MOQ_GROUP_ORDER_FIXED_SIZE;
     len += XQC_MOQ_CONTENT_EXIST_FIXED_SIZE;
@@ -2365,6 +2597,26 @@ xqc_moq_msg_encode_publish(xqc_moq_msg_base_t *msg_base, uint8_t *buf, size_t bu
 {
     xqc_int_t ret = 0;
     xqc_moq_publish_msg_t *publish = (xqc_moq_publish_msg_t*)msg_base;
+
+    if (publish->track_name_len > 0 && publish->track_name == NULL) {
+        return -XQC_EPARAM;
+    }
+    if (publish->track_name_len > XQC_MOQ_MAX_NAME_LEN) {
+        return -XQC_ELIMIT;
+    }
+    xqc_int_t track_name_len = publish->track_name_len;
+
+    size_t track_namespace_len = 0;
+    if (xqc_moq_track_namespace_tuple_validate_and_sum(publish->track_namespace_num,
+            publish->track_namespace_tuple, &track_namespace_len) != XQC_OK)
+    {
+        return -XQC_EPARAM;
+    }
+    publish->track_namespace_len = track_namespace_len;
+    if (track_namespace_len > XQC_MOQ_MAX_FULL_TRACK_NAME_LEN - (size_t)track_name_len) {
+        return -XQC_ELIMIT;
+    }
+
     xqc_int_t length = xqc_moq_msg_encode_publish_len(msg_base);
     if (length > buf_cap) {
         return -XQC_EILLEGAL_FRAME;
@@ -2375,13 +2627,13 @@ xqc_moq_msg_encode_publish(xqc_moq_msg_base_t *msg_base, uint8_t *buf, size_t bu
     p = xqc_put_varint(p, XQC_MOQ_MSG_PUBLISH);
     p = xqc_moq_put_varint_length(p, length);
     p = xqc_put_varint(p, publish->subscribe_id);
-    p = xqc_put_varint(p, 1); /* tuple element count */
-    p = xqc_put_varint(p, publish->track_namespace_len);
-    xqc_memcpy(p, publish->track_namespace, publish->track_namespace_len);
-    p += publish->track_namespace_len;
-    p = xqc_put_varint(p, publish->track_name_len);
-    xqc_memcpy(p, publish->track_name, publish->track_name_len);
-    p += publish->track_name_len;
+    p = xqc_moq_track_namespace_tuple_encode(p, publish->track_namespace_num,
+                                             publish->track_namespace_tuple);
+    p = xqc_put_varint(p, track_name_len);
+    if (track_name_len > 0) {
+        xqc_memcpy(p, publish->track_name, track_name_len);
+        p += track_name_len;
+    }
     p = xqc_put_varint(p, publish->track_alias);
     p = xqc_moq_put_u8(p, publish->group_order);
     p = xqc_moq_put_u8(p, publish->content_exist);
@@ -2438,53 +2690,99 @@ xqc_moq_msg_decode_publish(uint8_t *buf, size_t buf_len, uint8_t stream_fin, xqc
                     break;
                 }
                 processed += ret;
-                if (publish->track_namespace_num == 0 || publish->track_namespace_num != 1) {
-                    return -XQC_EILLEGAL_FRAME;
+                if (publish->track_namespace_num == 0) {
+                    return -MOQ_PROTOCOL_VIOLATION;
+                }
+                if (publish->track_namespace_num > XQC_MOQ_MAX_NAMESPACE_TUPLE_ELEMS) {
+                    return -MOQ_PROTOCOL_VIOLATION;
+                }
+                msg_ctx->cur_array_idx = 0;
+                msg_ctx->str_processed = 0;
+                msg_ctx->tuple_elem_len = 0;
+                msg_ctx->tuple_elem_len_ready = 0;
+                publish->track_namespace_len = 0;
+                if (publish->track_namespace_tuple == NULL) {
+                    publish->track_namespace_tuple =
+                        xqc_calloc(publish->track_namespace_num, sizeof(xqc_moq_track_ns_field_t));
+                    if (publish->track_namespace_tuple == NULL) {
+                        return -XQC_EMALLOC;
+                    }
                 }
             }
-            if (publish->track_namespace_len == 0) {
-                ret = xqc_vint_read(buf + processed, buf + buf_len, (uint64_t*)&publish->track_namespace_len);
-                if (ret < 0) {
+            for (; msg_ctx->cur_array_idx < publish->track_namespace_num; msg_ctx->cur_array_idx++) {
+                xqc_moq_track_ns_field_t *field =
+                    &publish->track_namespace_tuple[msg_ctx->cur_array_idx];
+
+                if (!msg_ctx->tuple_elem_len_ready) {
+                    ret = xqc_vint_read(buf + processed, buf + buf_len, &msg_ctx->tuple_elem_len);
+                    if (ret < 0) {
+                        *wait_more_data = 1;
+                        break;
+                    }
+                    processed += ret;
+                    msg_ctx->tuple_elem_len_ready = 1;
+                    if (msg_ctx->tuple_elem_len > XQC_MOQ_MAX_NAME_LEN) {
+                        return -XQC_ELIMIT;
+                    }
+                    field->len = msg_ctx->tuple_elem_len;
+                    if (publish->track_namespace_len > XQC_MOQ_MAX_FULL_TRACK_NAME_LEN - field->len) {
+                        return -MOQ_PROTOCOL_VIOLATION;
+                    }
+                    publish->track_namespace_len += field->len;
+                    if (field->data == NULL && field->len > 0) {
+                        field->data = xqc_calloc(1, field->len + 1);
+                        if (field->data == NULL) {
+                            return -XQC_EMALLOC;
+                        }
+                    }
+                }
+
+                if (processed == buf_len) {
                     *wait_more_data = 1;
                     break;
                 }
-                processed += ret;
-            }
-            if (publish->track_namespace == NULL) {
-                if (publish->track_namespace_len == 0 || publish->track_namespace_len > XQC_MOQ_MAX_NAME_LEN) {
-                    return -XQC_ELIMIT;
+
+                xqc_int_t field_remaining = msg_ctx->tuple_elem_len - msg_ctx->str_processed;
+                xqc_int_t buf_remaining = buf_len - processed;
+                xqc_int_t copy_len = field_remaining < buf_remaining ? field_remaining : buf_remaining;
+
+                if (copy_len > 0 && field->data != NULL) {
+                    xqc_memcpy(field->data + msg_ctx->str_processed, buf + processed, copy_len);
+                    msg_ctx->str_processed += copy_len;
+                    processed += copy_len;
                 }
-                publish->track_namespace = xqc_calloc(1, publish->track_namespace_len + 1);
-            }
-            if (processed == buf_len) {
-                *wait_more_data = 1;
-                break;
-            } else if (publish->track_namespace_len - msg_ctx->str_processed <= buf_len - processed) {
-                xqc_memcpy(publish->track_namespace + msg_ctx->str_processed, buf + processed,
-                           publish->track_namespace_len - msg_ctx->str_processed);
-                processed += publish->track_namespace_len - msg_ctx->str_processed;
+
+                if (msg_ctx->str_processed < msg_ctx->tuple_elem_len) {
+                    *wait_more_data = 1;
+                    break;
+                }
+
                 msg_ctx->str_processed = 0;
-            } else {
-                xqc_memcpy(publish->track_namespace + msg_ctx->str_processed, buf + processed,
-                           buf_len - processed);
-                msg_ctx->str_processed += buf_len - processed;
-                processed += buf_len - processed;
-                *wait_more_data = 1;
+                msg_ctx->tuple_elem_len_ready = 0;
+                msg_ctx->tuple_elem_len = 0;
+            }
+
+            if (*wait_more_data == 1) {
                 break;
             }
             msg_ctx->cur_field_idx = 3;
         case 3: //Track Name (b)
             if (publish->track_name_len == 0) {
-                ret = xqc_vint_read(buf + processed, buf + buf_len, (uint64_t*)&publish->track_name_len);
+                uint64_t track_name_len = 0;
+                ret = xqc_vint_read(buf + processed, buf + buf_len, &track_name_len);
                 if (ret < 0) {
                     *wait_more_data = 1;
                     break;
                 }
+                publish->track_name_len = track_name_len;
                 processed += ret;
             }
             if (publish->track_name == NULL) {
                 if (publish->track_name_len == 0 || publish->track_name_len > XQC_MOQ_MAX_NAME_LEN) {
                     return -XQC_ELIMIT;
+                }
+                if (publish->track_namespace_len > XQC_MOQ_MAX_FULL_TRACK_NAME_LEN - publish->track_name_len) {
+                    return -MOQ_PROTOCOL_VIOLATION;
                 }
                 publish->track_name = xqc_calloc(1, publish->track_name_len + 1);
             }
@@ -2919,11 +3217,13 @@ xqc_moq_msg_decode_publish_error(uint8_t *buf, size_t buf_len, uint8_t stream_fi
             msg_ctx->cur_field_idx = 2;
         case 2: //Reason Phrase (b)
             if (publish_error->reason_phrase_len == 0) {
-                ret = xqc_vint_read(buf + processed, buf + buf_len, (uint64_t*)&publish_error->reason_phrase_len);
+                uint64_t reason_phrase_len = 0;
+                ret = xqc_vint_read(buf + processed, buf + buf_len, &reason_phrase_len);
                 if (ret < 0) {
                     *wait_more_data = 1;
                     break;
                 }
+                publish_error->reason_phrase_len = reason_phrase_len;
                 processed += ret;
             }
             if (publish_error->reason_phrase == NULL) {
@@ -3076,11 +3376,13 @@ xqc_moq_msg_decode_publish_done(uint8_t *buf, size_t buf_len, uint8_t stream_fin
             msg_ctx->cur_field_idx = 4;
         case 4: //Reason Phrase (b)
             if (publish_done->reason_phrase_len == 0) {
-                ret = xqc_vint_read(buf + processed, buf + buf_len, (uint64_t*)&publish_done->reason_phrase_len);
+                uint64_t reason_phrase_len = 0;
+                ret = xqc_vint_read(buf + processed, buf + buf_len, &reason_phrase_len);
                 if (ret < 0) {
                     *wait_more_data = 1;
                     break;
                 }
+                publish_done->reason_phrase_len = reason_phrase_len;
                 processed += ret;
             }
             if (publish_done->reason_phrase == NULL) {
@@ -3105,6 +3407,1725 @@ xqc_moq_msg_decode_publish_done(uint8_t *buf, size_t buf_len, uint8_t stream_fin
                 *wait_more_data = 1;
                 break;
             }
+            *finish = 1;
+            break;
+        default:
+            return -XQC_EILLEGAL_FRAME;
+    }
+
+    return processed;
+}
+
+/**
+ * PUBLISH_NAMESPACE Message
+ */
+
+void *
+xqc_moq_msg_create_publish_namespace()
+{
+    xqc_moq_publish_namespace_msg_t *msg = xqc_calloc(1, sizeof(*msg));
+    xqc_moq_msg_publish_namespace_init_handler(&msg->msg_base);
+    return msg;
+}
+
+void
+xqc_moq_msg_free_publish_namespace(void *msg)
+{
+    if (msg == NULL) {
+        return;
+    }
+    xqc_moq_publish_namespace_msg_t *publish_namespace = (xqc_moq_publish_namespace_msg_t *)msg;
+    if (publish_namespace->track_namespace_tuple) {
+        for (uint64_t i = 0; i < publish_namespace->track_namespace_num; i++) {
+            if (publish_namespace->track_namespace_tuple[i].data) {
+                xqc_free(publish_namespace->track_namespace_tuple[i].data);
+                publish_namespace->track_namespace_tuple[i].data = NULL;
+                publish_namespace->track_namespace_tuple[i].len = 0;
+            }
+        }
+        xqc_free(publish_namespace->track_namespace_tuple);
+        publish_namespace->track_namespace_tuple = NULL;
+        publish_namespace->track_namespace_num = 0;
+    }
+    xqc_moq_msg_free_params(publish_namespace->params, publish_namespace->params_num);
+    xqc_free(publish_namespace);
+}
+
+xqc_moq_msg_type_t
+xqc_moq_msg_publish_namespace_type()
+{
+    return XQC_MOQ_MSG_PUBLISH_NAMESPACE;
+}
+
+void
+xqc_moq_msg_publish_namespace_init_handler(xqc_moq_msg_base_t *msg_base)
+{
+    *msg_base = publish_namespace_base;
+}
+
+xqc_int_t
+xqc_moq_msg_encode_publish_namespace_len(xqc_moq_msg_base_t *msg_base)
+{
+    xqc_int_t len = 0;
+    xqc_moq_publish_namespace_msg_t *publish_namespace = (xqc_moq_publish_namespace_msg_t *)msg_base;
+    size_t track_namespace_len = 0;
+    if (xqc_moq_track_namespace_tuple_validate_and_sum(publish_namespace->track_namespace_num,
+            publish_namespace->track_namespace_tuple, &track_namespace_len) != XQC_OK)
+    {
+        return -XQC_EPARAM;
+    }
+
+    len += xqc_put_varint_len(XQC_MOQ_MSG_PUBLISH_NAMESPACE);
+    len += XQC_MOQ_MSG_LENGTH_FIXED_SIZE;
+    len += xqc_put_varint_len(publish_namespace->request_id);
+    len += xqc_moq_track_namespace_tuple_encode_len(publish_namespace->track_namespace_num,
+                                                    publish_namespace->track_namespace_tuple);
+    len += xqc_put_varint_len(publish_namespace->params_num);
+    len += xqc_moq_msg_encode_params_len_v14(publish_namespace->params, publish_namespace->params_num);
+    return len;
+}
+
+xqc_int_t
+xqc_moq_msg_encode_publish_namespace(xqc_moq_msg_base_t *msg_base, uint8_t *buf, size_t buf_cap)
+{
+    xqc_int_t ret = 0;
+    xqc_moq_publish_namespace_msg_t *publish_namespace = (xqc_moq_publish_namespace_msg_t *)msg_base;
+    size_t track_namespace_len = 0;
+    if (xqc_moq_track_namespace_tuple_validate_and_sum(publish_namespace->track_namespace_num,
+            publish_namespace->track_namespace_tuple, &track_namespace_len) != XQC_OK)
+    {
+        return -XQC_EPARAM;
+    }
+    publish_namespace->track_namespace_len = track_namespace_len;
+
+    xqc_int_t length = xqc_moq_msg_encode_publish_namespace_len(msg_base);
+    if (length > buf_cap) {
+        return -XQC_EILLEGAL_FRAME;
+    }
+
+    length = length - xqc_put_varint_len(XQC_MOQ_MSG_PUBLISH_NAMESPACE) - XQC_MOQ_MSG_LENGTH_FIXED_SIZE;
+    uint8_t *p = buf;
+    p = xqc_put_varint(p, XQC_MOQ_MSG_PUBLISH_NAMESPACE);
+    p = xqc_moq_put_varint_length(p, length);
+    p = xqc_put_varint(p, publish_namespace->request_id);
+    p = xqc_moq_track_namespace_tuple_encode(p, publish_namespace->track_namespace_num,
+                                             publish_namespace->track_namespace_tuple);
+    p = xqc_put_varint(p, publish_namespace->params_num);
+    ret = xqc_moq_msg_encode_params_v14(publish_namespace->params, publish_namespace->params_num,
+                                        p, buf + buf_cap - p);
+    if (ret < 0) {
+        return ret;
+    }
+    p += ret;
+    return p - buf;
+}
+
+xqc_int_t
+xqc_moq_msg_decode_publish_namespace(uint8_t *buf, size_t buf_len, uint8_t stream_fin,
+    xqc_moq_decode_msg_ctx_t *msg_ctx, xqc_moq_msg_base_t *msg_base,
+    xqc_int_t *finish, xqc_int_t *wait_more_data)
+{
+    *finish = 0;
+    *wait_more_data = 0;
+    xqc_int_t processed = 0;
+    xqc_int_t ret = 0;
+    xqc_int_t param_finish = 0;
+    uint64_t length = 0;
+    xqc_moq_publish_namespace_msg_t *publish_namespace = (xqc_moq_publish_namespace_msg_t *)msg_base;
+    xqc_moq_decode_params_ctx_t *params_ctx = &msg_ctx->decode_params_ctx;
+
+    switch (msg_ctx->cur_field_idx) {
+        case 0: /* Length (16) */
+            ret = xqc_moq_length_read(buf + processed, buf + buf_len, &length);
+            if (ret < 0) {
+                *wait_more_data = 1;
+                break;
+            }
+            processed += ret;
+            msg_ctx->cur_field_idx = 1;
+        case 1: /* Request ID (i) */
+            ret = xqc_vint_read(buf + processed, buf + buf_len, &publish_namespace->request_id);
+            if (ret < 0) {
+                *wait_more_data = 1;
+                break;
+            }
+            processed += ret;
+            msg_ctx->cur_field_idx = 2;
+        case 2: /* Track Namespace tuple count */
+            if (publish_namespace->track_namespace_num == 0) {
+                ret = xqc_vint_read(buf + processed, buf + buf_len, &publish_namespace->track_namespace_num);
+                if (ret < 0) {
+                    *wait_more_data = 1;
+                    break;
+                }
+                processed += ret;
+                if (publish_namespace->track_namespace_num == 0) {
+                    return -MOQ_PROTOCOL_VIOLATION;
+                }
+                if (publish_namespace->track_namespace_num > XQC_MOQ_MAX_NAMESPACE_TUPLE_ELEMS) {
+                    return -MOQ_PROTOCOL_VIOLATION;
+                }
+                msg_ctx->cur_array_idx = 0;
+                msg_ctx->str_processed = 0;
+                msg_ctx->tuple_elem_len = 0;
+                msg_ctx->tuple_elem_len_ready = 0;
+                publish_namespace->track_namespace_len = 0;
+                if (publish_namespace->track_namespace_tuple == NULL) {
+                    publish_namespace->track_namespace_tuple =
+                        xqc_calloc(publish_namespace->track_namespace_num, sizeof(xqc_moq_track_ns_field_t));
+                    if (publish_namespace->track_namespace_tuple == NULL) {
+                        return -XQC_EMALLOC;
+                    }
+                }
+            }
+            msg_ctx->cur_field_idx = 3;
+        case 3: /* Track Namespace (tuple) */
+            for (; msg_ctx->cur_array_idx < publish_namespace->track_namespace_num; msg_ctx->cur_array_idx++) {
+                xqc_moq_track_ns_field_t *field =
+                    &publish_namespace->track_namespace_tuple[msg_ctx->cur_array_idx];
+
+                if (!msg_ctx->tuple_elem_len_ready) {
+                    ret = xqc_vint_read(buf + processed, buf + buf_len, &msg_ctx->tuple_elem_len);
+                    if (ret < 0) {
+                        *wait_more_data = 1;
+                        break;
+                    }
+                    processed += ret;
+                    msg_ctx->tuple_elem_len_ready = 1;
+                    if (msg_ctx->tuple_elem_len > XQC_MOQ_MAX_NAME_LEN) {
+                        return -XQC_ELIMIT;
+                    }
+                    field->len = msg_ctx->tuple_elem_len;
+                    if (publish_namespace->track_namespace_len
+                        > XQC_MOQ_MAX_FULL_TRACK_NAME_LEN - field->len)
+                    {
+                        return -MOQ_PROTOCOL_VIOLATION;
+                    }
+                    publish_namespace->track_namespace_len += field->len;
+                    if (field->data == NULL && field->len > 0) {
+                        field->data = xqc_calloc(1, field->len + 1);
+                        if (field->data == NULL) {
+                            return -XQC_EMALLOC;
+                        }
+                    }
+                }
+
+                if (processed == buf_len) {
+                    *wait_more_data = 1;
+                    break;
+                }
+
+                size_t field_remaining = (msg_ctx->tuple_elem_len - msg_ctx->str_processed);
+                size_t buf_remaining = buf_len - processed;
+                size_t copy_len = field_remaining < buf_remaining ? field_remaining : buf_remaining;
+
+                if (copy_len > 0 && field->data != NULL) {
+                    xqc_memcpy(field->data + msg_ctx->str_processed, buf + processed, copy_len);
+                    msg_ctx->str_processed += copy_len;
+                    processed += copy_len;
+                }
+
+                if (msg_ctx->str_processed < msg_ctx->tuple_elem_len) {
+                    *wait_more_data = 1;
+                    break;
+                }
+
+                msg_ctx->str_processed = 0;
+                msg_ctx->tuple_elem_len_ready = 0;
+                msg_ctx->tuple_elem_len = 0;
+            }
+
+            if (*wait_more_data == 1) {
+                break;
+            }
+
+            msg_ctx->cur_field_idx = 4;
+        case 4: /* Number of Parameters (i) */
+            if (publish_namespace->params_num == 0) {
+                ret = xqc_vint_read(buf + processed, buf + buf_len, &publish_namespace->params_num);
+                if (ret < 0) {
+                    *wait_more_data = 1;
+                    break;
+                }
+                processed += ret;
+                if (publish_namespace->params_num == 0) {
+                    *finish = 1;
+                    break;
+                }
+                if (publish_namespace->params_num > XQC_MOQ_MAX_PARAMS) {
+                    return -XQC_ELIMIT;
+                }
+                publish_namespace->params = xqc_moq_msg_alloc_params(publish_namespace->params_num);
+                if (publish_namespace->params == NULL) {
+                    return -XQC_EMALLOC;
+                }
+            }
+            msg_ctx->cur_field_idx = 5;
+        case 5:
+            ret = xqc_moq_msg_decode_params_v14(buf + processed, buf_len - processed, params_ctx,
+                                                publish_namespace->params, publish_namespace->params_num,
+                                                &param_finish, wait_more_data);
+            if (ret < 0) {
+                return ret;
+            }
+            processed += ret;
+            if (*wait_more_data == 1) {
+                break;
+            }
+            if (param_finish == 1) {
+                *finish = 1;
+            }
+            break;
+        default:
+            return -XQC_EILLEGAL_FRAME;
+    }
+
+    return processed;
+}
+
+/**
+ * PUBLISH_NAMESPACE_OK Message
+ */
+
+void *
+xqc_moq_msg_create_publish_namespace_ok()
+{
+    xqc_moq_publish_namespace_ok_msg_t *msg = xqc_calloc(1, sizeof(*msg));
+    xqc_moq_msg_publish_namespace_ok_init_handler(&msg->msg_base);
+    return msg;
+}
+
+void
+xqc_moq_msg_free_publish_namespace_ok(void *msg)
+{
+    xqc_free(msg);
+}
+
+xqc_moq_msg_type_t
+xqc_moq_msg_publish_namespace_ok_type()
+{
+    return XQC_MOQ_MSG_PUBLISH_NAMESPACE_OK;
+}
+
+void
+xqc_moq_msg_publish_namespace_ok_init_handler(xqc_moq_msg_base_t *msg_base)
+{
+    *msg_base = publish_namespace_ok_base;
+}
+
+xqc_int_t
+xqc_moq_msg_encode_publish_namespace_ok_len(xqc_moq_msg_base_t *msg_base)
+{
+    xqc_int_t len = 0;
+    xqc_moq_publish_namespace_ok_msg_t *ok = (xqc_moq_publish_namespace_ok_msg_t *)msg_base;
+    len += xqc_put_varint_len(XQC_MOQ_MSG_PUBLISH_NAMESPACE_OK);
+    len += XQC_MOQ_MSG_LENGTH_FIXED_SIZE;
+    len += xqc_put_varint_len(ok->request_id);
+    return len;
+}
+
+xqc_int_t
+xqc_moq_msg_encode_publish_namespace_ok(xqc_moq_msg_base_t *msg_base, uint8_t *buf, size_t buf_cap)
+{
+    xqc_moq_publish_namespace_ok_msg_t *ok = (xqc_moq_publish_namespace_ok_msg_t *)msg_base;
+    xqc_int_t length = xqc_moq_msg_encode_publish_namespace_ok_len(msg_base);
+    if (length > buf_cap) {
+        return -XQC_EILLEGAL_FRAME;
+    }
+    length = length - xqc_put_varint_len(XQC_MOQ_MSG_PUBLISH_NAMESPACE_OK) - XQC_MOQ_MSG_LENGTH_FIXED_SIZE;
+    uint8_t *p = buf;
+    p = xqc_put_varint(p, XQC_MOQ_MSG_PUBLISH_NAMESPACE_OK);
+    p = xqc_moq_put_varint_length(p, length);
+    p = xqc_put_varint(p, ok->request_id);
+    return p - buf;
+}
+
+xqc_int_t
+xqc_moq_msg_decode_publish_namespace_ok(uint8_t *buf, size_t buf_len, uint8_t stream_fin,
+    xqc_moq_decode_msg_ctx_t *msg_ctx, xqc_moq_msg_base_t *msg_base,
+    xqc_int_t *finish, xqc_int_t *wait_more_data)
+{
+    *finish = 0;
+    *wait_more_data = 0;
+    xqc_int_t processed = 0;
+    xqc_int_t ret = 0;
+    uint64_t length = 0;
+    xqc_moq_publish_namespace_ok_msg_t *ok = (xqc_moq_publish_namespace_ok_msg_t *)msg_base;
+
+    switch (msg_ctx->cur_field_idx) {
+        case 0:
+            ret = xqc_moq_length_read(buf + processed, buf + buf_len, &length);
+            if (ret < 0) {
+                *wait_more_data = 1;
+                break;
+            }
+            processed += ret;
+            msg_ctx->cur_field_idx = 1;
+        case 1:
+            ret = xqc_vint_read(buf + processed, buf + buf_len, &ok->request_id);
+            if (ret < 0) {
+                *wait_more_data = 1;
+                break;
+            }
+            processed += ret;
+            *finish = 1;
+            break;
+        default:
+            return -XQC_EILLEGAL_FRAME;
+    }
+
+    return processed;
+}
+
+/**
+ * PUBLISH_NAMESPACE_ERROR Message
+ */
+
+void *
+xqc_moq_msg_create_publish_namespace_error()
+{
+    xqc_moq_publish_namespace_error_msg_t *msg = xqc_calloc(1, sizeof(*msg));
+    xqc_moq_msg_publish_namespace_error_init_handler(&msg->msg_base);
+    return msg;
+}
+
+void
+xqc_moq_msg_free_publish_namespace_error(void *msg)
+{
+    if (msg == NULL) {
+        return;
+    }
+    xqc_moq_publish_namespace_error_msg_t *err = (xqc_moq_publish_namespace_error_msg_t *)msg;
+    xqc_free(err->reason_phrase);
+    xqc_free(err);
+}
+
+xqc_moq_msg_type_t
+xqc_moq_msg_publish_namespace_error_type()
+{
+    return XQC_MOQ_MSG_PUBLISH_NAMESPACE_ERROR;
+}
+
+void
+xqc_moq_msg_publish_namespace_error_init_handler(xqc_moq_msg_base_t *msg_base)
+{
+    *msg_base = publish_namespace_error_base;
+}
+
+xqc_int_t
+xqc_moq_msg_encode_publish_namespace_error_len(xqc_moq_msg_base_t *msg_base)
+{
+    xqc_int_t len = 0;
+    xqc_moq_publish_namespace_error_msg_t *err = (xqc_moq_publish_namespace_error_msg_t *)msg_base;
+    size_t reason_len = err->reason_phrase_len;
+    if (reason_len == 0 && err->reason_phrase != NULL) {
+        reason_len = strlen(err->reason_phrase);
+    }
+    len += xqc_put_varint_len(XQC_MOQ_MSG_PUBLISH_NAMESPACE_ERROR);
+    len += XQC_MOQ_MSG_LENGTH_FIXED_SIZE;
+    len += xqc_put_varint_len(err->request_id);
+    len += xqc_put_varint_len(err->error_code);
+    len += xqc_put_varint_len(reason_len);
+    len += reason_len;
+    return len;
+}
+
+xqc_int_t
+xqc_moq_msg_encode_publish_namespace_error(xqc_moq_msg_base_t *msg_base, uint8_t *buf, size_t buf_cap)
+{
+    xqc_moq_publish_namespace_error_msg_t *err = (xqc_moq_publish_namespace_error_msg_t *)msg_base;
+    size_t reason_len = err->reason_phrase_len;
+    if (reason_len == 0 && err->reason_phrase != NULL) {
+        reason_len = strlen(err->reason_phrase);
+    }
+
+    xqc_int_t length = xqc_moq_msg_encode_publish_namespace_error_len(msg_base);
+    if (length > buf_cap) {
+        return -XQC_EILLEGAL_FRAME;
+    }
+    length = length - xqc_put_varint_len(XQC_MOQ_MSG_PUBLISH_NAMESPACE_ERROR) - XQC_MOQ_MSG_LENGTH_FIXED_SIZE;
+    uint8_t *p = buf;
+    p = xqc_put_varint(p, XQC_MOQ_MSG_PUBLISH_NAMESPACE_ERROR);
+    p = xqc_moq_put_varint_length(p, length);
+    p = xqc_put_varint(p, err->request_id);
+    p = xqc_put_varint(p, err->error_code);
+    p = xqc_put_varint(p, reason_len);
+    if (reason_len > 0 && err->reason_phrase) {
+        xqc_memcpy(p, err->reason_phrase, reason_len);
+        p += reason_len;
+    }
+    return p - buf;
+}
+
+xqc_int_t
+xqc_moq_msg_decode_publish_namespace_error(uint8_t *buf, size_t buf_len, uint8_t stream_fin,
+    xqc_moq_decode_msg_ctx_t *msg_ctx, xqc_moq_msg_base_t *msg_base,
+    xqc_int_t *finish, xqc_int_t *wait_more_data)
+{
+    *finish = 0;
+    *wait_more_data = 0;
+    xqc_int_t processed = 0;
+    xqc_int_t ret = 0;
+    uint64_t length = 0;
+    xqc_moq_publish_namespace_error_msg_t *err = (xqc_moq_publish_namespace_error_msg_t *)msg_base;
+
+    switch (msg_ctx->cur_field_idx) {
+        case 0:
+            ret = xqc_moq_length_read(buf + processed, buf + buf_len, &length);
+            if (ret < 0) {
+                *wait_more_data = 1;
+                break;
+            }
+            processed += ret;
+            msg_ctx->cur_field_idx = 1;
+        case 1:
+            ret = xqc_vint_read(buf + processed, buf + buf_len, &err->request_id);
+            if (ret < 0) {
+                *wait_more_data = 1;
+                break;
+            }
+            processed += ret;
+            msg_ctx->cur_field_idx = 2;
+        case 2:
+            ret = xqc_vint_read(buf + processed, buf + buf_len, &err->error_code);
+            if (ret < 0) {
+                *wait_more_data = 1;
+                break;
+            }
+            processed += ret;
+            msg_ctx->cur_field_idx = 3;
+        case 3:
+            if (err->reason_phrase_len == 0) {
+                uint64_t reason_phrase_len = 0;
+                ret = xqc_vint_read(buf + processed, buf + buf_len, &reason_phrase_len);
+                if (ret < 0) {
+                    *wait_more_data = 1;
+                    break;
+                }
+                err->reason_phrase_len = reason_phrase_len;
+                processed += ret;
+            }
+            if (err->reason_phrase == NULL) {
+                if (err->reason_phrase_len > XQC_MOQ_MAX_NAME_LEN) {
+                    return -XQC_ELIMIT;
+                }
+                err->reason_phrase = xqc_calloc(1, err->reason_phrase_len + 1);
+                if (err->reason_phrase == NULL) {
+                    return -XQC_EMALLOC;
+                }
+            }
+            if (processed == buf_len) {
+                *wait_more_data = 1;
+                break;
+            } else if (err->reason_phrase_len - msg_ctx->str_processed <= buf_len - processed) {
+                xqc_memcpy(err->reason_phrase + msg_ctx->str_processed, buf + processed,
+                           err->reason_phrase_len - msg_ctx->str_processed);
+                processed += err->reason_phrase_len - msg_ctx->str_processed;
+                msg_ctx->str_processed = 0;
+            } else {
+                xqc_memcpy(err->reason_phrase + msg_ctx->str_processed, buf + processed, buf_len - processed);
+                msg_ctx->str_processed += buf_len - processed;
+                processed += buf_len - processed;
+                *wait_more_data = 1;
+                break;
+            }
+            *finish = 1;
+            break;
+        default:
+            return -XQC_EILLEGAL_FRAME;
+    }
+
+    return processed;
+}
+
+/**
+ * PUBLISH_NAMESPACE_DONE Message
+ */
+
+void *
+xqc_moq_msg_create_publish_namespace_done()
+{
+    xqc_moq_publish_namespace_done_msg_t *msg = xqc_calloc(1, sizeof(*msg));
+    xqc_moq_msg_publish_namespace_done_init_handler(&msg->msg_base);
+    return msg;
+}
+
+void
+xqc_moq_msg_free_publish_namespace_done(void *msg)
+{
+    if (msg == NULL) {
+        return;
+    }
+    xqc_moq_publish_namespace_done_msg_t *done = (xqc_moq_publish_namespace_done_msg_t *)msg;
+    if (done->track_namespace_tuple) {
+        for (uint64_t i = 0; i < done->track_namespace_num; i++) {
+            if (done->track_namespace_tuple[i].data) {
+                xqc_free(done->track_namespace_tuple[i].data);
+                done->track_namespace_tuple[i].data = NULL;
+                done->track_namespace_tuple[i].len = 0;
+            }
+        }
+        xqc_free(done->track_namespace_tuple);
+        done->track_namespace_tuple = NULL;
+        done->track_namespace_num = 0;
+    }
+    xqc_free(done);
+}
+
+xqc_moq_msg_type_t
+xqc_moq_msg_publish_namespace_done_type()
+{
+    return XQC_MOQ_MSG_PUBLISH_NAMESPACE_DONE;
+}
+
+void
+xqc_moq_msg_publish_namespace_done_init_handler(xqc_moq_msg_base_t *msg_base)
+{
+    *msg_base = publish_namespace_done_base;
+}
+
+xqc_int_t
+xqc_moq_msg_encode_publish_namespace_done_len(xqc_moq_msg_base_t *msg_base)
+{
+    xqc_int_t len = 0;
+    xqc_moq_publish_namespace_done_msg_t *done = (xqc_moq_publish_namespace_done_msg_t *)msg_base;
+    size_t track_namespace_len = 0;
+    if (xqc_moq_track_namespace_tuple_validate_and_sum(done->track_namespace_num,
+            done->track_namespace_tuple, &track_namespace_len) != XQC_OK)
+    {
+        return -XQC_EPARAM;
+    }
+
+    len += xqc_put_varint_len(XQC_MOQ_MSG_PUBLISH_NAMESPACE_DONE);
+    len += XQC_MOQ_MSG_LENGTH_FIXED_SIZE;
+    len += xqc_moq_track_namespace_tuple_encode_len(done->track_namespace_num,
+                                                    done->track_namespace_tuple);
+    return len;
+}
+
+xqc_int_t
+xqc_moq_msg_encode_publish_namespace_done(xqc_moq_msg_base_t *msg_base, uint8_t *buf, size_t buf_cap)
+{
+    xqc_moq_publish_namespace_done_msg_t *done = (xqc_moq_publish_namespace_done_msg_t *)msg_base;
+    size_t track_namespace_len = 0;
+    if (xqc_moq_track_namespace_tuple_validate_and_sum(done->track_namespace_num,
+            done->track_namespace_tuple, &track_namespace_len) != XQC_OK)
+    {
+        return -XQC_EPARAM;
+    }
+    done->track_namespace_len = track_namespace_len;
+
+    xqc_int_t length = xqc_moq_msg_encode_publish_namespace_done_len(msg_base);
+    if (length > buf_cap) {
+        return -XQC_EILLEGAL_FRAME;
+    }
+    length = length - xqc_put_varint_len(XQC_MOQ_MSG_PUBLISH_NAMESPACE_DONE) - XQC_MOQ_MSG_LENGTH_FIXED_SIZE;
+
+    uint8_t *p = buf;
+    p = xqc_put_varint(p, XQC_MOQ_MSG_PUBLISH_NAMESPACE_DONE);
+    p = xqc_moq_put_varint_length(p, length);
+    p = xqc_moq_track_namespace_tuple_encode(p, done->track_namespace_num,
+                                             done->track_namespace_tuple);
+    return p - buf;
+}
+
+xqc_int_t
+xqc_moq_msg_decode_publish_namespace_done(uint8_t *buf, size_t buf_len, uint8_t stream_fin,
+    xqc_moq_decode_msg_ctx_t *msg_ctx, xqc_moq_msg_base_t *msg_base,
+    xqc_int_t *finish, xqc_int_t *wait_more_data)
+{
+    *finish = 0;
+    *wait_more_data = 0;
+    xqc_int_t processed = 0;
+    xqc_int_t ret = 0;
+    uint64_t length = 0;
+    xqc_moq_publish_namespace_done_msg_t *done = (xqc_moq_publish_namespace_done_msg_t *)msg_base;
+
+    switch (msg_ctx->cur_field_idx) {
+        case 0:
+            ret = xqc_moq_length_read(buf + processed, buf + buf_len, &length);
+            if (ret < 0) {
+                *wait_more_data = 1;
+                break;
+            }
+            processed += ret;
+            msg_ctx->cur_field_idx = 1;
+        case 1:
+            if (done->track_namespace_num == 0) {
+                ret = xqc_vint_read(buf + processed, buf + buf_len, &done->track_namespace_num);
+                if (ret < 0) {
+                    *wait_more_data = 1;
+                    break;
+                }
+                processed += ret;
+                if (done->track_namespace_num == 0) {
+                    return -MOQ_PROTOCOL_VIOLATION;
+                }
+                if (done->track_namespace_num > XQC_MOQ_MAX_NAMESPACE_TUPLE_ELEMS) {
+                    return -MOQ_PROTOCOL_VIOLATION;
+                }
+                msg_ctx->cur_array_idx = 0;
+                msg_ctx->str_processed = 0;
+                msg_ctx->tuple_elem_len = 0;
+                msg_ctx->tuple_elem_len_ready = 0;
+                done->track_namespace_len = 0;
+                if (done->track_namespace_tuple == NULL) {
+                    done->track_namespace_tuple = xqc_calloc(done->track_namespace_num, sizeof(xqc_moq_track_ns_field_t));
+                    if (done->track_namespace_tuple == NULL) {
+                        return -XQC_EMALLOC;
+                    }
+                }
+            }
+            msg_ctx->cur_field_idx = 2;
+        case 2:
+            for (; msg_ctx->cur_array_idx < done->track_namespace_num; msg_ctx->cur_array_idx++) {
+                xqc_moq_track_ns_field_t *field = &done->track_namespace_tuple[msg_ctx->cur_array_idx];
+
+                if (!msg_ctx->tuple_elem_len_ready) {
+                    ret = xqc_vint_read(buf + processed, buf + buf_len, &msg_ctx->tuple_elem_len);
+                    if (ret < 0) {
+                        *wait_more_data = 1;
+                        break;
+                    }
+                    processed += ret;
+                    msg_ctx->tuple_elem_len_ready = 1;
+                    if (msg_ctx->tuple_elem_len > XQC_MOQ_MAX_NAME_LEN) {
+                        return -XQC_ELIMIT;
+                    }
+                    field->len = msg_ctx->tuple_elem_len;
+                    if (done->track_namespace_len > XQC_MOQ_MAX_FULL_TRACK_NAME_LEN - field->len) {
+                        return -MOQ_PROTOCOL_VIOLATION;
+                    }
+                    done->track_namespace_len += field->len;
+                    if (field->data == NULL && field->len > 0) {
+                        field->data = xqc_calloc(1, field->len + 1);
+                        if (field->data == NULL) {
+                            return -XQC_EMALLOC;
+                        }
+                    }
+                }
+
+                if (processed == buf_len) {
+                    *wait_more_data = 1;
+                    break;
+                }
+
+                size_t field_remaining = (msg_ctx->tuple_elem_len - msg_ctx->str_processed);
+                size_t buf_remaining = buf_len - processed;
+                size_t copy_len = field_remaining < buf_remaining ? field_remaining : buf_remaining;
+
+                if (copy_len > 0 && field->data != NULL) {
+                    xqc_memcpy(field->data + msg_ctx->str_processed, buf + processed, copy_len);
+                    msg_ctx->str_processed += copy_len;
+                    processed += copy_len;
+                }
+
+                if (msg_ctx->str_processed < msg_ctx->tuple_elem_len) {
+                    *wait_more_data = 1;
+                    break;
+                }
+
+                msg_ctx->str_processed = 0;
+                msg_ctx->tuple_elem_len_ready = 0;
+                msg_ctx->tuple_elem_len = 0;
+            }
+
+            if (*wait_more_data == 1) {
+                break;
+            }
+
+            *finish = 1;
+            break;
+        default:
+            return -XQC_EILLEGAL_FRAME;
+    }
+
+    return processed;
+}
+
+/**
+ * PUBLISH_NAMESPACE_CANCEL Message
+ */
+
+void *
+xqc_moq_msg_create_publish_namespace_cancel()
+{
+    xqc_moq_publish_namespace_cancel_msg_t *msg = xqc_calloc(1, sizeof(*msg));
+    xqc_moq_msg_publish_namespace_cancel_init_handler(&msg->msg_base);
+    return msg;
+}
+
+void
+xqc_moq_msg_free_publish_namespace_cancel(void *msg)
+{
+    if (msg == NULL) {
+        return;
+    }
+    xqc_moq_publish_namespace_cancel_msg_t *cancel = (xqc_moq_publish_namespace_cancel_msg_t *)msg;
+    if (cancel->track_namespace_tuple) {
+        for (uint64_t i = 0; i < cancel->track_namespace_num; i++) {
+            if (cancel->track_namespace_tuple[i].data) {
+                xqc_free(cancel->track_namespace_tuple[i].data);
+                cancel->track_namespace_tuple[i].data = NULL;
+                cancel->track_namespace_tuple[i].len = 0;
+            }
+        }
+        xqc_free(cancel->track_namespace_tuple);
+        cancel->track_namespace_tuple = NULL;
+        cancel->track_namespace_num = 0;
+    }
+    cancel->track_namespace_len = 0;
+    xqc_free(cancel->reason_phrase);
+    xqc_free(cancel);
+}
+
+xqc_moq_msg_type_t
+xqc_moq_msg_publish_namespace_cancel_type()
+{
+    return XQC_MOQ_MSG_PUBLISH_NAMESPACE_CANCEL;
+}
+
+void
+xqc_moq_msg_publish_namespace_cancel_init_handler(xqc_moq_msg_base_t *msg_base)
+{
+    *msg_base = publish_namespace_cancel_base;
+}
+
+xqc_int_t
+xqc_moq_msg_encode_publish_namespace_cancel_len(xqc_moq_msg_base_t *msg_base)
+{
+    xqc_int_t len = 0;
+    xqc_moq_publish_namespace_cancel_msg_t *cancel = (xqc_moq_publish_namespace_cancel_msg_t *)msg_base;
+    size_t track_namespace_len = 0;
+    if (xqc_moq_track_namespace_tuple_validate_and_sum(cancel->track_namespace_num,
+            cancel->track_namespace_tuple, &track_namespace_len) != XQC_OK)
+    {
+        return -XQC_EPARAM;
+    }
+    size_t reason_len = cancel->reason_phrase_len;
+    if (reason_len == 0 && cancel->reason_phrase != NULL) {
+        reason_len = strlen(cancel->reason_phrase);
+    }
+
+    len += xqc_put_varint_len(XQC_MOQ_MSG_PUBLISH_NAMESPACE_CANCEL);
+    len += XQC_MOQ_MSG_LENGTH_FIXED_SIZE;
+    len += xqc_moq_track_namespace_tuple_encode_len(cancel->track_namespace_num,
+                                                    cancel->track_namespace_tuple);
+    len += xqc_put_varint_len(cancel->error_code);
+    len += xqc_put_varint_len(reason_len);
+    len += reason_len;
+    return len;
+}
+
+xqc_int_t
+xqc_moq_msg_encode_publish_namespace_cancel(xqc_moq_msg_base_t *msg_base, uint8_t *buf, size_t buf_cap)
+{
+    xqc_moq_publish_namespace_cancel_msg_t *cancel = (xqc_moq_publish_namespace_cancel_msg_t *)msg_base;
+    size_t track_namespace_len = 0;
+    if (xqc_moq_track_namespace_tuple_validate_and_sum(cancel->track_namespace_num,
+            cancel->track_namespace_tuple, &track_namespace_len) != XQC_OK)
+    {
+        return -XQC_EPARAM;
+    }
+    cancel->track_namespace_len = track_namespace_len;
+    size_t reason_len = cancel->reason_phrase_len;
+    if (reason_len == 0 && cancel->reason_phrase != NULL) {
+        reason_len = strlen(cancel->reason_phrase);
+    }
+
+    xqc_int_t length = xqc_moq_msg_encode_publish_namespace_cancel_len(msg_base);
+    if (length > buf_cap) {
+        return -XQC_EILLEGAL_FRAME;
+    }
+    length = length - xqc_put_varint_len(XQC_MOQ_MSG_PUBLISH_NAMESPACE_CANCEL) - XQC_MOQ_MSG_LENGTH_FIXED_SIZE;
+
+    uint8_t *p = buf;
+    p = xqc_put_varint(p, XQC_MOQ_MSG_PUBLISH_NAMESPACE_CANCEL);
+    p = xqc_moq_put_varint_length(p, length);
+    p = xqc_moq_track_namespace_tuple_encode(p, cancel->track_namespace_num,
+                                             cancel->track_namespace_tuple);
+    p = xqc_put_varint(p, cancel->error_code);
+    p = xqc_put_varint(p, reason_len);
+    if (reason_len > 0 && cancel->reason_phrase) {
+        xqc_memcpy(p, cancel->reason_phrase, reason_len);
+        p += reason_len;
+    }
+    return p - buf;
+}
+
+xqc_int_t
+xqc_moq_msg_decode_publish_namespace_cancel(uint8_t *buf, size_t buf_len, uint8_t stream_fin,
+    xqc_moq_decode_msg_ctx_t *msg_ctx, xqc_moq_msg_base_t *msg_base,
+    xqc_int_t *finish, xqc_int_t *wait_more_data)
+{
+    *finish = 0;
+    *wait_more_data = 0;
+    xqc_int_t processed = 0;
+    xqc_int_t ret = 0;
+    uint64_t length = 0;
+    xqc_moq_publish_namespace_cancel_msg_t *cancel = (xqc_moq_publish_namespace_cancel_msg_t *)msg_base;
+
+    switch (msg_ctx->cur_field_idx) {
+        case 0:
+            ret = xqc_moq_length_read(buf + processed, buf + buf_len, &length);
+            if (ret < 0) {
+                *wait_more_data = 1;
+                break;
+            }
+            processed += ret;
+            msg_ctx->cur_field_idx = 1;
+        case 1:
+            if (cancel->track_namespace_num == 0) {
+                ret = xqc_vint_read(buf + processed, buf + buf_len, &cancel->track_namespace_num);
+                if (ret < 0) {
+                    *wait_more_data = 1;
+                    break;
+                }
+                processed += ret;
+                if (cancel->track_namespace_num == 0) {
+                    return -MOQ_PROTOCOL_VIOLATION;
+                }
+                if (cancel->track_namespace_num > XQC_MOQ_MAX_NAMESPACE_TUPLE_ELEMS) {
+                    return -MOQ_PROTOCOL_VIOLATION;
+                }
+                msg_ctx->cur_array_idx = 0;
+                msg_ctx->str_processed = 0;
+                msg_ctx->tuple_elem_len = 0;
+                msg_ctx->tuple_elem_len_ready = 0;
+                cancel->track_namespace_len = 0;
+                if (cancel->track_namespace_tuple == NULL) {
+                    cancel->track_namespace_tuple = xqc_calloc(cancel->track_namespace_num, sizeof(xqc_moq_track_ns_field_t));
+                    if (cancel->track_namespace_tuple == NULL) {
+                        return -XQC_EMALLOC;
+                    }
+                }
+            }
+            msg_ctx->cur_field_idx = 2;
+        case 2:
+            for (; msg_ctx->cur_array_idx < cancel->track_namespace_num; msg_ctx->cur_array_idx++) {
+                xqc_moq_track_ns_field_t *field = &cancel->track_namespace_tuple[msg_ctx->cur_array_idx];
+
+                if (!msg_ctx->tuple_elem_len_ready) {
+                    ret = xqc_vint_read(buf + processed, buf + buf_len, &msg_ctx->tuple_elem_len);
+                    if (ret < 0) {
+                        *wait_more_data = 1;
+                        break;
+                    }
+                    processed += ret;
+                    msg_ctx->tuple_elem_len_ready = 1;
+                    if (msg_ctx->tuple_elem_len > XQC_MOQ_MAX_NAME_LEN) {
+                        return -XQC_ELIMIT;
+                    }
+                    field->len = msg_ctx->tuple_elem_len;
+                    if (cancel->track_namespace_len > XQC_MOQ_MAX_FULL_TRACK_NAME_LEN - field->len) {
+                        return -MOQ_PROTOCOL_VIOLATION;
+                    }
+                    cancel->track_namespace_len += field->len;
+                    if (field->data == NULL && field->len > 0) {
+                        field->data = xqc_calloc(1, field->len + 1);
+                        if (field->data == NULL) {
+                            return -XQC_EMALLOC;
+                        }
+                    }
+                }
+
+                if (processed == buf_len) {
+                    *wait_more_data = 1;
+                    break;
+                }
+
+                size_t field_remaining = (msg_ctx->tuple_elem_len - msg_ctx->str_processed);
+                size_t buf_remaining = buf_len - processed;
+                size_t copy_len = field_remaining < buf_remaining ? field_remaining : buf_remaining;
+
+                if (copy_len > 0 && field->data != NULL) {
+                    xqc_memcpy(field->data + msg_ctx->str_processed, buf + processed, copy_len);
+                    msg_ctx->str_processed += copy_len;
+                    processed += copy_len;
+                }
+
+                if (msg_ctx->str_processed < msg_ctx->tuple_elem_len) {
+                    *wait_more_data = 1;
+                    break;
+                }
+
+                msg_ctx->str_processed = 0;
+                msg_ctx->tuple_elem_len_ready = 0;
+                msg_ctx->tuple_elem_len = 0;
+            }
+
+            if (*wait_more_data == 1) {
+                break;
+            }
+
+            msg_ctx->cur_field_idx = 3;
+        case 3:
+            ret = xqc_vint_read(buf + processed, buf + buf_len, &cancel->error_code);
+            if (ret < 0) {
+                *wait_more_data = 1;
+                break;
+            }
+            processed += ret;
+            msg_ctx->cur_field_idx = 4;
+        case 4:
+            if (cancel->reason_phrase_len == 0) {
+                uint64_t reason_phrase_len = 0;
+                ret = xqc_vint_read(buf + processed, buf + buf_len, &reason_phrase_len);
+                if (ret < 0) {
+                    *wait_more_data = 1;
+                    break;
+                }
+                cancel->reason_phrase_len = reason_phrase_len;
+                processed += ret;
+            }
+            if (cancel->reason_phrase == NULL) {
+                if (cancel->reason_phrase_len > XQC_MOQ_MAX_NAME_LEN) {
+                    return -XQC_ELIMIT;
+                }
+                cancel->reason_phrase = xqc_calloc(1, cancel->reason_phrase_len + 1);
+                if (cancel->reason_phrase == NULL) {
+                    return -XQC_EMALLOC;
+                }
+            }
+            if (processed == buf_len) {
+                *wait_more_data = 1;
+                break;
+            } else if (cancel->reason_phrase_len - msg_ctx->str_processed <= buf_len - processed) {
+                xqc_memcpy(cancel->reason_phrase + msg_ctx->str_processed, buf + processed,
+                           cancel->reason_phrase_len - msg_ctx->str_processed);
+                processed += cancel->reason_phrase_len - msg_ctx->str_processed;
+                msg_ctx->str_processed = 0;
+            } else {
+                xqc_memcpy(cancel->reason_phrase + msg_ctx->str_processed, buf + processed, buf_len - processed);
+                msg_ctx->str_processed += buf_len - processed;
+                processed += buf_len - processed;
+                *wait_more_data = 1;
+                break;
+            }
+            *finish = 1;
+            break;
+        default:
+            return -XQC_EILLEGAL_FRAME;
+    }
+
+    return processed;
+}
+
+/**
+ * SUBSCRIBE_NAMESPACE Message
+ */
+
+void *
+xqc_moq_msg_create_subscribe_namespace()
+{
+    xqc_moq_subscribe_namespace_msg_t *msg = xqc_calloc(1, sizeof(*msg));
+    xqc_moq_msg_subscribe_namespace_init_handler(&msg->msg_base);
+    return msg;
+}
+
+void
+xqc_moq_msg_free_subscribe_namespace(void *msg)
+{
+    if (msg == NULL) {
+        return;
+    }
+    xqc_moq_subscribe_namespace_msg_t *sub = (xqc_moq_subscribe_namespace_msg_t *)msg;
+    if (sub->track_namespace_tuple) {
+        for (uint64_t i = 0; i < sub->track_namespace_num; i++) {
+            if (sub->track_namespace_tuple[i].data) {
+                xqc_free(sub->track_namespace_tuple[i].data);
+                sub->track_namespace_tuple[i].data = NULL;
+                sub->track_namespace_tuple[i].len = 0;
+            }
+        }
+        xqc_free(sub->track_namespace_tuple);
+        sub->track_namespace_tuple = NULL;
+        sub->track_namespace_num = 0;
+    }
+    sub->track_namespace_len = 0;
+    xqc_moq_msg_free_params(sub->params, sub->params_num);
+    xqc_free(sub);
+}
+
+xqc_moq_msg_type_t
+xqc_moq_msg_subscribe_namespace_type()
+{
+    return XQC_MOQ_MSG_SUBSCRIBE_NAMESPACE;
+}
+
+void
+xqc_moq_msg_subscribe_namespace_init_handler(xqc_moq_msg_base_t *msg_base)
+{
+    *msg_base = subscribe_namespace_base;
+}
+
+xqc_int_t
+xqc_moq_msg_encode_subscribe_namespace_len(xqc_moq_msg_base_t *msg_base)
+{
+    xqc_int_t len = 0;
+    xqc_moq_subscribe_namespace_msg_t *sub = (xqc_moq_subscribe_namespace_msg_t *)msg_base;
+    size_t track_namespace_len = 0;
+    if (xqc_moq_track_namespace_tuple_validate_and_sum(sub->track_namespace_num,
+            sub->track_namespace_tuple, &track_namespace_len) != XQC_OK)
+    {
+        return -XQC_EPARAM;
+    }
+
+    len += xqc_put_varint_len(XQC_MOQ_MSG_SUBSCRIBE_NAMESPACE);
+    len += XQC_MOQ_MSG_LENGTH_FIXED_SIZE;
+    len += xqc_put_varint_len(sub->request_id);
+    len += xqc_moq_track_namespace_tuple_encode_len(sub->track_namespace_num,
+                                                    sub->track_namespace_tuple);
+    len += xqc_put_varint_len(sub->params_num);
+    len += xqc_moq_msg_encode_params_len_v14(sub->params, sub->params_num);
+    return len;
+}
+
+xqc_int_t
+xqc_moq_msg_encode_subscribe_namespace(xqc_moq_msg_base_t *msg_base, uint8_t *buf, size_t buf_cap)
+{
+    xqc_int_t ret = 0;
+    xqc_moq_subscribe_namespace_msg_t *sub = (xqc_moq_subscribe_namespace_msg_t *)msg_base;
+    size_t track_namespace_len = 0;
+    if (xqc_moq_track_namespace_tuple_validate_and_sum(sub->track_namespace_num,
+            sub->track_namespace_tuple, &track_namespace_len) != XQC_OK)
+    {
+        return -XQC_EPARAM;
+    }
+    sub->track_namespace_len = track_namespace_len;
+
+    xqc_int_t length = xqc_moq_msg_encode_subscribe_namespace_len(msg_base);
+    if (length > buf_cap) {
+        return -XQC_EILLEGAL_FRAME;
+    }
+    length = length - xqc_put_varint_len(XQC_MOQ_MSG_SUBSCRIBE_NAMESPACE) - XQC_MOQ_MSG_LENGTH_FIXED_SIZE;
+
+    uint8_t *p = buf;
+    p = xqc_put_varint(p, XQC_MOQ_MSG_SUBSCRIBE_NAMESPACE);
+    p = xqc_moq_put_varint_length(p, length);
+    p = xqc_put_varint(p, sub->request_id);
+    p = xqc_moq_track_namespace_tuple_encode(p, sub->track_namespace_num,
+                                             sub->track_namespace_tuple);
+    p = xqc_put_varint(p, sub->params_num);
+    ret = xqc_moq_msg_encode_params_v14(sub->params, sub->params_num, p, buf + buf_cap - p);
+    if (ret < 0) {
+        return ret;
+    }
+    p += ret;
+    return p - buf;
+}
+
+xqc_int_t
+xqc_moq_msg_decode_subscribe_namespace(uint8_t *buf, size_t buf_len, uint8_t stream_fin,
+    xqc_moq_decode_msg_ctx_t *msg_ctx, xqc_moq_msg_base_t *msg_base,
+    xqc_int_t *finish, xqc_int_t *wait_more_data)
+{
+    *finish = 0;
+    *wait_more_data = 0;
+    xqc_int_t processed = 0;
+    xqc_int_t ret = 0;
+    xqc_int_t param_finish = 0;
+    uint64_t length = 0;
+    xqc_moq_subscribe_namespace_msg_t *sub = (xqc_moq_subscribe_namespace_msg_t *)msg_base;
+    xqc_moq_decode_params_ctx_t *params_ctx = &msg_ctx->decode_params_ctx;
+
+    switch (msg_ctx->cur_field_idx) {
+        case 0:
+            ret = xqc_moq_length_read(buf + processed, buf + buf_len, &length);
+            if (ret < 0) {
+                *wait_more_data = 1;
+                break;
+            }
+            processed += ret;
+            msg_ctx->cur_field_idx = 1;
+        case 1:
+            ret = xqc_vint_read(buf + processed, buf + buf_len, &sub->request_id);
+            if (ret < 0) {
+                *wait_more_data = 1;
+                break;
+            }
+            processed += ret;
+            msg_ctx->cur_field_idx = 2;
+        case 2:
+            if (sub->track_namespace_num == 0) {
+                ret = xqc_vint_read(buf + processed, buf + buf_len, &sub->track_namespace_num);
+                if (ret < 0) {
+                    *wait_more_data = 1;
+                    break;
+                }
+                processed += ret;
+                if (sub->track_namespace_num == 0) {
+                    return -MOQ_PROTOCOL_VIOLATION;
+                }
+                if (sub->track_namespace_num > XQC_MOQ_MAX_NAMESPACE_TUPLE_ELEMS) {
+                    return -MOQ_PROTOCOL_VIOLATION;
+                }
+                msg_ctx->cur_array_idx = 0;
+                msg_ctx->str_processed = 0;
+                msg_ctx->tuple_elem_len = 0;
+                msg_ctx->tuple_elem_len_ready = 0;
+                sub->track_namespace_len = 0;
+                if (sub->track_namespace_tuple == NULL) {
+                    sub->track_namespace_tuple = xqc_calloc(sub->track_namespace_num, sizeof(xqc_moq_track_ns_field_t));
+                    if (sub->track_namespace_tuple == NULL) {
+                        return -XQC_EMALLOC;
+                    }
+                }
+            }
+            msg_ctx->cur_field_idx = 3;
+        case 3:
+            for (; msg_ctx->cur_array_idx < sub->track_namespace_num; msg_ctx->cur_array_idx++) {
+                xqc_moq_track_ns_field_t *field = &sub->track_namespace_tuple[msg_ctx->cur_array_idx];
+
+                if (!msg_ctx->tuple_elem_len_ready) {
+                    ret = xqc_vint_read(buf + processed, buf + buf_len, &msg_ctx->tuple_elem_len);
+                    if (ret < 0) {
+                        *wait_more_data = 1;
+                        break;
+                    }
+                    processed += ret;
+                    msg_ctx->tuple_elem_len_ready = 1;
+                    if (msg_ctx->tuple_elem_len > XQC_MOQ_MAX_NAME_LEN) {
+                        return -XQC_ELIMIT;
+                    }
+                    field->len = msg_ctx->tuple_elem_len;
+                    if (sub->track_namespace_len > XQC_MOQ_MAX_FULL_TRACK_NAME_LEN - field->len) {
+                        return -MOQ_PROTOCOL_VIOLATION;
+                    }
+                    sub->track_namespace_len += field->len;
+                    if (field->data == NULL && field->len > 0) {
+                        field->data = xqc_calloc(1, field->len + 1);
+                        if (field->data == NULL) {
+                            return -XQC_EMALLOC;
+                        }
+                    }
+                }
+
+                if (processed == buf_len) {
+                    *wait_more_data = 1;
+                    break;
+                }
+
+                size_t field_remaining = (msg_ctx->tuple_elem_len - msg_ctx->str_processed);
+                size_t buf_remaining = buf_len - processed;
+                size_t copy_len = field_remaining < buf_remaining ? field_remaining : buf_remaining;
+
+                if (copy_len > 0 && field->data != NULL) {
+                    xqc_memcpy(field->data + msg_ctx->str_processed, buf + processed, copy_len);
+                    msg_ctx->str_processed += copy_len;
+                    processed += copy_len;
+                }
+
+                if (msg_ctx->str_processed < msg_ctx->tuple_elem_len) {
+                    *wait_more_data = 1;
+                    break;
+                }
+
+                msg_ctx->str_processed = 0;
+                msg_ctx->tuple_elem_len_ready = 0;
+                msg_ctx->tuple_elem_len = 0;
+            }
+
+            if (*wait_more_data == 1) {
+                break;
+            }
+
+            msg_ctx->cur_field_idx = 4;
+        case 4:
+            if (sub->params_num == 0) {
+                ret = xqc_vint_read(buf + processed, buf + buf_len, &sub->params_num);
+                if (ret < 0) {
+                    *wait_more_data = 1;
+                    break;
+                }
+                processed += ret;
+                if (sub->params_num == 0) {
+                    *finish = 1;
+                    break;
+                }
+                if (sub->params_num > XQC_MOQ_MAX_PARAMS) {
+                    return -XQC_ELIMIT;
+                }
+                sub->params = xqc_moq_msg_alloc_params(sub->params_num);
+                if (sub->params == NULL) {
+                    return -XQC_EMALLOC;
+                }
+            }
+            msg_ctx->cur_field_idx = 5;
+        case 5:
+            ret = xqc_moq_msg_decode_params_v14(buf + processed, buf_len - processed, params_ctx,
+                                                sub->params, sub->params_num, &param_finish, wait_more_data);
+            if (ret < 0) {
+                return ret;
+            }
+            processed += ret;
+            if (*wait_more_data == 1) {
+                break;
+            }
+            if (param_finish == 1) {
+                *finish = 1;
+            }
+            break;
+        default:
+            return -XQC_EILLEGAL_FRAME;
+    }
+
+    return processed;
+}
+
+/**
+ * SUBSCRIBE_NAMESPACE_OK Message
+ */
+
+void *
+xqc_moq_msg_create_subscribe_namespace_ok()
+{
+    xqc_moq_subscribe_namespace_ok_msg_t *msg = xqc_calloc(1, sizeof(*msg));
+    xqc_moq_msg_subscribe_namespace_ok_init_handler(&msg->msg_base);
+    return msg;
+}
+
+void
+xqc_moq_msg_free_subscribe_namespace_ok(void *msg)
+{
+    xqc_free(msg);
+}
+
+xqc_moq_msg_type_t
+xqc_moq_msg_subscribe_namespace_ok_type()
+{
+    return XQC_MOQ_MSG_SUBSCRIBE_NAMESPACE_OK;
+}
+
+void
+xqc_moq_msg_subscribe_namespace_ok_init_handler(xqc_moq_msg_base_t *msg_base)
+{
+    *msg_base = subscribe_namespace_ok_base;
+}
+
+xqc_int_t
+xqc_moq_msg_encode_subscribe_namespace_ok_len(xqc_moq_msg_base_t *msg_base)
+{
+    xqc_int_t len = 0;
+    xqc_moq_subscribe_namespace_ok_msg_t *ok = (xqc_moq_subscribe_namespace_ok_msg_t *)msg_base;
+    len += xqc_put_varint_len(XQC_MOQ_MSG_SUBSCRIBE_NAMESPACE_OK);
+    len += XQC_MOQ_MSG_LENGTH_FIXED_SIZE;
+    len += xqc_put_varint_len(ok->request_id);
+    return len;
+}
+
+xqc_int_t
+xqc_moq_msg_encode_subscribe_namespace_ok(xqc_moq_msg_base_t *msg_base, uint8_t *buf, size_t buf_cap)
+{
+    xqc_moq_subscribe_namespace_ok_msg_t *ok = (xqc_moq_subscribe_namespace_ok_msg_t *)msg_base;
+    xqc_int_t length = xqc_moq_msg_encode_subscribe_namespace_ok_len(msg_base);
+    if (length > buf_cap) {
+        return -XQC_EILLEGAL_FRAME;
+    }
+    length = length - xqc_put_varint_len(XQC_MOQ_MSG_SUBSCRIBE_NAMESPACE_OK) - XQC_MOQ_MSG_LENGTH_FIXED_SIZE;
+    uint8_t *p = buf;
+    p = xqc_put_varint(p, XQC_MOQ_MSG_SUBSCRIBE_NAMESPACE_OK);
+    p = xqc_moq_put_varint_length(p, length);
+    p = xqc_put_varint(p, ok->request_id);
+    return p - buf;
+}
+
+xqc_int_t
+xqc_moq_msg_decode_subscribe_namespace_ok(uint8_t *buf, size_t buf_len, uint8_t stream_fin,
+    xqc_moq_decode_msg_ctx_t *msg_ctx, xqc_moq_msg_base_t *msg_base,
+    xqc_int_t *finish, xqc_int_t *wait_more_data)
+{
+    *finish = 0;
+    *wait_more_data = 0;
+    xqc_int_t processed = 0;
+    xqc_int_t ret = 0;
+    uint64_t length = 0;
+    xqc_moq_subscribe_namespace_ok_msg_t *ok = (xqc_moq_subscribe_namespace_ok_msg_t *)msg_base;
+
+    switch (msg_ctx->cur_field_idx) {
+        case 0:
+            ret = xqc_moq_length_read(buf + processed, buf + buf_len, &length);
+            if (ret < 0) {
+                *wait_more_data = 1;
+                break;
+            }
+            processed += ret;
+            msg_ctx->cur_field_idx = 1;
+        case 1:
+            ret = xqc_vint_read(buf + processed, buf + buf_len, &ok->request_id);
+            if (ret < 0) {
+                *wait_more_data = 1;
+                break;
+            }
+            processed += ret;
+            *finish = 1;
+            break;
+        default:
+            return -XQC_EILLEGAL_FRAME;
+    }
+
+    return processed;
+}
+
+/**
+ * SUBSCRIBE_NAMESPACE_ERROR Message
+ */
+
+void *
+xqc_moq_msg_create_subscribe_namespace_error()
+{
+    xqc_moq_subscribe_namespace_error_msg_t *msg = xqc_calloc(1, sizeof(*msg));
+    xqc_moq_msg_subscribe_namespace_error_init_handler(&msg->msg_base);
+    return msg;
+}
+
+void
+xqc_moq_msg_free_subscribe_namespace_error(void *msg)
+{
+    if (msg == NULL) {
+        return;
+    }
+    xqc_moq_subscribe_namespace_error_msg_t *err = (xqc_moq_subscribe_namespace_error_msg_t *)msg;
+    xqc_free(err->reason_phrase);
+    xqc_free(err);
+}
+
+xqc_moq_msg_type_t
+xqc_moq_msg_subscribe_namespace_error_type()
+{
+    return XQC_MOQ_MSG_SUBSCRIBE_NAMESPACE_ERROR;
+}
+
+void
+xqc_moq_msg_subscribe_namespace_error_init_handler(xqc_moq_msg_base_t *msg_base)
+{
+    *msg_base = subscribe_namespace_error_base;
+}
+
+xqc_int_t
+xqc_moq_msg_encode_subscribe_namespace_error_len(xqc_moq_msg_base_t *msg_base)
+{
+    xqc_int_t len = 0;
+    xqc_moq_subscribe_namespace_error_msg_t *err = (xqc_moq_subscribe_namespace_error_msg_t *)msg_base;
+    size_t reason_len = err->reason_phrase_len;
+    if (reason_len == 0 && err->reason_phrase != NULL) {
+        reason_len = strlen(err->reason_phrase);
+    }
+
+    len += xqc_put_varint_len(XQC_MOQ_MSG_SUBSCRIBE_NAMESPACE_ERROR);
+    len += XQC_MOQ_MSG_LENGTH_FIXED_SIZE;
+    len += xqc_put_varint_len(err->request_id);
+    len += xqc_put_varint_len(err->error_code);
+    len += xqc_put_varint_len(reason_len);
+    len += reason_len;
+    return len;
+}
+
+xqc_int_t
+xqc_moq_msg_encode_subscribe_namespace_error(xqc_moq_msg_base_t *msg_base, uint8_t *buf, size_t buf_cap)
+{
+    xqc_moq_subscribe_namespace_error_msg_t *err = (xqc_moq_subscribe_namespace_error_msg_t *)msg_base;
+    size_t reason_len = err->reason_phrase_len;
+    if (reason_len == 0 && err->reason_phrase != NULL) {
+        reason_len = strlen(err->reason_phrase);
+    }
+
+    xqc_int_t length = xqc_moq_msg_encode_subscribe_namespace_error_len(msg_base);
+    if (length > buf_cap) {
+        return -XQC_EILLEGAL_FRAME;
+    }
+    length = length - xqc_put_varint_len(XQC_MOQ_MSG_SUBSCRIBE_NAMESPACE_ERROR) - XQC_MOQ_MSG_LENGTH_FIXED_SIZE;
+    uint8_t *p = buf;
+    p = xqc_put_varint(p, XQC_MOQ_MSG_SUBSCRIBE_NAMESPACE_ERROR);
+    p = xqc_moq_put_varint_length(p, length);
+    p = xqc_put_varint(p, err->request_id);
+    p = xqc_put_varint(p, err->error_code);
+    p = xqc_put_varint(p, reason_len);
+    if (reason_len > 0 && err->reason_phrase) {
+        xqc_memcpy(p, err->reason_phrase, reason_len);
+        p += reason_len;
+    }
+    return p - buf;
+}
+
+xqc_int_t
+xqc_moq_msg_decode_subscribe_namespace_error(uint8_t *buf, size_t buf_len, uint8_t stream_fin,
+    xqc_moq_decode_msg_ctx_t *msg_ctx, xqc_moq_msg_base_t *msg_base,
+    xqc_int_t *finish, xqc_int_t *wait_more_data)
+{
+    *finish = 0;
+    *wait_more_data = 0;
+    xqc_int_t processed = 0;
+    xqc_int_t ret = 0;
+    uint64_t length = 0;
+    xqc_moq_subscribe_namespace_error_msg_t *err = (xqc_moq_subscribe_namespace_error_msg_t *)msg_base;
+
+    switch (msg_ctx->cur_field_idx) {
+        case 0:
+            ret = xqc_moq_length_read(buf + processed, buf + buf_len, &length);
+            if (ret < 0) {
+                *wait_more_data = 1;
+                break;
+            }
+            processed += ret;
+            msg_ctx->cur_field_idx = 1;
+        case 1:
+            ret = xqc_vint_read(buf + processed, buf + buf_len, &err->request_id);
+            if (ret < 0) {
+                *wait_more_data = 1;
+                break;
+            }
+            processed += ret;
+            msg_ctx->cur_field_idx = 2;
+        case 2:
+            ret = xqc_vint_read(buf + processed, buf + buf_len, &err->error_code);
+            if (ret < 0) {
+                *wait_more_data = 1;
+                break;
+            }
+            processed += ret;
+            msg_ctx->cur_field_idx = 3;
+        case 3:
+            if (err->reason_phrase_len == 0) {
+                uint64_t reason_phrase_len = 0;
+                ret = xqc_vint_read(buf + processed, buf + buf_len, &reason_phrase_len);
+                if (ret < 0) {
+                    *wait_more_data = 1;
+                    break;
+                }
+                err->reason_phrase_len = reason_phrase_len;
+                processed += ret;
+            }
+            if (err->reason_phrase == NULL) {
+                if (err->reason_phrase_len > XQC_MOQ_MAX_NAME_LEN) {
+                    return -XQC_ELIMIT;
+                }
+                err->reason_phrase = xqc_calloc(1, err->reason_phrase_len + 1);
+                if (err->reason_phrase == NULL) {
+                    return -XQC_EMALLOC;
+                }
+            }
+            if (processed == buf_len) {
+                *wait_more_data = 1;
+                break;
+            } else if (err->reason_phrase_len - msg_ctx->str_processed <= buf_len - processed) {
+                xqc_memcpy(err->reason_phrase + msg_ctx->str_processed, buf + processed,
+                           err->reason_phrase_len - msg_ctx->str_processed);
+                processed += err->reason_phrase_len - msg_ctx->str_processed;
+                msg_ctx->str_processed = 0;
+            } else {
+                xqc_memcpy(err->reason_phrase + msg_ctx->str_processed, buf + processed, buf_len - processed);
+                msg_ctx->str_processed += buf_len - processed;
+                processed += buf_len - processed;
+                *wait_more_data = 1;
+                break;
+            }
+            *finish = 1;
+            break;
+        default:
+            return -XQC_EILLEGAL_FRAME;
+    }
+
+    return processed;
+}
+
+/**
+ * UNSUBSCRIBE_NAMESPACE Message
+ */
+
+void *
+xqc_moq_msg_create_unsubscribe_namespace()
+{
+    xqc_moq_unsubscribe_namespace_msg_t *msg = xqc_calloc(1, sizeof(*msg));
+    xqc_moq_msg_unsubscribe_namespace_init_handler(&msg->msg_base);
+    return msg;
+}
+
+void
+xqc_moq_msg_free_unsubscribe_namespace(void *msg)
+{
+    if (msg == NULL) {
+        return;
+    }
+    xqc_moq_unsubscribe_namespace_msg_t *unsub = (xqc_moq_unsubscribe_namespace_msg_t *)msg;
+    if (unsub->track_namespace_tuple) {
+        for (uint64_t i = 0; i < unsub->track_namespace_num; i++) {
+            if (unsub->track_namespace_tuple[i].data) {
+                xqc_free(unsub->track_namespace_tuple[i].data);
+                unsub->track_namespace_tuple[i].data = NULL;
+                unsub->track_namespace_tuple[i].len = 0;
+            }
+        }
+        xqc_free(unsub->track_namespace_tuple);
+        unsub->track_namespace_tuple = NULL;
+        unsub->track_namespace_num = 0;
+    }
+    unsub->track_namespace_len = 0;
+    xqc_free(unsub);
+}
+
+xqc_moq_msg_type_t
+xqc_moq_msg_unsubscribe_namespace_type()
+{
+    return XQC_MOQ_MSG_UNSUBSCRIBE_NAMESPACE;
+}
+
+void
+xqc_moq_msg_unsubscribe_namespace_init_handler(xqc_moq_msg_base_t *msg_base)
+{
+    *msg_base = unsubscribe_namespace_base;
+}
+
+xqc_int_t
+xqc_moq_msg_encode_unsubscribe_namespace_len(xqc_moq_msg_base_t *msg_base)
+{
+    xqc_int_t len = 0;
+    xqc_moq_unsubscribe_namespace_msg_t *unsub = (xqc_moq_unsubscribe_namespace_msg_t *)msg_base;
+    size_t track_namespace_len = 0;
+    if (xqc_moq_track_namespace_tuple_validate_and_sum(unsub->track_namespace_num,
+            unsub->track_namespace_tuple, &track_namespace_len) != XQC_OK)
+    {
+        return -XQC_EPARAM;
+    }
+
+    len += xqc_put_varint_len(XQC_MOQ_MSG_UNSUBSCRIBE_NAMESPACE);
+    len += XQC_MOQ_MSG_LENGTH_FIXED_SIZE;
+    len += xqc_moq_track_namespace_tuple_encode_len(unsub->track_namespace_num,
+                                                    unsub->track_namespace_tuple);
+    return len;
+}
+
+xqc_int_t
+xqc_moq_msg_encode_unsubscribe_namespace(xqc_moq_msg_base_t *msg_base, uint8_t *buf, size_t buf_cap)
+{
+    xqc_moq_unsubscribe_namespace_msg_t *unsub = (xqc_moq_unsubscribe_namespace_msg_t *)msg_base;
+    size_t track_namespace_len = 0;
+    if (xqc_moq_track_namespace_tuple_validate_and_sum(unsub->track_namespace_num,
+            unsub->track_namespace_tuple, &track_namespace_len) != XQC_OK)
+    {
+        return -XQC_EPARAM;
+    }
+    unsub->track_namespace_len = track_namespace_len;
+
+    xqc_int_t length = xqc_moq_msg_encode_unsubscribe_namespace_len(msg_base);
+    if (length > buf_cap) {
+        return -XQC_EILLEGAL_FRAME;
+    }
+    length = length - xqc_put_varint_len(XQC_MOQ_MSG_UNSUBSCRIBE_NAMESPACE) - XQC_MOQ_MSG_LENGTH_FIXED_SIZE;
+
+    uint8_t *p = buf;
+    p = xqc_put_varint(p, XQC_MOQ_MSG_UNSUBSCRIBE_NAMESPACE);
+    p = xqc_moq_put_varint_length(p, length);
+    p = xqc_moq_track_namespace_tuple_encode(p, unsub->track_namespace_num,
+                                             unsub->track_namespace_tuple);
+    return p - buf;
+}
+
+xqc_int_t
+xqc_moq_msg_decode_unsubscribe_namespace(uint8_t *buf, size_t buf_len, uint8_t stream_fin,
+    xqc_moq_decode_msg_ctx_t *msg_ctx, xqc_moq_msg_base_t *msg_base,
+    xqc_int_t *finish, xqc_int_t *wait_more_data)
+{
+    *finish = 0;
+    *wait_more_data = 0;
+    xqc_int_t processed = 0;
+    xqc_int_t ret = 0;
+    uint64_t length = 0;
+    xqc_moq_unsubscribe_namespace_msg_t *unsub = (xqc_moq_unsubscribe_namespace_msg_t *)msg_base;
+
+    switch (msg_ctx->cur_field_idx) {
+        case 0:
+            ret = xqc_moq_length_read(buf + processed, buf + buf_len, &length);
+            if (ret < 0) {
+                *wait_more_data = 1;
+                break;
+            }
+            processed += ret;
+            msg_ctx->cur_field_idx = 1;
+        case 1:
+            if (unsub->track_namespace_num == 0) {
+                ret = xqc_vint_read(buf + processed, buf + buf_len, &unsub->track_namespace_num);
+                if (ret < 0) {
+                    *wait_more_data = 1;
+                    break;
+                }
+                processed += ret;
+                if (unsub->track_namespace_num == 0) {
+                    return -MOQ_PROTOCOL_VIOLATION;
+                }
+                if (unsub->track_namespace_num > XQC_MOQ_MAX_NAMESPACE_TUPLE_ELEMS) {
+                    return -MOQ_PROTOCOL_VIOLATION;
+                }
+                msg_ctx->cur_array_idx = 0;
+                msg_ctx->str_processed = 0;
+                msg_ctx->tuple_elem_len = 0;
+                msg_ctx->tuple_elem_len_ready = 0;
+                unsub->track_namespace_len = 0;
+                if (unsub->track_namespace_tuple == NULL) {
+                    unsub->track_namespace_tuple = xqc_calloc(unsub->track_namespace_num, sizeof(xqc_moq_track_ns_field_t));
+                    if (unsub->track_namespace_tuple == NULL) {
+                        return -XQC_EMALLOC;
+                    }
+                }
+            }
+            msg_ctx->cur_field_idx = 2;
+        case 2:
+            for (; msg_ctx->cur_array_idx < unsub->track_namespace_num; msg_ctx->cur_array_idx++) {
+                xqc_moq_track_ns_field_t *field = &unsub->track_namespace_tuple[msg_ctx->cur_array_idx];
+
+                if (!msg_ctx->tuple_elem_len_ready) {
+                    ret = xqc_vint_read(buf + processed, buf + buf_len, &msg_ctx->tuple_elem_len);
+                    if (ret < 0) {
+                        *wait_more_data = 1;
+                        break;
+                    }
+                    processed += ret;
+                    msg_ctx->tuple_elem_len_ready = 1;
+                    if (msg_ctx->tuple_elem_len > XQC_MOQ_MAX_NAME_LEN) {
+                        return -XQC_ELIMIT;
+                    }
+                    field->len = msg_ctx->tuple_elem_len;
+                    if (unsub->track_namespace_len > XQC_MOQ_MAX_FULL_TRACK_NAME_LEN - field->len) {
+                        return -MOQ_PROTOCOL_VIOLATION;
+                    }
+                    unsub->track_namespace_len += field->len;
+                    if (field->data == NULL && field->len > 0) {
+                        field->data = xqc_calloc(1, field->len + 1);
+                        if (field->data == NULL) {
+                            return -XQC_EMALLOC;
+                        }
+                    }
+                }
+
+                if (processed == buf_len) {
+                    *wait_more_data = 1;
+                    break;
+                }
+
+                size_t field_remaining = (msg_ctx->tuple_elem_len - msg_ctx->str_processed);
+                size_t buf_remaining = buf_len - processed;
+                size_t copy_len = field_remaining < buf_remaining ? field_remaining : buf_remaining;
+
+                if (copy_len > 0 && field->data != NULL) {
+                    xqc_memcpy(field->data + msg_ctx->str_processed, buf + processed, copy_len);
+                    msg_ctx->str_processed += copy_len;
+                    processed += copy_len;
+                }
+
+                if (msg_ctx->str_processed < msg_ctx->tuple_elem_len) {
+                    *wait_more_data = 1;
+                    break;
+                }
+
+                msg_ctx->str_processed = 0;
+                msg_ctx->tuple_elem_len_ready = 0;
+                msg_ctx->tuple_elem_len = 0;
+            }
+
+            if (*wait_more_data == 1) {
+                break;
+            }
+
             *finish = 1;
             break;
         default:
@@ -3214,8 +5235,7 @@ xqc_moq_msg_free_object_stream(void *msg)
     }
     xqc_moq_object_stream_msg_t *object_stream = (xqc_moq_object_stream_msg_t *)msg;
     if (object_stream->ext_params) {
-        xqc_moq_msg_free_params(object_stream->ext_params,
-                                (xqc_int_t)object_stream->ext_params_num);
+        xqc_moq_msg_free_params(object_stream->ext_params, object_stream->ext_params_num);
         object_stream->ext_params = NULL;
         object_stream->ext_params_num = 0;
     }
@@ -3487,7 +5507,7 @@ xqc_moq_msg_subgroup_parse_ext_params(xqc_moq_subgroup_msg_t *object)
     ret = xqc_moq_msg_decode_params_v14(object->ext_buf, object->ext_len,
                                         &params_ctx,
                                         object->ext_params,
-                                        (xqc_int_t)object->ext_params_num,
+                                        object->ext_params_num,
                                         &params_finish, &params_wait);
     if (ret < 0 || params_finish == 0 || params_wait != 0) {
         return -XQC_EILLEGAL_FRAME;
@@ -3523,7 +5543,7 @@ xqc_moq_msg_encode_subgroup_len(xqc_moq_msg_base_t *msg_base)
         uint64_t ext_len = 0;
         if (object->ext_params && object->ext_params_num > 0) {
             ext_len = xqc_moq_msg_encode_params_len_v14(object->ext_params,
-                                                        (xqc_int_t)object->ext_params_num);
+                                                        object->ext_params_num);
         }
         len += xqc_put_varint_len(ext_len);
         len += ext_len;
@@ -3638,18 +5658,18 @@ xqc_moq_msg_encode_subgroup(xqc_moq_msg_base_t *msg_base, uint8_t *buf, size_t b
         uint64_t ext_len = 0;
         if (object->ext_params && object->ext_params_num > 0) {
             ext_len = xqc_moq_msg_encode_params_len_v14(object->ext_params,
-                                                        (xqc_int_t)object->ext_params_num);
+                                                        object->ext_params_num);
         }
         p = xqc_put_varint(p, ext_len);
-        if (ext_len > 0) {
-            xqc_int_t ret = xqc_moq_msg_encode_params_v14(object->ext_params,
-                                                          (xqc_int_t)object->ext_params_num,
+            if (ext_len > 0) {
+                xqc_int_t ret = xqc_moq_msg_encode_params_v14(object->ext_params,
+                                                          object->ext_params_num,
                                                           p, buf + buf_cap - p);
-            if (ret < 0) {
-                return ret;
+                if (ret < 0) {
+                    return ret;
+                }
+                p += ret;
             }
-            p += ret;
-        }
     }
     p = xqc_put_varint(p, object->payload_len);
     if (object->payload_len == 0) {

--- a/moq/moq_transport/xqc_moq_message.c
+++ b/moq/moq_transport/xqc_moq_message.c
@@ -2394,6 +2394,7 @@ xqc_moq_msg_encode_subscribe_error_len(xqc_moq_msg_base_t *msg_base)
     xqc_int_t len = 0;
     xqc_moq_subscribe_error_msg_t *subscribe_error = (xqc_moq_subscribe_error_msg_t*)msg_base;
     len += xqc_put_varint_len(XQC_MOQ_MSG_SUBSCRIBE_ERROR);
+    len += XQC_MOQ_MSG_LENGTH_FIXED_SIZE;
     len += xqc_put_varint_len(subscribe_error->subscribe_id);
     len += xqc_put_varint_len(subscribe_error->error_code);
     len += xqc_put_varint_len(subscribe_error->reason_phrase_len);
@@ -2405,14 +2406,16 @@ xqc_moq_msg_encode_subscribe_error_len(xqc_moq_msg_base_t *msg_base)
 xqc_int_t
 xqc_moq_msg_encode_subscribe_error(xqc_moq_msg_base_t *msg_base, uint8_t *buf, size_t buf_cap)
 {
-    xqc_int_t ret = 0;
     xqc_moq_subscribe_error_msg_t *subscribe_error = (xqc_moq_subscribe_error_msg_t*)msg_base;
-    if (xqc_moq_msg_encode_subscribe_error_len(msg_base) > buf_cap) {
+    xqc_int_t length = xqc_moq_msg_encode_subscribe_error_len(msg_base);
+    if (length > buf_cap) {
         return -XQC_EILLEGAL_FRAME;
     }
 
+    length = length - xqc_put_varint_len(XQC_MOQ_MSG_SUBSCRIBE_ERROR) - XQC_MOQ_MSG_LENGTH_FIXED_SIZE;
     uint8_t *p = buf;
     p = xqc_put_varint(p, XQC_MOQ_MSG_SUBSCRIBE_ERROR);
+    p = xqc_moq_put_varint_length(p, length);
     p = xqc_put_varint(p, subscribe_error->subscribe_id);
     p = xqc_put_varint(p, subscribe_error->error_code);
     p = xqc_put_varint(p, subscribe_error->reason_phrase_len);

--- a/moq/moq_transport/xqc_moq_message.h
+++ b/moq/moq_transport/xqc_moq_message.h
@@ -7,7 +7,11 @@
 #define XQC_MOQ_MAX_VERSIONS        10
 #define XQC_MOQ_MAX_OBJECT_LEN      (10 * 1024 * 1024)
 #define XQC_MOQ_MAX_PARAM_VALUE_LEN 4096
-#define XQC_MOQ_MAX_NAME_LEN        1024
+#define XQC_MOQ_MAX_NAME_LEN        4096
+/* draft-14: Track Namespace tuple N MUST be between 1 and 32 */
+#define XQC_MOQ_MAX_NAMESPACE_TUPLE_ELEMS 32
+/* draft-14: maximum total length of Full Track Name */
+#define XQC_MOQ_MAX_FULL_TRACK_NAME_LEN 4096
 #define XQC_MOQ_MAX_AUTH_LEN        1024
 #define XQC_MOQ_MSG_LENGTH_FIXED_SIZE 2
 #define XQC_MOQ_U8_FIXED_SIZE 1
@@ -36,6 +40,8 @@ typedef struct xqc_moq_decode_msg_ctx_s {
     xqc_int_t                   cur_array_idx;
     xqc_int_t                   payload_processed;
     xqc_int_t                   str_processed;
+    uint64_t                    tuple_elem_len;
+    uint8_t                     tuple_elem_len_ready;
     xqc_moq_decode_params_ctx_t decode_params_ctx;
 } xqc_moq_decode_msg_ctx_t;
 
@@ -138,22 +144,6 @@ typedef struct xqc_moq_group_stream_obj_msg_s {
     uint64_t                    status;
     uint8_t                     *payload;
 } xqc_moq_group_stream_obj_msg_t;
-
-typedef struct xqc_moq_announce_msg_s {
-    xqc_moq_msg_base_t          msg_base;
-} xqc_moq_announce_msg_t;
-
-typedef struct xqc_moq_announce_ok_msg_s {
-    xqc_moq_msg_base_t          msg_base;
-} xqc_moq_announce_ok_msg_t;
-
-typedef struct xqc_moq_announce_error_msg_s {
-    xqc_moq_msg_base_t          msg_base;
-} xqc_moq_announce_error_msg_t;
-
-typedef struct xqc_moq_unannounce_msg_s {
-    xqc_moq_msg_base_t          msg_base;
-} xqc_moq_unannounce_msg_t;
 
 typedef struct xqc_moq_subscribe_update_msg_s {
     xqc_moq_msg_base_t          msg_base;
@@ -462,6 +452,141 @@ xqc_int_t xqc_moq_msg_encode_publish_done_len(xqc_moq_msg_base_t *msg_base);
 xqc_int_t xqc_moq_msg_encode_publish_done(xqc_moq_msg_base_t *msg_base, uint8_t *buf, size_t buf_cap);
 
 xqc_int_t xqc_moq_msg_decode_publish_done(uint8_t *buf, size_t buf_len, uint8_t stream_fin,
+    xqc_moq_decode_msg_ctx_t *msg_ctx, xqc_moq_msg_base_t *msg_base, xqc_int_t *finish, xqc_int_t *wait_more_data);
+
+void *xqc_moq_msg_create_publish_namespace();
+
+void xqc_moq_msg_free_publish_namespace(void *msg);
+
+xqc_moq_msg_type_t xqc_moq_msg_publish_namespace_type();
+
+void xqc_moq_msg_publish_namespace_init_handler(xqc_moq_msg_base_t *msg_base);
+
+xqc_int_t xqc_moq_msg_encode_publish_namespace_len(xqc_moq_msg_base_t *msg_base);
+
+xqc_int_t xqc_moq_msg_encode_publish_namespace(xqc_moq_msg_base_t *msg_base, uint8_t *buf, size_t buf_cap);
+
+xqc_int_t xqc_moq_msg_decode_publish_namespace(uint8_t *buf, size_t buf_len, uint8_t stream_fin,
+    xqc_moq_decode_msg_ctx_t *msg_ctx, xqc_moq_msg_base_t *msg_base, xqc_int_t *finish, xqc_int_t *wait_more_data);
+
+void *xqc_moq_msg_create_publish_namespace_ok();
+
+void xqc_moq_msg_free_publish_namespace_ok(void *msg);
+
+xqc_moq_msg_type_t xqc_moq_msg_publish_namespace_ok_type();
+
+void xqc_moq_msg_publish_namespace_ok_init_handler(xqc_moq_msg_base_t *msg_base);
+
+xqc_int_t xqc_moq_msg_encode_publish_namespace_ok_len(xqc_moq_msg_base_t *msg_base);
+
+xqc_int_t xqc_moq_msg_encode_publish_namespace_ok(xqc_moq_msg_base_t *msg_base, uint8_t *buf, size_t buf_cap);
+
+xqc_int_t xqc_moq_msg_decode_publish_namespace_ok(uint8_t *buf, size_t buf_len, uint8_t stream_fin,
+    xqc_moq_decode_msg_ctx_t *msg_ctx, xqc_moq_msg_base_t *msg_base, xqc_int_t *finish, xqc_int_t *wait_more_data);
+
+void *xqc_moq_msg_create_publish_namespace_error();
+
+void xqc_moq_msg_free_publish_namespace_error(void *msg);
+
+xqc_moq_msg_type_t xqc_moq_msg_publish_namespace_error_type();
+
+void xqc_moq_msg_publish_namespace_error_init_handler(xqc_moq_msg_base_t *msg_base);
+
+xqc_int_t xqc_moq_msg_encode_publish_namespace_error_len(xqc_moq_msg_base_t *msg_base);
+
+xqc_int_t xqc_moq_msg_encode_publish_namespace_error(xqc_moq_msg_base_t *msg_base, uint8_t *buf, size_t buf_cap);
+
+xqc_int_t xqc_moq_msg_decode_publish_namespace_error(uint8_t *buf, size_t buf_len, uint8_t stream_fin,
+    xqc_moq_decode_msg_ctx_t *msg_ctx, xqc_moq_msg_base_t *msg_base, xqc_int_t *finish, xqc_int_t *wait_more_data);
+
+void *xqc_moq_msg_create_publish_namespace_done();
+
+void xqc_moq_msg_free_publish_namespace_done(void *msg);
+
+xqc_moq_msg_type_t xqc_moq_msg_publish_namespace_done_type();
+
+void xqc_moq_msg_publish_namespace_done_init_handler(xqc_moq_msg_base_t *msg_base);
+
+xqc_int_t xqc_moq_msg_encode_publish_namespace_done_len(xqc_moq_msg_base_t *msg_base);
+
+xqc_int_t xqc_moq_msg_encode_publish_namespace_done(xqc_moq_msg_base_t *msg_base, uint8_t *buf, size_t buf_cap);
+
+xqc_int_t xqc_moq_msg_decode_publish_namespace_done(uint8_t *buf, size_t buf_len, uint8_t stream_fin,
+    xqc_moq_decode_msg_ctx_t *msg_ctx, xqc_moq_msg_base_t *msg_base, xqc_int_t *finish, xqc_int_t *wait_more_data);
+
+void *xqc_moq_msg_create_publish_namespace_cancel();
+
+void xqc_moq_msg_free_publish_namespace_cancel(void *msg);
+
+xqc_moq_msg_type_t xqc_moq_msg_publish_namespace_cancel_type();
+
+void xqc_moq_msg_publish_namespace_cancel_init_handler(xqc_moq_msg_base_t *msg_base);
+
+xqc_int_t xqc_moq_msg_encode_publish_namespace_cancel_len(xqc_moq_msg_base_t *msg_base);
+
+xqc_int_t xqc_moq_msg_encode_publish_namespace_cancel(xqc_moq_msg_base_t *msg_base, uint8_t *buf, size_t buf_cap);
+
+xqc_int_t xqc_moq_msg_decode_publish_namespace_cancel(uint8_t *buf, size_t buf_len, uint8_t stream_fin,
+    xqc_moq_decode_msg_ctx_t *msg_ctx, xqc_moq_msg_base_t *msg_base, xqc_int_t *finish, xqc_int_t *wait_more_data);
+
+void *xqc_moq_msg_create_subscribe_namespace();
+
+void xqc_moq_msg_free_subscribe_namespace(void *msg);
+
+xqc_moq_msg_type_t xqc_moq_msg_subscribe_namespace_type();
+
+void xqc_moq_msg_subscribe_namespace_init_handler(xqc_moq_msg_base_t *msg_base);
+
+xqc_int_t xqc_moq_msg_encode_subscribe_namespace_len(xqc_moq_msg_base_t *msg_base);
+
+xqc_int_t xqc_moq_msg_encode_subscribe_namespace(xqc_moq_msg_base_t *msg_base, uint8_t *buf, size_t buf_cap);
+
+xqc_int_t xqc_moq_msg_decode_subscribe_namespace(uint8_t *buf, size_t buf_len, uint8_t stream_fin,
+    xqc_moq_decode_msg_ctx_t *msg_ctx, xqc_moq_msg_base_t *msg_base, xqc_int_t *finish, xqc_int_t *wait_more_data);
+
+void *xqc_moq_msg_create_subscribe_namespace_ok();
+
+void xqc_moq_msg_free_subscribe_namespace_ok(void *msg);
+
+xqc_moq_msg_type_t xqc_moq_msg_subscribe_namespace_ok_type();
+
+void xqc_moq_msg_subscribe_namespace_ok_init_handler(xqc_moq_msg_base_t *msg_base);
+
+xqc_int_t xqc_moq_msg_encode_subscribe_namespace_ok_len(xqc_moq_msg_base_t *msg_base);
+
+xqc_int_t xqc_moq_msg_encode_subscribe_namespace_ok(xqc_moq_msg_base_t *msg_base, uint8_t *buf, size_t buf_cap);
+
+xqc_int_t xqc_moq_msg_decode_subscribe_namespace_ok(uint8_t *buf, size_t buf_len, uint8_t stream_fin,
+    xqc_moq_decode_msg_ctx_t *msg_ctx, xqc_moq_msg_base_t *msg_base, xqc_int_t *finish, xqc_int_t *wait_more_data);
+
+void *xqc_moq_msg_create_subscribe_namespace_error();
+
+void xqc_moq_msg_free_subscribe_namespace_error(void *msg);
+
+xqc_moq_msg_type_t xqc_moq_msg_subscribe_namespace_error_type();
+
+void xqc_moq_msg_subscribe_namespace_error_init_handler(xqc_moq_msg_base_t *msg_base);
+
+xqc_int_t xqc_moq_msg_encode_subscribe_namespace_error_len(xqc_moq_msg_base_t *msg_base);
+
+xqc_int_t xqc_moq_msg_encode_subscribe_namespace_error(xqc_moq_msg_base_t *msg_base, uint8_t *buf, size_t buf_cap);
+
+xqc_int_t xqc_moq_msg_decode_subscribe_namespace_error(uint8_t *buf, size_t buf_len, uint8_t stream_fin,
+    xqc_moq_decode_msg_ctx_t *msg_ctx, xqc_moq_msg_base_t *msg_base, xqc_int_t *finish, xqc_int_t *wait_more_data);
+
+void *xqc_moq_msg_create_unsubscribe_namespace();
+
+void xqc_moq_msg_free_unsubscribe_namespace(void *msg);
+
+xqc_moq_msg_type_t xqc_moq_msg_unsubscribe_namespace_type();
+
+void xqc_moq_msg_unsubscribe_namespace_init_handler(xqc_moq_msg_base_t *msg_base);
+
+xqc_int_t xqc_moq_msg_encode_unsubscribe_namespace_len(xqc_moq_msg_base_t *msg_base);
+
+xqc_int_t xqc_moq_msg_encode_unsubscribe_namespace(xqc_moq_msg_base_t *msg_base, uint8_t *buf, size_t buf_cap);
+
+xqc_int_t xqc_moq_msg_decode_unsubscribe_namespace(uint8_t *buf, size_t buf_len, uint8_t stream_fin,
     xqc_moq_decode_msg_ctx_t *msg_ctx, xqc_moq_msg_base_t *msg_base, xqc_int_t *finish, xqc_int_t *wait_more_data);
 
 #endif /* _XQC_MOQ_MESSAGE_H_INCLUDED_ */

--- a/moq/moq_transport/xqc_moq_message_handler.c
+++ b/moq/moq_transport/xqc_moq_message_handler.c
@@ -321,7 +321,15 @@ xqc_moq_on_subscribe(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream, x
     xqc_int_t ret;
     xqc_moq_subscribe_msg_t *subscribe_msg = (xqc_moq_subscribe_msg_t*)msg_base;
 
-    track = xqc_moq_find_track_by_name(session, subscribe_msg->track_namespace, subscribe_msg->track_name, XQC_MOQ_TRACK_FOR_PUB);
+    if (subscribe_msg->track_namespace_tuple == NULL || subscribe_msg->track_namespace_num == 0) {
+        xqc_log(session->log, XQC_LOG_ERROR, "|subscribe missing namespace tuple|subscribe_id:%ui|",
+                subscribe_msg->subscribe_id);
+        goto error;
+    }
+
+    track = xqc_moq_find_track_by_track_namespace_tuple(session,
+        subscribe_msg->track_namespace_tuple, subscribe_msg->track_namespace_num,
+        subscribe_msg->track_name, XQC_MOQ_TRACK_FOR_PUB);
     if (track == NULL) {
         xqc_log(session->log, XQC_LOG_ERROR, "|track not found|track_alias:%ui|", subscribe_msg->track_alias);
         goto error;
@@ -346,10 +354,12 @@ xqc_moq_on_subscribe(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream, x
     xqc_moq_track_set_subscribe_id(track, subscribe_msg->subscribe_id);
     xqc_moq_track_set_alias(track, subscribe_msg->track_alias);
 
-    subscribe = xqc_moq_subscribe_create(session, subscribe_msg->subscribe_id,
-                     subscribe_msg->track_alias, subscribe_msg->track_namespace, subscribe_msg->track_name,
-                     subscribe_msg->filter_type, subscribe_msg->start_group_id, subscribe_msg->start_object_id,
-                     subscribe_msg->end_group_id, subscribe_msg->end_object_id, NULL, 0);
+    subscribe = xqc_moq_subscribe_create_with_namespace_tuple(session, subscribe_msg->subscribe_id,
+        subscribe_msg->track_alias,
+        subscribe_msg->track_namespace_tuple, subscribe_msg->track_namespace_num,
+        subscribe_msg->track_name, subscribe_msg->track_name_len,
+        subscribe_msg->filter_type, subscribe_msg->start_group_id, subscribe_msg->start_object_id,
+        subscribe_msg->end_group_id, subscribe_msg->end_object_id, NULL, 0);
     if (subscribe == NULL) {
         xqc_log(session->log, XQC_LOG_ERROR, "|create subscribe error|");
         goto error;
@@ -534,23 +544,36 @@ xqc_moq_on_publish(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream, xqc
                 xqc_moq_track_info_t *track_info_array[1];
                 track_info_array[0] = &catalog_track->track_info;
                 session->session_callbacks.on_catalog(session->user_session, track_info_array, 1);
-                track = xqc_moq_find_track_by_name(session, publish->track_namespace, publish->track_name, XQC_MOQ_TRACK_FOR_SUB);
+                track = NULL;
+                if (publish->track_namespace_tuple != NULL && publish->track_namespace_num > 0) {
+                    track = xqc_moq_find_track_by_track_namespace_tuple(session, publish->track_namespace_tuple,
+                                                                  publish->track_namespace_num,
+                                                                  publish->track_name, XQC_MOQ_TRACK_FOR_SUB);
+                }
+                if (track == NULL) {
+                    if (catalog_track != NULL
+                        && catalog_track->track_info.track_namespace_tuple != NULL
+                        && catalog_track->track_info.track_namespace_num > 0)
+                    {
+                        track = xqc_moq_find_track_by_track_namespace_tuple(session,
+                                catalog_track->track_info.track_namespace_tuple,
+                                catalog_track->track_info.track_namespace_num,
+                                publish->track_name, XQC_MOQ_TRACK_FOR_SUB);
+                    }
+                }
                 if (track) {
                     xqc_moq_track_set_params(track, &catalog_track->track_info.selection_params);
                 } else {
                     xqc_log(session->log, XQC_LOG_INFO,
-                            "|on_publish catalog params pending track create|track:%s/%s|",
-                            publish->track_namespace, publish->track_name);
+                            "|on_publish catalog params pending track create|track_name:%s|",
+                            publish->track_name ? publish->track_name : "null");
                 }
             } else if (catalog_track->track_info.track_type == XQC_MOQ_TRACK_DATACHANNEL) {
                 track_type = XQC_MOQ_TRACK_DATACHANNEL;
                 xqc_log(session->log, XQC_LOG_INFO,
-                        "|on_publish_catalog_datatrack|subscribe_id:%ui|track:%s/%s|",
+                        "|on_publish_catalog_datatrack|subscribe_id:%ui|track:%s|",
                         publish->subscribe_id,
-                        catalog_track->track_info.track_namespace ?
-                            catalog_track->track_info.track_namespace : "null",
-                        catalog_track->track_info.track_name ?
-                            catalog_track->track_info.track_name : "null");
+                        xqc_moq_track_get_full_name(catalog_track));
             }
         }
 
@@ -558,7 +581,17 @@ xqc_moq_on_publish(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream, xqc
         break;
     }
 
-    track = xqc_moq_find_track_by_name(session, publish->track_namespace, publish->track_name, XQC_MOQ_TRACK_FOR_SUB);
+    if (track == NULL) {
+        if (publish->track_namespace_tuple == NULL || publish->track_namespace_num == 0) {
+            xqc_log(session->log, XQC_LOG_ERROR, "|on_publish missing namespace tuple|subscribe_id:%ui|",
+                    publish->subscribe_id);
+            xqc_moq_publish_send_error(session, NULL, publish->subscribe_id,
+                                      XQC_MOQ_PUBLISH_ERR_INTERNAL, "missing namespace tuple");
+            goto clean_up;
+        }
+        track = xqc_moq_find_track_by_track_namespace_tuple(session, publish->track_namespace_tuple,
+            publish->track_namespace_num, publish->track_name, XQC_MOQ_TRACK_FOR_SUB);
+    }
     if (track == NULL) {
         xqc_moq_selection_params_t *params = NULL;
         xqc_moq_container_t container = XQC_MOQ_CONTAINER_LOC;
@@ -576,9 +609,9 @@ xqc_moq_on_publish(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream, xqc
             container = XQC_MOQ_CONTAINER_NONE;
         }
 
-        track = xqc_moq_track_create(session, publish->track_namespace, publish->track_name,
-                                     track_type, params, container,
-                                     XQC_MOQ_TRACK_FOR_SUB);
+        track = xqc_moq_track_create_with_namespace_tuple(session,
+            publish->track_namespace_num, publish->track_namespace_tuple,
+            publish->track_name, track_type, params, container, XQC_MOQ_TRACK_FOR_SUB);
         if (track == NULL) {
             xqc_log(session->log, XQC_LOG_ERROR, "|on_publish track not found|track_name:%s|", publish->track_name);
             xqc_moq_publish_send_error(session, NULL, publish->subscribe_id,
@@ -593,17 +626,15 @@ xqc_moq_on_publish(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream, xqc
         }
 
         xqc_log(session->log, XQC_LOG_INFO,
-                "|on_publish_track_created|subscribe_id:%ui|track:%s/%s|track_type:%d|container:%d|",
+                "|on_publish_track_created|subscribe_id:%ui|track:%s|track_type:%d|container:%d|",
                 publish->subscribe_id,
-                track->track_info.track_namespace ? track->track_info.track_namespace : "null",
-                track->track_info.track_name ? track->track_info.track_name : "null",
+                xqc_moq_track_get_full_name(track),
                 track->track_info.track_type, track->container_format);
     } else {
         xqc_log(session->log, XQC_LOG_INFO,
-                "|on_publish_track_found|subscribe_id:%ui|track:%s/%s|track_type:%d|",
+                "|on_publish_track_found|subscribe_id:%ui|track:%s|track_type:%d|",
                 publish->subscribe_id,
-                track->track_info.track_namespace ? track->track_info.track_namespace : "null",
-                track->track_info.track_name ? track->track_info.track_name : "null",
+                xqc_moq_track_get_full_name(track),
                 track->track_info.track_type);
     }
 
@@ -616,8 +647,9 @@ xqc_moq_on_publish(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream, xqc
     }
 
     xqc_log(session->log, XQC_LOG_INFO,
-            "|on_publish|subscribe_id:%ui|track:%s/%s|track_alias:%ui|forward:%u|",
-            publish->subscribe_id, publish->track_namespace, publish->track_name,
+            "|on_publish|subscribe_id:%ui|track name:%s|track_alias:%ui|forward:%u|",
+            publish->subscribe_id,
+            publish->track_name ? publish->track_name : "null",
             publish->track_alias, publish->forward);
 
     xqc_moq_publish_selected_params_t selected_params;
@@ -637,11 +669,13 @@ xqc_moq_on_publish(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream, xqc
 
     subscribe = xqc_moq_find_subscribe(session, publish->subscribe_id, 1);
     if (subscribe == NULL) {
-        subscribe = xqc_moq_subscribe_create(session, publish->subscribe_id,
-                                             publish->track_alias, publish->track_namespace,
-                                             publish->track_name, selected_params.filter_type,
-                                             selected_params.start_group_id, selected_params.start_object_id,
-                                             selected_params.end_group_id, selected_params.end_object_id, NULL, 1);
+        subscribe = xqc_moq_subscribe_create_with_namespace_tuple(session, publish->subscribe_id,
+            publish->track_alias,
+            publish->track_namespace_tuple, publish->track_namespace_num,
+            publish->track_name, publish->track_name_len,
+            selected_params.filter_type,
+            selected_params.start_group_id, selected_params.start_object_id,
+            selected_params.end_group_id, selected_params.end_object_id, NULL, 1);
         if (subscribe == NULL) {
             xqc_log(session->log, XQC_LOG_ERROR, "|on_publish create subscribe error|");
             xqc_moq_publish_send_error(session, track, publish->subscribe_id,
@@ -724,10 +758,10 @@ xqc_moq_on_publish_error(xqc_moq_session_t *session, xqc_moq_stream_t *moq_strea
 
     track = xqc_moq_find_track_by_alias(session, subscribe->subscribe_msg->track_alias, XQC_MOQ_TRACK_FOR_PUB);
     if (track) {
-        xqc_log(session->log, XQC_LOG_INFO,
-                "|on_publish_error|subscribe_id:%ui|track:%s/%s|reason:%s|",
+        xqc_log(session->log, XQC_LOG_ERROR,
+                "|on_publish_error|subscribe_id:%ui|track:%s|reason:%s|",
                 publish_error->subscribe_id,
-                track->track_info.track_namespace, track->track_info.track_name,
+                xqc_moq_track_get_full_name(track),
                 publish_error->reason_phrase ? publish_error->reason_phrase : "null");
         xqc_moq_track_set_alias(track, XQC_MOQ_INVALID_ID);
         xqc_moq_track_set_subscribe_id(track, XQC_MOQ_INVALID_ID);
@@ -763,8 +797,8 @@ xqc_moq_on_publish_done(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream
     track = xqc_moq_find_track_by_alias(session, subscribe->subscribe_msg->track_alias, XQC_MOQ_TRACK_FOR_SUB);
     if (track) {
         xqc_log(session->log, XQC_LOG_INFO,
-                "|on_publish_done|subscribe_id:%ui|track:%s/%s|status:%ui|streams:%ui|reason:%s|",
-                publish_done->subscribe_id, track->track_info.track_namespace, track->track_info.track_name,
+                "|on_publish_done|subscribe_id:%ui|track:%s|status:%ui|streams:%ui|reason:%s|",
+                publish_done->subscribe_id, xqc_moq_track_get_full_name(track),
                 publish_done->status_code, publish_done->stream_count,
                 publish_done->reason_phrase ? publish_done->reason_phrase : "null");
         xqc_moq_track_set_alias(track, XQC_MOQ_INVALID_ID);
@@ -835,10 +869,9 @@ xqc_moq_on_object(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream, xqc_
 
     if (track->track_info.track_type == XQC_MOQ_TRACK_DATACHANNEL) {
         xqc_log(session->log, XQC_LOG_INFO,
-                "|on_object_datatrack|subscribe_id:%ui|track:%s/%s|payload_len:%ui|",
+                "|on_object_datatrack|subscribe_id:%ui|track:%s|payload_len:%ui|",
                 object->subscribe_id,
-                track->track_info.track_namespace ? track->track_info.track_namespace : "null",
-                track->track_info.track_name ? track->track_info.track_name : "null",
+                xqc_moq_track_get_full_name(track),
                 object->payload_len);
     }
 
@@ -955,6 +988,233 @@ xqc_moq_on_unsubscribe(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream,
     xqc_moq_subscribe_destroy(subscribe);
     xqc_moq_track_set_subscribe_id(track, XQC_MOQ_INVALID_ID);
     xqc_moq_track_set_alias(track, XQC_MOQ_INVALID_ID);
+}
+
+void
+xqc_moq_on_publish_namespace(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream, xqc_moq_msg_base_t *msg_base)
+{
+    xqc_moq_publish_namespace_msg_t *msg = (xqc_moq_publish_namespace_msg_t *)msg_base;
+    if (session == NULL || msg == NULL) {
+        return;
+    }
+
+    if (session->session_callbacks.on_publish_namespace) {
+        session->session_callbacks.on_publish_namespace(session->user_session, msg);
+        return;
+    }
+
+    xqc_moq_publish_namespace_ok_msg_t ok;
+    memset(&ok, 0, sizeof(ok));
+    ok.request_id = msg->request_id;
+    xqc_int_t ret = xqc_moq_write_publish_namespace_ok(session, &ok);
+    if (ret < 0) {
+        xqc_log(session->log, XQC_LOG_ERROR, "|write_publish_namespace_ok error|ret:%d|", ret);
+        xqc_moq_session_error(session, MOQ_INTERNAL_ERROR, "on publish namespace");
+    }
+}
+
+void
+xqc_moq_on_publish_namespace_ok(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream, xqc_moq_msg_base_t *msg_base)
+{
+    xqc_moq_publish_namespace_ok_msg_t *ok = (xqc_moq_publish_namespace_ok_msg_t *)msg_base;
+    if (session == NULL || ok == NULL) {
+        return;
+    }
+    xqc_log(session->log, XQC_LOG_INFO, "|publish_namespace_ok|request_id:%ui|", ok->request_id);
+}
+
+void
+xqc_moq_on_publish_namespace_error(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream, xqc_moq_msg_base_t *msg_base)
+{
+    xqc_moq_publish_namespace_error_msg_t *err = (xqc_moq_publish_namespace_error_msg_t *)msg_base;
+    if (session == NULL || err == NULL) {
+        return;
+    }
+    xqc_log(session->log, XQC_LOG_WARN, "|publish_namespace_error|request_id:%ui|error_code:%ui|reason:%s|",
+            err->request_id, err->error_code, err->reason_phrase ? err->reason_phrase : "");
+}
+
+void
+xqc_moq_on_publish_namespace_done(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream, xqc_moq_msg_base_t *msg_base)
+{
+    xqc_moq_publish_namespace_done_msg_t *done = (xqc_moq_publish_namespace_done_msg_t *)msg_base;
+    if (session == NULL || done == NULL) {
+        return;
+    }
+    if (session->session_callbacks.on_publish_namespace_done) {
+        session->session_callbacks.on_publish_namespace_done(session->user_session, done);
+    }
+}
+
+void
+xqc_moq_on_publish_namespace_cancel(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream, xqc_moq_msg_base_t *msg_base)
+{
+    xqc_moq_publish_namespace_cancel_msg_t *cancel = (xqc_moq_publish_namespace_cancel_msg_t *)msg_base;
+    if (session == NULL || cancel == NULL) {
+        return;
+    }
+    if (session->session_callbacks.on_publish_namespace_cancel) {
+        session->session_callbacks.on_publish_namespace_cancel(session->user_session, cancel);
+    }
+}
+
+static xqc_int_t
+xqc_moq_discovery_send_publish_namespace(xqc_moq_session_t *session, void *user_data,
+    const xqc_moq_track_ns_field_t *track_namespace_tuple, uint64_t track_namespace_num)
+{
+    (void)user_data;
+
+    if (session == NULL || track_namespace_tuple == NULL || track_namespace_num == 0) {
+        return -XQC_EPARAM;
+    }
+
+    xqc_moq_publish_namespace_msg_t publish_namespace_msg;
+    memset(&publish_namespace_msg, 0, sizeof(publish_namespace_msg));
+    publish_namespace_msg.request_id = xqc_moq_session_alloc_subscribe_id(session);
+    publish_namespace_msg.track_namespace_num = track_namespace_num;
+    publish_namespace_msg.track_namespace_tuple = (xqc_moq_track_ns_field_t *)track_namespace_tuple;
+    publish_namespace_msg.track_namespace_len = 0;
+    publish_namespace_msg.params_num = 0;
+    publish_namespace_msg.params = NULL;
+    return xqc_moq_write_publish_namespace(session, &publish_namespace_msg);
+}
+
+static xqc_int_t
+xqc_moq_discovery_send_publish_track(xqc_moq_session_t *session, void *user_data, xqc_moq_track_t *track)
+{
+    (void)user_data;
+    if (session == NULL || track == NULL || track->track_info.track_name == NULL
+        || track->track_info.track_namespace_tuple == NULL || track->track_info.track_namespace_num == 0)
+    {
+        return -XQC_EPARAM;
+    }
+
+    xqc_moq_publish_msg_t publish_msg;
+    memset(&publish_msg, 0, sizeof(publish_msg));
+    publish_msg.track_namespace_num = track->track_info.track_namespace_num;
+    publish_msg.track_namespace_tuple = track->track_info.track_namespace_tuple;
+    publish_msg.track_namespace_len = 0;
+    publish_msg.track_name = track->track_info.track_name;
+    publish_msg.track_name_len = 0;
+    publish_msg.group_order = 0;
+    publish_msg.content_exist = 0;
+    publish_msg.largest_group_id = 0;
+    publish_msg.largest_object_id = 0;
+    publish_msg.forward = 1;
+    publish_msg.params_num = 0;
+    publish_msg.params = NULL;
+
+    xqc_int_t ret = xqc_moq_publish(session, &publish_msg);
+    return ret < 0 ? ret : XQC_OK;
+}
+
+void
+xqc_moq_on_subscribe_namespace(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream, xqc_moq_msg_base_t *msg_base)
+{
+    xqc_moq_subscribe_namespace_msg_t *msg = (xqc_moq_subscribe_namespace_msg_t *)msg_base;
+    if (session == NULL || msg == NULL) {
+        return;
+    }
+
+    if (session->session_callbacks.on_subscribe_namespace) {
+        session->session_callbacks.on_subscribe_namespace(session->user_session, msg);
+        return;
+    }
+
+    if (msg->track_namespace_tuple == NULL
+        || msg->track_namespace_num == 0
+        || msg->track_namespace_num > XQC_MOQ_MAX_NAMESPACE_TUPLE_ELEMS)
+    {
+        xqc_log(session->log, XQC_LOG_ERROR,
+                "|subscribe_namespace invalid prefix|request_id:%ui|prefix_num:%ui|",
+                msg->request_id, msg->track_namespace_num);
+        xqc_moq_session_error(session, MOQ_PROTOCOL_VIOLATION, "subscribe namespace invalid prefix");
+        return;
+    }
+
+    if (xqc_moq_session_namespace_prefix_overlaps(session, msg->track_namespace_tuple, msg->track_namespace_num)) {
+        xqc_moq_subscribe_namespace_error_msg_t err;
+        memset(&err, 0, sizeof(err));
+        err.request_id = msg->request_id;
+        err.error_code = XQC_MOQ_SUBSCRIBE_NAMESPACE_ERR_PREFIX_OVERLAP;
+        err.reason_phrase = "namespace prefix overlap";
+        xqc_int_t ret = xqc_moq_write_subscribe_namespace_error(session, &err);
+        if (ret < 0) {
+            xqc_log(session->log, XQC_LOG_ERROR, "|write_subscribe_namespace_error error|ret:%d|", ret);
+            xqc_moq_session_error(session, MOQ_INTERNAL_ERROR, "on subscribe namespace");
+        }
+        return;
+    }
+
+    xqc_int_t ret = xqc_moq_session_add_namespace_prefix(session, msg->track_namespace_tuple, msg->track_namespace_num);
+    if (ret < 0) {
+        xqc_log(session->log, XQC_LOG_ERROR, "|add namespace prefix failed|ret:%d|", ret);
+        xqc_moq_session_error(session, MOQ_INTERNAL_ERROR, "on subscribe namespace");
+        return;
+    }
+
+    xqc_moq_subscribe_namespace_ok_msg_t ok;
+    memset(&ok, 0, sizeof(ok));
+    ok.request_id = msg->request_id;
+    ret = xqc_moq_write_subscribe_namespace_ok(session, &ok);
+    if (ret < 0) {
+        xqc_log(session->log, XQC_LOG_ERROR, "|write_subscribe_namespace_ok error|ret:%d|", ret);
+        xqc_moq_session_error(session, MOQ_INTERNAL_ERROR, "on subscribe namespace");
+        return;
+    }
+
+    xqc_moq_namespace_discovery_update_cb_t discovery_update_callbacks = {
+        .user_data = NULL,
+        .on_namespace = xqc_moq_discovery_send_publish_namespace,
+        .on_namespace_done = NULL,
+        .on_track = xqc_moq_discovery_send_publish_track,
+    };
+
+    ret = xqc_moq_session_discovery_refresh_namespace_prefix(session,
+        msg->track_namespace_tuple, msg->track_namespace_num, &discovery_update_callbacks);
+    if (ret < 0) {
+        xqc_log(session->log, XQC_LOG_ERROR, "|forward namespace discovery failed|ret:%d|", ret);
+        xqc_moq_session_error(session, MOQ_INTERNAL_ERROR, "forward namespace discovery");
+        return;
+    }
+}
+
+void
+xqc_moq_on_subscribe_namespace_ok(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream, xqc_moq_msg_base_t *msg_base)
+{
+    xqc_moq_subscribe_namespace_ok_msg_t *ok = (xqc_moq_subscribe_namespace_ok_msg_t *)msg_base;
+    if (session == NULL || ok == NULL) {
+        return;
+    }
+    xqc_log(session->log, XQC_LOG_INFO, "|subscribe_namespace_ok|request_id:%ui|", ok->request_id);
+}
+
+void
+xqc_moq_on_subscribe_namespace_error(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream, xqc_moq_msg_base_t *msg_base)
+{
+    xqc_moq_subscribe_namespace_error_msg_t *err = (xqc_moq_subscribe_namespace_error_msg_t *)msg_base;
+    if (session == NULL || err == NULL) {
+        return;
+    }
+    xqc_log(session->log, XQC_LOG_WARN, "|subscribe_namespace_error|request_id:%ui|error_code:%ui|reason:%s|",
+            err->request_id, err->error_code, err->reason_phrase ? err->reason_phrase : "");
+}
+
+void
+xqc_moq_on_unsubscribe_namespace(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream, xqc_moq_msg_base_t *msg_base)
+{
+    xqc_moq_unsubscribe_namespace_msg_t *msg = (xqc_moq_unsubscribe_namespace_msg_t *)msg_base;
+    if (session == NULL || msg == NULL) {
+        return;
+    }
+
+    if (msg->track_namespace_tuple != NULL && msg->track_namespace_num > 0) {
+        xqc_moq_session_remove_namespace_prefix(session, msg->track_namespace_tuple, msg->track_namespace_num);
+    }
+
+    if (session->session_callbacks.on_unsubscribe_namespace) {
+        session->session_callbacks.on_unsubscribe_namespace(session->user_session, msg);
+    }
 }
 
 static uint8_t

--- a/moq/moq_transport/xqc_moq_message_handler.c
+++ b/moq/moq_transport/xqc_moq_message_handler.c
@@ -176,17 +176,13 @@ xqc_moq_on_client_setup_v14(xqc_moq_session_t *session, xqc_moq_stream_t *moq_st
     }
     xqc_log(session->log, XQC_LOG_INFO, "|client_setup_v14_complete|local_role:%u|", session->role);
 
-    ret = xqc_moq_subscribe_datachannel(session);
-    if (ret < 0) {
-        xqc_log(session->log, XQC_LOG_ERROR, "|xqc_moq_subscribe_datachannel error|ret:%d|", ret);
-        goto error;
+    if (session->role != XQC_MOQ_PUBSUB) {
+        ret = xqc_moq_subscribe_datachannel(session);
+        if (ret < 0) {
+            xqc_log(session->log, XQC_LOG_ERROR, "|xqc_moq_subscribe_datachannel error|ret:%d|", ret);
+            goto error;
+        }
     }
-
-    // ret = xqc_moq_subscribe_catalog(session);
-    // if (ret < 0) {
-    //     xqc_log(session->log, XQC_LOG_ERROR, "|xqc_moq_subscribe_catalog error|ret:%d|", ret);
-    //     goto error;
-    // }
 
     session->session_setup_done = 1;
 
@@ -331,8 +327,22 @@ xqc_moq_on_subscribe(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream, x
         subscribe_msg->track_namespace_tuple, subscribe_msg->track_namespace_num,
         subscribe_msg->track_name, XQC_MOQ_TRACK_FOR_PUB);
     if (track == NULL) {
-        xqc_log(session->log, XQC_LOG_ERROR, "|track not found|track_alias:%ui|", subscribe_msg->track_alias);
-        goto error;
+        xqc_log(session->log, XQC_LOG_WARN, "|track not found|track_alias:%ui|subscribe_id:%ui|",
+                subscribe_msg->track_alias, subscribe_msg->subscribe_id);
+        if (session->session_callbacks.on_subscribe) {
+            session->session_callbacks.on_subscribe(session->user_session,
+                subscribe_msg->subscribe_id, NULL, subscribe_msg);
+            return;
+        }
+        xqc_moq_subscribe_error_msg_t subscribe_error;
+        memset(&subscribe_error, 0, sizeof(subscribe_error));
+        subscribe_error.subscribe_id = subscribe_msg->subscribe_id;
+        subscribe_error.error_code = MOQ_INTERNAL_ERROR;
+        subscribe_error.reason_phrase = "track not found";
+        subscribe_error.reason_phrase_len = 15;
+        subscribe_error.track_alias = subscribe_msg->track_alias;
+        xqc_moq_write_subscribe_error(session, &subscribe_error);
+        return;
     }
 
     if (track->subscribe_id != XQC_MOQ_INVALID_ID) {

--- a/moq/moq_transport/xqc_moq_message_handler.c
+++ b/moq/moq_transport/xqc_moq_message_handler.c
@@ -287,17 +287,13 @@ xqc_moq_on_server_setup_v14(xqc_moq_session_t *session, xqc_moq_stream_t *moq_st
         }
     }
 
-    ret = xqc_moq_subscribe_datachannel(session);
-    if (ret < 0) {
-        xqc_log(session->log, XQC_LOG_ERROR, "|xqc_moq_subscribe_datachannel error|ret:%d|", ret);
-        goto error;
+    if (session->role != XQC_MOQ_PUBSUB) {
+        ret = xqc_moq_subscribe_datachannel(session);
+        if (ret < 0) {
+            xqc_log(session->log, XQC_LOG_ERROR, "|xqc_moq_subscribe_datachannel error|ret:%d|", ret);
+            goto error;
+        }
     }
-
-    // ret = xqc_moq_subscribe_catalog(session);
-    // if (ret < 0) {
-    //     xqc_log(session->log, XQC_LOG_ERROR, "|xqc_moq_subscribe_catalog error|ret:%d|", ret);
-    //     goto error;
-    // }
 
     session->session_setup_done = 1;
     xqc_log(session->log, XQC_LOG_INFO, "|server_setup_v14_complete|");

--- a/moq/moq_transport/xqc_moq_message_handler.h
+++ b/moq/moq_transport/xqc_moq_message_handler.h
@@ -27,6 +27,24 @@ void xqc_moq_on_publish_error(xqc_moq_session_t *session, xqc_moq_stream_t *moq_
 
 void xqc_moq_on_publish_done(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream, xqc_moq_msg_base_t *msg_base);
 
+void xqc_moq_on_publish_namespace(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream, xqc_moq_msg_base_t *msg_base);
+
+void xqc_moq_on_publish_namespace_ok(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream, xqc_moq_msg_base_t *msg_base);
+
+void xqc_moq_on_publish_namespace_error(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream, xqc_moq_msg_base_t *msg_base);
+
+void xqc_moq_on_publish_namespace_done(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream, xqc_moq_msg_base_t *msg_base);
+
+void xqc_moq_on_publish_namespace_cancel(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream, xqc_moq_msg_base_t *msg_base);
+
+void xqc_moq_on_subscribe_namespace(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream, xqc_moq_msg_base_t *msg_base);
+
+void xqc_moq_on_subscribe_namespace_ok(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream, xqc_moq_msg_base_t *msg_base);
+
+void xqc_moq_on_subscribe_namespace_error(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream, xqc_moq_msg_base_t *msg_base);
+
+void xqc_moq_on_unsubscribe_namespace(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream, xqc_moq_msg_base_t *msg_base);
+
 void xqc_moq_on_object(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream, xqc_moq_object_t *object);
 
 void xqc_moq_on_object_stream(xqc_moq_session_t *session, xqc_moq_stream_t *moq_stream, xqc_moq_msg_base_t *msg_base);

--- a/moq/moq_transport/xqc_moq_message_writer.c
+++ b/moq/moq_transport/xqc_moq_message_writer.c
@@ -1,7 +1,55 @@
-
 #include "moq/moq_transport/xqc_moq_message_writer.h"
 #include "moq/moq_transport/xqc_moq_session.h"
 #include "moq/moq_transport/xqc_moq_stream.h"
+
+static xqc_int_t
+xqc_moq_validate_full_track_name_for_write(xqc_moq_session_t *session,
+    uint64_t track_namespace_num, const xqc_moq_track_ns_field_t *track_namespace_tuple,
+    const char *track_name, size_t track_name_len)
+{
+    if (session == NULL) {
+        return -XQC_EPARAM;
+    }
+
+    if (track_namespace_tuple == NULL || track_namespace_num == 0) {
+        return -XQC_EPARAM;
+    }
+    if (track_namespace_num > XQC_MOQ_MAX_NAMESPACE_TUPLE_ELEMS) {
+        xqc_log(session->log, XQC_LOG_ERROR,
+                "|invalid namespace tuple count|track_namespace_num:%ui|", track_namespace_num);
+        return -XQC_EPARAM;
+    }
+
+    size_t namespace_total_len = 0;
+    for (uint64_t i = 0; i < track_namespace_num; i++) {
+        if (track_namespace_tuple[i].len > XQC_MOQ_MAX_NAME_LEN
+            || namespace_total_len > XQC_MOQ_MAX_FULL_TRACK_NAME_LEN - track_namespace_tuple[i].len)
+        {
+            xqc_log(session->log, XQC_LOG_ERROR, "|full track name too long (namespace)|");
+            return -XQC_EPARAM;
+        }
+        namespace_total_len += track_namespace_tuple[i].len;
+    }
+
+    if (track_name == NULL) {
+        if (track_name_len != 0) {
+            return -XQC_EPARAM;
+        }
+        track_name_len = 0;
+    }
+
+    if (track_name_len == 0 && track_name != NULL) {
+        track_name_len = strlen(track_name);
+    }
+    if (track_name_len > XQC_MOQ_MAX_FULL_TRACK_NAME_LEN
+        || namespace_total_len > XQC_MOQ_MAX_FULL_TRACK_NAME_LEN - track_name_len)
+    {
+        xqc_log(session->log, XQC_LOG_ERROR, "|full track name too long|");
+        return -XQC_EPARAM;
+    }
+
+    return XQC_OK;
+}
 
 xqc_int_t
 xqc_moq_msg_write(xqc_moq_session_t *session, xqc_moq_stream_t *stream, xqc_moq_msg_base_t *msg_base)
@@ -87,6 +135,13 @@ xqc_moq_write_server_setup_v14(xqc_moq_session_t *session, xqc_moq_server_setup_
 xqc_int_t
 xqc_moq_write_subscribe(xqc_moq_session_t *session, xqc_moq_subscribe_msg_t *subscribe)
 {
+    xqc_int_t ret = xqc_moq_validate_full_track_name_for_write(session,
+        subscribe->track_namespace_num, subscribe->track_namespace_tuple,
+        subscribe->track_name, subscribe->track_name_len);
+    if (ret != XQC_OK) {
+        return ret;
+    }
+
     return xqc_moq_write_msg_generic(session, session->ctl_stream, &subscribe->msg_base,
                                      xqc_moq_msg_subscribe_init_handler);
 }
@@ -122,6 +177,13 @@ xqc_moq_write_subscribe_error(xqc_moq_session_t *session, xqc_moq_subscribe_erro
 xqc_int_t
 xqc_moq_write_publish(xqc_moq_session_t *session, xqc_moq_publish_msg_t *publish)
 {
+    xqc_int_t ret = xqc_moq_validate_full_track_name_for_write(session,
+        publish->track_namespace_num, publish->track_namespace_tuple,
+        publish->track_name, publish->track_name_len);
+    if (ret != XQC_OK) {
+        return ret;
+    }
+
     return xqc_moq_write_msg_generic(session, session->ctl_stream, &publish->msg_base,
                                      xqc_moq_msg_publish_init_handler);
 }
@@ -159,6 +221,113 @@ xqc_moq_write_publish_done(xqc_moq_session_t *session, xqc_moq_publish_done_msg_
 
     return xqc_moq_write_msg_generic(session, session->ctl_stream, &publish_done->msg_base,
                                      xqc_moq_msg_publish_done_init_handler);
+}
+
+xqc_int_t
+xqc_moq_write_publish_namespace(xqc_moq_session_t *session,
+    xqc_moq_publish_namespace_msg_t *publish_namespace)
+{
+    xqc_int_t ret = xqc_moq_validate_full_track_name_for_write(session,
+        publish_namespace->track_namespace_num, publish_namespace->track_namespace_tuple,
+        NULL, 0);
+    if (ret != XQC_OK) {
+        return ret;
+    }
+
+    return xqc_moq_write_msg_generic(session, session->ctl_stream, &publish_namespace->msg_base,
+                                     xqc_moq_msg_publish_namespace_init_handler);
+}
+
+xqc_int_t
+xqc_moq_write_publish_namespace_ok(xqc_moq_session_t *session,
+    xqc_moq_publish_namespace_ok_msg_t *publish_namespace_ok)
+{
+    return xqc_moq_write_msg_generic(session, session->ctl_stream, &publish_namespace_ok->msg_base,
+                                     xqc_moq_msg_publish_namespace_ok_init_handler);
+}
+
+xqc_int_t
+xqc_moq_write_publish_namespace_error(xqc_moq_session_t *session,
+    xqc_moq_publish_namespace_error_msg_t *publish_namespace_error)
+{
+    return xqc_moq_write_msg_generic(session, session->ctl_stream, &publish_namespace_error->msg_base,
+                                     xqc_moq_msg_publish_namespace_error_init_handler);
+}
+
+xqc_int_t
+xqc_moq_write_publish_namespace_done(xqc_moq_session_t *session,
+    xqc_moq_publish_namespace_done_msg_t *publish_namespace_done)
+{
+    xqc_int_t ret = xqc_moq_validate_full_track_name_for_write(session,
+        publish_namespace_done->track_namespace_num, publish_namespace_done->track_namespace_tuple,
+        NULL, 0);
+    if (ret != XQC_OK) {
+        return ret;
+    }
+
+    return xqc_moq_write_msg_generic(session, session->ctl_stream, &publish_namespace_done->msg_base,
+                                     xqc_moq_msg_publish_namespace_done_init_handler);
+}
+
+xqc_int_t
+xqc_moq_write_publish_namespace_cancel(xqc_moq_session_t *session,
+    xqc_moq_publish_namespace_cancel_msg_t *publish_namespace_cancel)
+{
+    xqc_int_t ret = xqc_moq_validate_full_track_name_for_write(session,
+        publish_namespace_cancel->track_namespace_num, publish_namespace_cancel->track_namespace_tuple,
+        NULL, 0);
+    if (ret != XQC_OK) {
+        return ret;
+    }
+
+    return xqc_moq_write_msg_generic(session, session->ctl_stream, &publish_namespace_cancel->msg_base,
+                                     xqc_moq_msg_publish_namespace_cancel_init_handler);
+}
+
+xqc_int_t
+xqc_moq_write_subscribe_namespace(xqc_moq_session_t *session,
+    xqc_moq_subscribe_namespace_msg_t *subscribe_namespace)
+{
+    xqc_int_t ret = xqc_moq_validate_full_track_name_for_write(session,
+        subscribe_namespace->track_namespace_num, subscribe_namespace->track_namespace_tuple,
+        NULL, 0);
+    if (ret != XQC_OK) {
+        return ret;
+    }
+
+    return xqc_moq_write_msg_generic(session, session->ctl_stream, &subscribe_namespace->msg_base,
+                                     xqc_moq_msg_subscribe_namespace_init_handler);
+}
+
+xqc_int_t
+xqc_moq_write_subscribe_namespace_ok(xqc_moq_session_t *session,
+    xqc_moq_subscribe_namespace_ok_msg_t *subscribe_namespace_ok)
+{
+    return xqc_moq_write_msg_generic(session, session->ctl_stream, &subscribe_namespace_ok->msg_base,
+                                     xqc_moq_msg_subscribe_namespace_ok_init_handler);
+}
+
+xqc_int_t
+xqc_moq_write_subscribe_namespace_error(xqc_moq_session_t *session,
+    xqc_moq_subscribe_namespace_error_msg_t *subscribe_namespace_error)
+{
+    return xqc_moq_write_msg_generic(session, session->ctl_stream, &subscribe_namespace_error->msg_base,
+                                     xqc_moq_msg_subscribe_namespace_error_init_handler);
+}
+
+xqc_int_t
+xqc_moq_write_unsubscribe_namespace(xqc_moq_session_t *session,
+    xqc_moq_unsubscribe_namespace_msg_t *unsubscribe_namespace)
+{
+    xqc_int_t ret = xqc_moq_validate_full_track_name_for_write(session,
+        unsubscribe_namespace->track_namespace_num, unsubscribe_namespace->track_namespace_tuple,
+        NULL, 0);
+    if (ret != XQC_OK) {
+        return ret;
+    }
+
+    return xqc_moq_write_msg_generic(session, session->ctl_stream, &unsubscribe_namespace->msg_base,
+                                     xqc_moq_msg_unsubscribe_namespace_init_handler);
 }
 
 xqc_int_t

--- a/moq/moq_transport/xqc_moq_message_writer.h
+++ b/moq/moq_transport/xqc_moq_message_writer.h
@@ -33,6 +33,33 @@ xqc_int_t xqc_moq_write_publish_error(xqc_moq_session_t *session, xqc_moq_publis
 
 xqc_int_t xqc_moq_write_publish_done(xqc_moq_session_t *session, xqc_moq_publish_done_msg_t *publish_done);
 
+xqc_int_t xqc_moq_write_publish_namespace(xqc_moq_session_t *session,
+    xqc_moq_publish_namespace_msg_t *publish_namespace);
+
+xqc_int_t xqc_moq_write_publish_namespace_ok(xqc_moq_session_t *session,
+    xqc_moq_publish_namespace_ok_msg_t *publish_namespace_ok);
+
+xqc_int_t xqc_moq_write_publish_namespace_error(xqc_moq_session_t *session,
+    xqc_moq_publish_namespace_error_msg_t *publish_namespace_error);
+
+xqc_int_t xqc_moq_write_publish_namespace_done(xqc_moq_session_t *session,
+    xqc_moq_publish_namespace_done_msg_t *publish_namespace_done);
+
+xqc_int_t xqc_moq_write_publish_namespace_cancel(xqc_moq_session_t *session,
+    xqc_moq_publish_namespace_cancel_msg_t *publish_namespace_cancel);
+
+xqc_int_t xqc_moq_write_subscribe_namespace(xqc_moq_session_t *session,
+    xqc_moq_subscribe_namespace_msg_t *subscribe_namespace);
+
+xqc_int_t xqc_moq_write_subscribe_namespace_ok(xqc_moq_session_t *session,
+    xqc_moq_subscribe_namespace_ok_msg_t *subscribe_namespace_ok);
+
+xqc_int_t xqc_moq_write_subscribe_namespace_error(xqc_moq_session_t *session,
+    xqc_moq_subscribe_namespace_error_msg_t *subscribe_namespace_error);
+
+xqc_int_t xqc_moq_write_unsubscribe_namespace(xqc_moq_session_t *session,
+    xqc_moq_unsubscribe_namespace_msg_t *unsubscribe_namespace);
+
 xqc_int_t xqc_moq_write_object_stream_msg(xqc_moq_session_t *session, xqc_moq_stream_t *stream,
     xqc_moq_object_stream_msg_t *object);
 

--- a/moq/moq_transport/xqc_moq_namespace.c
+++ b/moq/moq_transport/xqc_moq_namespace.c
@@ -1,0 +1,191 @@
+#include <string.h>
+
+#include "src/common/xqc_malloc.h"
+#include "moq/moq_transport/xqc_moq_namespace.h"
+
+static xqc_int_t
+xqc_moq_namespace_tuple_field_equal(const xqc_moq_track_ns_field_t *a, const xqc_moq_track_ns_field_t *b)
+{
+    if (a == NULL || b == NULL) {
+        return 0;
+    }
+    if (a->len != b->len) {
+        return 0;
+    }
+    if (a->len == 0) {
+        return 1;
+    }
+    if (a->data == NULL || b->data == NULL) {
+        return 0;
+    }
+    return memcmp(a->data, b->data, a->len) == 0;
+}
+
+xqc_int_t
+xqc_moq_namespace_tuple_equal(const xqc_moq_track_ns_field_t *a, uint64_t na,
+    const xqc_moq_track_ns_field_t *b, uint64_t nb)
+{
+    if (a == NULL || b == NULL || na == 0 || nb == 0) {
+        return 0;
+    }
+    if (na != nb) {
+        return 0;
+    }
+    for (uint64_t i = 0; i < na; i++) {
+        if (!xqc_moq_namespace_tuple_field_equal(&a[i], &b[i])) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+xqc_int_t
+xqc_moq_namespace_tuple_is_prefix(const xqc_moq_track_ns_field_t *a, uint64_t na,
+    const xqc_moq_track_ns_field_t *b, uint64_t nb)
+{
+    if (a == NULL || b == NULL || na == 0 || nb == 0 || na > nb) {
+        return 0;
+    }
+    for (uint64_t i = 0; i < na; i++) {
+        if (!xqc_moq_namespace_tuple_field_equal(&a[i], &b[i])) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+xqc_int_t
+xqc_moq_namespace_tuple_overlaps(const xqc_moq_track_ns_field_t *a, uint64_t na,
+    const xqc_moq_track_ns_field_t *b, uint64_t nb)
+{
+    return xqc_moq_namespace_tuple_is_prefix(a, na, b, nb)
+        || xqc_moq_namespace_tuple_is_prefix(b, nb, a, na);
+}
+
+xqc_moq_track_ns_field_t *
+xqc_moq_namespace_tuple_copy(const xqc_moq_track_ns_field_t *src, uint64_t num)
+{
+    if (src == NULL || num == 0) {
+        return NULL;
+    }
+
+    xqc_moq_track_ns_field_t *dst = xqc_calloc(num, sizeof(xqc_moq_track_ns_field_t));
+    if (dst == NULL) {
+        return NULL;
+    }
+    for (uint64_t i = 0; i < num; i++) {
+        dst[i].len = src[i].len;
+        if (src[i].len > 0 && src[i].data != NULL) {
+            dst[i].data = xqc_calloc(1, src[i].len + 1);
+            if (dst[i].data == NULL) {
+                xqc_moq_namespace_tuple_free(dst, num);
+                return NULL;
+            }
+            memcpy(dst[i].data, src[i].data, src[i].len);
+        }
+    }
+    return dst;
+}
+
+void
+xqc_moq_namespace_tuple_free(xqc_moq_track_ns_field_t *tuple, uint64_t num)
+{
+    if (tuple == NULL) {
+        return;
+    }
+    for (uint64_t i = 0; i < num; i++) {
+        xqc_free(tuple[i].data);
+        tuple[i].data = NULL;
+        tuple[i].len = 0;
+    }
+    xqc_free(tuple);
+}
+
+xqc_moq_namespace_prefix_t *
+xqc_moq_namespace_prefix_create_copy(const xqc_moq_track_ns_field_t *prefix_tuple, uint64_t prefix_num)
+{
+    if (prefix_tuple == NULL || prefix_num == 0) {
+        return NULL;
+    }
+
+    xqc_moq_namespace_prefix_t *namespace_prefix = xqc_calloc(1, sizeof(*namespace_prefix));
+    if (namespace_prefix == NULL) {
+        return NULL;
+    }
+    xqc_init_list_head(&namespace_prefix->list_member);
+    xqc_init_list_head(&namespace_prefix->advertised_namespace_list);
+    namespace_prefix->prefix_num = prefix_num;
+    namespace_prefix->prefix_tuple = xqc_moq_namespace_tuple_copy(prefix_tuple, prefix_num);
+    if (namespace_prefix->prefix_tuple == NULL) {
+        xqc_free(namespace_prefix);
+        return NULL;
+    }
+    return namespace_prefix;
+}
+
+void
+xqc_moq_namespace_prefix_destroy(xqc_moq_namespace_prefix_t *prefix)
+{
+    if (prefix == NULL) {
+        return;
+    }
+    xqc_list_head_t *pos, *next;
+    xqc_list_for_each_safe(pos, next, &prefix->advertised_namespace_list) {
+        xqc_moq_namespace_advertisement_t *namespace_advertisement =
+            xqc_list_entry(pos, xqc_moq_namespace_advertisement_t, list_member);
+        xqc_list_del(pos);
+        xqc_moq_namespace_advertisement_destroy(namespace_advertisement);
+    }
+    xqc_moq_namespace_tuple_free(prefix->prefix_tuple, prefix->prefix_num);
+    prefix->prefix_tuple = NULL;
+    prefix->prefix_num = 0;
+    xqc_free(prefix);
+}
+
+xqc_moq_namespace_advertisement_t *
+xqc_moq_namespace_advertisement_create_copy(const xqc_moq_track_ns_field_t *track_namespace_tuple,
+    uint64_t track_namespace_num)
+{
+    if (track_namespace_tuple == NULL || track_namespace_num == 0) {
+        return NULL;
+    }
+
+    xqc_moq_namespace_advertisement_t *namespace_advertisement =
+        xqc_calloc(1, sizeof(*namespace_advertisement));
+    if (namespace_advertisement == NULL) {
+        return NULL;
+    }
+    xqc_init_list_head(&namespace_advertisement->list_member);
+    xqc_init_list_head(&namespace_advertisement->advertised_track_list);
+    namespace_advertisement->track_namespace_num = track_namespace_num;
+    namespace_advertisement->track_namespace_tuple =
+        xqc_moq_namespace_tuple_copy(track_namespace_tuple, track_namespace_num);
+    if (namespace_advertisement->track_namespace_tuple == NULL) {
+        xqc_free(namespace_advertisement);
+        return NULL;
+    }
+    namespace_advertisement->track_refcnt = 0;
+    return namespace_advertisement;
+}
+
+void
+xqc_moq_namespace_advertisement_destroy(xqc_moq_namespace_advertisement_t *namespace_advertisement)
+{
+    if (namespace_advertisement == NULL) {
+        return;
+    }
+
+    xqc_list_head_t *pos, *next;
+    xqc_list_for_each_safe(pos, next, &namespace_advertisement->advertised_track_list) {
+        xqc_moq_advertised_track_t *advertised_track =
+            xqc_list_entry(pos, xqc_moq_advertised_track_t, list_member);
+        xqc_list_del(pos);
+        xqc_free(advertised_track);
+    }
+    xqc_moq_namespace_tuple_free(namespace_advertisement->track_namespace_tuple,
+                                 namespace_advertisement->track_namespace_num);
+    namespace_advertisement->track_namespace_tuple = NULL;
+    namespace_advertisement->track_namespace_num = 0;
+    namespace_advertisement->track_refcnt = 0;
+    xqc_free(namespace_advertisement);
+}

--- a/moq/moq_transport/xqc_moq_namespace.h
+++ b/moq/moq_transport/xqc_moq_namespace.h
@@ -1,0 +1,55 @@
+#ifndef _XQC_MOQ_NAMESPACE_H_INCLUDED_
+#define _XQC_MOQ_NAMESPACE_H_INCLUDED_
+
+#include "src/common/xqc_list.h"
+#include "moq/xqc_moq.h"
+
+typedef struct xqc_moq_namespace_prefix_s {
+    xqc_list_head_t              list_member;
+    uint64_t                     prefix_num;
+    xqc_moq_track_ns_field_t     *prefix_tuple;
+    /* Namespaces currently advertised for this active prefix subscription. */
+    xqc_list_head_t              advertised_namespace_list;
+} xqc_moq_namespace_prefix_t;
+
+typedef struct xqc_moq_namespace_advertisement_s {
+    xqc_list_head_t              list_member;
+    uint64_t                     track_namespace_num;
+    xqc_moq_track_ns_field_t     *track_namespace_tuple;
+    uint64_t                     track_refcnt;
+    /*
+     * Tracks that have been counted (refcnt++) for this namespace advertisement.
+     * Used to make refresh/on_track_added idempotent and to avoid refcnt drift.
+     */
+    xqc_list_head_t              advertised_track_list;
+} xqc_moq_namespace_advertisement_t;
+
+typedef struct xqc_moq_advertised_track_s {
+    xqc_list_head_t              list_member;
+    xqc_moq_track_t              *track;
+} xqc_moq_advertised_track_t;
+
+xqc_int_t xqc_moq_namespace_tuple_equal(const xqc_moq_track_ns_field_t *a, uint64_t na,
+    const xqc_moq_track_ns_field_t *b, uint64_t nb);
+
+xqc_int_t xqc_moq_namespace_tuple_is_prefix(const xqc_moq_track_ns_field_t *a, uint64_t na,
+    const xqc_moq_track_ns_field_t *b, uint64_t nb);
+
+xqc_int_t xqc_moq_namespace_tuple_overlaps(const xqc_moq_track_ns_field_t *a, uint64_t na,
+    const xqc_moq_track_ns_field_t *b, uint64_t nb);
+
+xqc_moq_track_ns_field_t *xqc_moq_namespace_tuple_copy(const xqc_moq_track_ns_field_t *src, uint64_t num);
+
+void xqc_moq_namespace_tuple_free(xqc_moq_track_ns_field_t *tuple, uint64_t num);
+
+xqc_moq_namespace_prefix_t *xqc_moq_namespace_prefix_create_copy(
+    const xqc_moq_track_ns_field_t *prefix_tuple, uint64_t prefix_num);
+
+void xqc_moq_namespace_prefix_destroy(xqc_moq_namespace_prefix_t *prefix);
+
+xqc_moq_namespace_advertisement_t *xqc_moq_namespace_advertisement_create_copy(
+    const xqc_moq_track_ns_field_t *track_namespace_tuple, uint64_t track_namespace_num);
+
+void xqc_moq_namespace_advertisement_destroy(xqc_moq_namespace_advertisement_t *namespace_advertisement);
+
+#endif /* _XQC_MOQ_NAMESPACE_H_INCLUDED_ */

--- a/moq/moq_transport/xqc_moq_session.c
+++ b/moq/moq_transport/xqc_moq_session.c
@@ -1,12 +1,242 @@
 #include "src/transport/xqc_engine.h"
 #include "src/transport/xqc_conn.h"
 #include "src/transport/xqc_send_ctl.h"
+#include "moq/moq_transport/xqc_moq_namespace.h"
 #include "moq/moq_transport/xqc_moq_session.h"
 #include "moq/moq_transport/xqc_moq_message_writer.h"
 #include "moq/moq_transport/xqc_moq_stream.h"
 #include "moq/moq_transport/xqc_moq_stream_quic.h"
 #include "moq/moq_transport/xqc_moq_stream_webtransport.h"
 #include "moq/moq_transport/xqc_moq_subscribe.h"
+
+static xqc_moq_namespace_prefix_t *
+xqc_moq_session_find_namespace_prefix(xqc_moq_session_t *session,
+    const xqc_moq_track_ns_field_t *namespace_prefix_tuple, uint64_t namespace_prefix_num)
+{
+    if (session == NULL || namespace_prefix_tuple == NULL || namespace_prefix_num == 0) {
+        return NULL;
+    }
+
+    xqc_list_head_t *pos, *next;
+    xqc_list_for_each_safe(pos, next, &session->peer_subscribe_namespace_list) {
+        xqc_moq_namespace_prefix_t *namespace_prefix =
+            xqc_list_entry(pos, xqc_moq_namespace_prefix_t, list_member);
+        if (namespace_prefix->prefix_num != namespace_prefix_num) {
+            continue;
+        }
+        if (xqc_moq_namespace_tuple_equal(namespace_prefix_tuple, namespace_prefix_num,
+                                          namespace_prefix->prefix_tuple, namespace_prefix->prefix_num))
+        {
+            return namespace_prefix;
+        }
+    }
+    return NULL;
+}
+
+static xqc_moq_namespace_prefix_t *
+xqc_moq_session_find_matching_namespace_prefix(xqc_moq_session_t *session,
+    const xqc_moq_track_ns_field_t *track_namespace_tuple, uint64_t track_namespace_num)
+{
+    if (session == NULL || track_namespace_tuple == NULL || track_namespace_num == 0) {
+        return NULL;
+    }
+
+    xqc_list_head_t *pos, *next;
+    xqc_list_for_each_safe(pos, next, &session->peer_subscribe_namespace_list) {
+        xqc_moq_namespace_prefix_t *namespace_prefix =
+            xqc_list_entry(pos, xqc_moq_namespace_prefix_t, list_member);
+        if (xqc_moq_namespace_tuple_is_prefix(namespace_prefix->prefix_tuple, namespace_prefix->prefix_num,
+                                              track_namespace_tuple, track_namespace_num))
+        {
+            return namespace_prefix;
+        }
+    }
+    return NULL;
+}
+
+static xqc_moq_namespace_advertisement_t *
+xqc_moq_namespace_prefix_find_advertisement(xqc_moq_namespace_prefix_t *namespace_subscription,
+    const xqc_moq_track_ns_field_t *track_namespace_tuple, uint64_t track_namespace_num)
+{
+    if (namespace_subscription == NULL || track_namespace_tuple == NULL || track_namespace_num == 0) {
+        return NULL;
+    }
+
+    xqc_list_head_t *pos, *next;
+    xqc_list_for_each_safe(pos, next, &namespace_subscription->advertised_namespace_list) {
+        xqc_moq_namespace_advertisement_t *namespace_advertisement =
+            xqc_list_entry(pos, xqc_moq_namespace_advertisement_t, list_member);
+        if (namespace_advertisement->track_namespace_num != track_namespace_num) {
+            continue;
+        }
+        if (xqc_moq_namespace_tuple_equal(namespace_advertisement->track_namespace_tuple,
+                                          namespace_advertisement->track_namespace_num,
+                                          track_namespace_tuple, track_namespace_num))
+        {
+            return namespace_advertisement;
+        }
+    }
+    return NULL;
+}
+
+static xqc_moq_advertised_track_t *
+xqc_moq_namespace_advertisement_find_track(xqc_moq_namespace_advertisement_t *namespace_advertisement,
+    const xqc_moq_track_t *track)
+{
+    if (namespace_advertisement == NULL || track == NULL) {
+        return NULL;
+    }
+
+    xqc_list_head_t *pos, *next;
+    xqc_list_for_each_safe(pos, next, &namespace_advertisement->advertised_track_list) {
+        xqc_moq_advertised_track_t *advertised_track =
+            xqc_list_entry(pos, xqc_moq_advertised_track_t, list_member);
+        if (advertised_track->track == track) {
+            return advertised_track;
+        }
+    }
+    return NULL;
+}
+
+static xqc_int_t
+xqc_moq_namespace_prefix_ensure_advertised(xqc_moq_session_t *session,
+    xqc_moq_namespace_prefix_t *namespace_subscription,
+    const xqc_moq_track_ns_field_t *track_namespace_tuple, uint64_t track_namespace_num,
+    const xqc_moq_namespace_discovery_update_cb_t *discovery_update_callbacks,
+    xqc_moq_namespace_advertisement_t **namespace_advertisement)
+{
+    if (session == NULL || namespace_subscription == NULL
+        || track_namespace_tuple == NULL || track_namespace_num == 0
+        || discovery_update_callbacks == NULL || discovery_update_callbacks->on_namespace == NULL
+        || namespace_advertisement == NULL)
+    {
+        return -XQC_EPARAM;
+    }
+
+    xqc_moq_namespace_advertisement_t *namespace_advertisement_entry =
+        xqc_moq_namespace_prefix_find_advertisement(namespace_subscription,
+                                                    track_namespace_tuple, track_namespace_num);
+    if (namespace_advertisement_entry != NULL) {
+        *namespace_advertisement = namespace_advertisement_entry;
+        return XQC_OK;
+    }
+
+    xqc_int_t ret = discovery_update_callbacks->on_namespace(session, discovery_update_callbacks->user_data,
+                                                            track_namespace_tuple, track_namespace_num);
+    if (ret < 0) {
+        return ret;
+    }
+
+    namespace_advertisement_entry =
+        xqc_moq_namespace_advertisement_create_copy(track_namespace_tuple, track_namespace_num);
+    if (namespace_advertisement_entry == NULL) {
+        return -XQC_EMALLOC;
+    }
+    xqc_list_add_tail(&namespace_advertisement_entry->list_member,
+                      &namespace_subscription->advertised_namespace_list);
+    *namespace_advertisement = namespace_advertisement_entry;
+    return XQC_OK;
+}
+
+static xqc_int_t
+xqc_moq_session_discovery_subscription_on_track_added(xqc_moq_session_t *session,
+    xqc_moq_namespace_prefix_t *subscription, xqc_moq_track_t *track,
+    const xqc_moq_namespace_discovery_update_cb_t *discovery_update_callbacks)
+{
+    if (session == NULL || subscription == NULL || track == NULL || discovery_update_callbacks == NULL) {
+        return -XQC_EPARAM;
+    }
+
+    xqc_moq_track_info_t *track_info = &track->track_info;
+    if (track_info->track_namespace_tuple == NULL || track_info->track_namespace_num == 0
+        || track_info->track_name == NULL)
+    {
+        return -XQC_EPARAM;
+    }
+
+    xqc_moq_namespace_advertisement_t *namespace_advertisement = NULL;
+    xqc_int_t ret = xqc_moq_namespace_prefix_ensure_advertised(session, subscription,
+        track_info->track_namespace_tuple, track_info->track_namespace_num,
+        discovery_update_callbacks, &namespace_advertisement);
+    if (ret < 0) {
+        return ret;
+    }
+
+    if (xqc_moq_namespace_advertisement_find_track(namespace_advertisement, track) != NULL) {
+        /* Idempotency: this track has already been counted for this namespace. */
+        return XQC_OK;
+    }
+
+    xqc_moq_advertised_track_t *advertised_track = xqc_calloc(1, sizeof(*advertised_track));
+    if (advertised_track == NULL) {
+        return -XQC_EMALLOC;
+    }
+    xqc_init_list_head(&advertised_track->list_member);
+    advertised_track->track = track;
+    xqc_list_add_tail(&advertised_track->list_member, &namespace_advertisement->advertised_track_list);
+    namespace_advertisement->track_refcnt++;
+
+    if (discovery_update_callbacks->on_track != NULL && track->subscribe_id == XQC_MOQ_INVALID_ID) {
+        ret = discovery_update_callbacks->on_track(session, discovery_update_callbacks->user_data, track);
+        if (ret < 0) {
+            return ret;
+        }
+    }
+
+    return XQC_OK;
+}
+
+static xqc_int_t
+xqc_moq_session_discovery_subscription_on_track_removed(xqc_moq_session_t *session,
+    xqc_moq_namespace_prefix_t *subscription, xqc_moq_track_t *track,
+    const xqc_moq_namespace_discovery_update_cb_t *discovery_update_callbacks)
+{
+    if (session == NULL || subscription == NULL || track == NULL || discovery_update_callbacks == NULL) {
+        return -XQC_EPARAM;
+    }
+
+    xqc_moq_track_info_t *track_info = &track->track_info;
+    if (track_info->track_namespace_tuple == NULL || track_info->track_namespace_num == 0) {
+        return -XQC_EPARAM;
+    }
+
+    xqc_moq_namespace_advertisement_t *namespace_advertisement =
+        xqc_moq_namespace_prefix_find_advertisement(subscription,
+            track_info->track_namespace_tuple, track_info->track_namespace_num);
+    if (namespace_advertisement == NULL) {
+        return XQC_OK;
+    }
+
+    xqc_moq_advertised_track_t *advertised_track =
+        xqc_moq_namespace_advertisement_find_track(namespace_advertisement, track);
+    if (advertised_track == NULL) {
+        /* Idempotency: track was never counted (or already removed). */
+        return XQC_OK;
+    }
+    xqc_list_del(&advertised_track->list_member);
+    xqc_free(advertised_track);
+
+    if (namespace_advertisement->track_refcnt > 0) {
+        namespace_advertisement->track_refcnt--;
+    } else {
+        namespace_advertisement->track_refcnt = 0;
+    }
+
+    if (namespace_advertisement->track_refcnt == 0) {
+        if (discovery_update_callbacks->on_namespace_done != NULL) {
+            xqc_int_t ret = discovery_update_callbacks->on_namespace_done(session,
+                discovery_update_callbacks->user_data,
+                namespace_advertisement->track_namespace_tuple, namespace_advertisement->track_namespace_num);
+            if (ret < 0) {
+                return ret;
+            }
+        }
+        xqc_list_del(&namespace_advertisement->list_member);
+        xqc_moq_namespace_advertisement_destroy(namespace_advertisement);
+    }
+
+    return XQC_OK;
+}
 
 void
 xqc_moq_init_alpn(xqc_engine_t *engine, xqc_conn_callbacks_t *conn_cbs, xqc_moq_transport_type_t transport_type)
@@ -66,6 +296,7 @@ xqc_moq_session_create_internal(void *conn, xqc_moq_user_session_t *user_session
 
     xqc_init_list_head(&session->local_subscribe_list);
     xqc_init_list_head(&session->peer_subscribe_list);
+    xqc_init_list_head(&session->peer_subscribe_namespace_list);
     xqc_init_list_head(&session->track_list_for_pub);
     xqc_init_list_head(&session->track_list_for_sub);
 
@@ -183,7 +414,9 @@ xqc_moq_session_destroy(xqc_moq_session_t *session)
     xqc_list_head_t *pos, *next;
     xqc_moq_subscribe_t *subscribe;
     xqc_moq_track_t *track;
+    xqc_list_head_t *npos, *nnext;
 
+    session->is_destroying = 1;
     xqc_log(session->log, XQC_LOG_INFO, "|session destroy begin|");
 
     xqc_list_for_each_safe(pos, next, &session->local_subscribe_list) {
@@ -206,7 +439,407 @@ xqc_moq_session_destroy(xqc_moq_session_t *session)
         xqc_list_del(pos);
         xqc_moq_track_destroy(track);
     }
+
+    xqc_list_for_each_safe(npos, nnext, &session->peer_subscribe_namespace_list) {
+        xqc_moq_namespace_prefix_t *namespace_prefix_subscription =
+            xqc_list_entry(npos, xqc_moq_namespace_prefix_t, list_member);
+        xqc_list_del(npos);
+        xqc_moq_namespace_prefix_destroy(namespace_prefix_subscription);
+    }
     xqc_free(session);
+}
+
+xqc_int_t
+xqc_moq_session_namespace_prefix_overlaps(xqc_moq_session_t *session,
+    const xqc_moq_track_ns_field_t *namespace_prefix_tuple, uint64_t namespace_prefix_num)
+{
+    if (session == NULL || namespace_prefix_tuple == NULL || namespace_prefix_num == 0) {
+        return 0;
+    }
+
+    xqc_list_head_t *pos, *next;
+    xqc_list_for_each_safe(pos, next, &session->peer_subscribe_namespace_list) {
+        xqc_moq_namespace_prefix_t *namespace_prefix_subscription =
+            xqc_list_entry(pos, xqc_moq_namespace_prefix_t, list_member);
+        if (xqc_moq_namespace_tuple_overlaps(namespace_prefix_tuple, namespace_prefix_num,
+                                             namespace_prefix_subscription->prefix_tuple,
+                                             namespace_prefix_subscription->prefix_num))
+        {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+xqc_int_t
+xqc_moq_session_add_namespace_prefix(xqc_moq_session_t *session,
+    const xqc_moq_track_ns_field_t *namespace_prefix_tuple, uint64_t namespace_prefix_num)
+{
+    if (session == NULL || namespace_prefix_tuple == NULL || namespace_prefix_num == 0) {
+        return -XQC_EPARAM;
+    }
+
+    if (xqc_moq_session_namespace_prefix_overlaps(session, namespace_prefix_tuple, namespace_prefix_num)) {
+        return -XQC_EPARAM;
+    }
+
+    xqc_moq_namespace_prefix_t *namespace_prefix_subscription =
+        xqc_moq_namespace_prefix_create_copy(namespace_prefix_tuple, namespace_prefix_num);
+    if (namespace_prefix_subscription == NULL) {
+        return -XQC_EMALLOC;
+    }
+    xqc_list_add_tail(&namespace_prefix_subscription->list_member, &session->peer_subscribe_namespace_list);
+    return XQC_OK;
+}
+
+xqc_int_t
+xqc_moq_session_remove_namespace_prefix(xqc_moq_session_t *session,
+    const xqc_moq_track_ns_field_t *namespace_prefix_tuple, uint64_t namespace_prefix_num)
+{
+    if (session == NULL || namespace_prefix_tuple == NULL || namespace_prefix_num == 0) {
+        return -XQC_EPARAM;
+    }
+
+    xqc_list_head_t *pos, *next;
+    xqc_list_for_each_safe(pos, next, &session->peer_subscribe_namespace_list) {
+        xqc_moq_namespace_prefix_t *namespace_prefix_subscription =
+            xqc_list_entry(pos, xqc_moq_namespace_prefix_t, list_member);
+        if (namespace_prefix_subscription->prefix_num != namespace_prefix_num) {
+            continue;
+        }
+        if (!xqc_moq_namespace_tuple_equal(namespace_prefix_tuple, namespace_prefix_num,
+                                           namespace_prefix_subscription->prefix_tuple,
+                                           namespace_prefix_subscription->prefix_num))
+        {
+            continue;
+        }
+
+        xqc_list_del(pos);
+        xqc_moq_namespace_prefix_destroy(namespace_prefix_subscription);
+        return 1;
+    }
+
+    return 0;
+}
+
+static xqc_int_t
+xqc_moq_discovery_send_publish_namespace(xqc_moq_session_t *session, void *user_data,
+    const xqc_moq_track_ns_field_t *track_namespace_tuple, uint64_t track_namespace_num)
+{
+    if (session == NULL || track_namespace_tuple == NULL || track_namespace_num == 0) {
+        return -XQC_EPARAM;
+    }
+
+    xqc_moq_publish_namespace_msg_t publish_namespace_msg;
+    memset(&publish_namespace_msg, 0, sizeof(publish_namespace_msg));
+    publish_namespace_msg.request_id = xqc_moq_session_alloc_subscribe_id(session);
+    publish_namespace_msg.track_namespace_num = track_namespace_num;
+    publish_namespace_msg.track_namespace_tuple = (xqc_moq_track_ns_field_t *)track_namespace_tuple;
+    publish_namespace_msg.track_namespace_len = 0;
+    publish_namespace_msg.params_num = 0;
+    publish_namespace_msg.params = NULL;
+    return xqc_moq_write_publish_namespace(session, &publish_namespace_msg);
+}
+
+static xqc_int_t
+xqc_moq_discovery_send_publish_namespace_done(xqc_moq_session_t *session, void *user_data,
+    const xqc_moq_track_ns_field_t *track_namespace_tuple, uint64_t track_namespace_num)
+{
+
+    if (session == NULL || track_namespace_tuple == NULL || track_namespace_num == 0) {
+        return -XQC_EPARAM;
+    }
+
+    xqc_moq_publish_namespace_done_msg_t done;
+    memset(&done, 0, sizeof(done));
+    done.track_namespace_num = track_namespace_num;
+    done.track_namespace_tuple = (xqc_moq_track_ns_field_t *)track_namespace_tuple;
+    done.track_namespace_len = 0;
+    return xqc_moq_write_publish_namespace_done(session, &done);
+}
+
+static xqc_int_t
+xqc_moq_discovery_send_publish_track(xqc_moq_session_t *session, void *user_data, xqc_moq_track_t *track)
+{
+
+    if (session == NULL || track == NULL || track->track_info.track_name == NULL
+        || track->track_info.track_namespace_tuple == NULL || track->track_info.track_namespace_num == 0)
+    {
+        return -XQC_EPARAM;
+    }
+
+    xqc_moq_publish_msg_t publish_msg;
+    memset(&publish_msg, 0, sizeof(publish_msg));
+    publish_msg.track_namespace_num = track->track_info.track_namespace_num;
+    publish_msg.track_namespace_tuple = track->track_info.track_namespace_tuple;
+    publish_msg.track_namespace_len = 0;
+    publish_msg.track_name = track->track_info.track_name;
+    publish_msg.track_name_len = 0;
+    publish_msg.group_order = 0;
+    publish_msg.content_exist = 0;
+    publish_msg.largest_group_id = 0;
+    publish_msg.largest_object_id = 0;
+    publish_msg.forward = 1;
+    publish_msg.params_num = 0;
+    publish_msg.params = NULL;
+
+    xqc_int_t ret = xqc_moq_publish(session, &publish_msg);
+    return ret < 0 ? ret : XQC_OK;
+}
+
+xqc_int_t
+xqc_moq_session_discovery_refresh_namespace_prefix(xqc_moq_session_t *session,
+    const xqc_moq_track_ns_field_t *prefix_tuple, uint64_t prefix_num,
+    const xqc_moq_namespace_discovery_update_cb_t *discovery_update_callbacks)
+{
+    if (session == NULL || prefix_tuple == NULL || prefix_num == 0 || discovery_update_callbacks == NULL) {
+        return -XQC_EPARAM;
+    }
+
+    xqc_moq_namespace_prefix_t *subscription =
+        xqc_moq_session_find_namespace_prefix(session, prefix_tuple, prefix_num);
+    if (subscription == NULL) {
+        return -XQC_ENULLPTR;
+    }
+
+    xqc_list_head_t *pos, *next;
+    xqc_list_for_each_safe(pos, next, &session->track_list_for_pub) {
+        xqc_moq_track_t *track = xqc_list_entry(pos, xqc_moq_track_t, list_member);
+        xqc_moq_track_info_t *track_info = track ? &track->track_info : NULL;
+        if (track_info == NULL || track_info->track_name == NULL
+            || track_info->track_namespace_tuple == NULL || track_info->track_namespace_num == 0)
+        {
+            continue;
+        }
+
+        if (!xqc_moq_namespace_tuple_is_prefix(prefix_tuple, prefix_num,
+                                               track_info->track_namespace_tuple,
+                                               track_info->track_namespace_num))
+        {
+            continue;
+        }
+
+        xqc_int_t ret = xqc_moq_session_discovery_subscription_on_track_added(session,
+            subscription, track, discovery_update_callbacks);
+        if (ret < 0) {
+            return ret;
+        }
+    }
+
+    return XQC_OK;
+}
+
+void
+xqc_moq_session_discovery_on_track_added(xqc_moq_session_t *session, xqc_moq_track_t *track)
+{
+    if (session == NULL || track == NULL) {
+        return;
+    }
+    if (track->track_role != XQC_MOQ_TRACK_FOR_PUB) {
+        return;
+    }
+    if (xqc_list_empty(&session->peer_subscribe_namespace_list)) {
+        return;
+    }
+
+    xqc_moq_track_info_t *track_info = &track->track_info;
+    if (track_info->track_namespace_tuple == NULL || track_info->track_namespace_num == 0) {
+        return;
+    }
+
+    xqc_moq_namespace_discovery_update_cb_t discovery_update_callbacks = {
+        .user_data = NULL,
+        .on_namespace = xqc_moq_discovery_send_publish_namespace,
+        .on_namespace_done = xqc_moq_discovery_send_publish_namespace_done,
+        .on_track = xqc_moq_discovery_send_publish_track,
+    };
+
+    xqc_int_t ret = xqc_moq_session_discovery_on_track_added_with_cb(session, track,
+                                                                     &discovery_update_callbacks);
+    if (ret < 0) {
+        xqc_log(session->log, XQC_LOG_ERROR, "|discovery track added failed|ret:%d|", ret);
+        xqc_moq_session_error(session, MOQ_INTERNAL_ERROR, "discovery track added");
+    }
+}
+
+void
+xqc_moq_session_discovery_on_track_removed(xqc_moq_session_t *session, xqc_moq_track_t *track)
+{
+    if (session == NULL || track == NULL) {
+        return;
+    }
+    if (track->track_role != XQC_MOQ_TRACK_FOR_PUB) {
+        return;
+    }
+    if (xqc_list_empty(&session->peer_subscribe_namespace_list)) {
+        return;
+    }
+
+    xqc_moq_track_info_t *track_info = &track->track_info;
+    if (track_info->track_namespace_tuple == NULL || track_info->track_namespace_num == 0) {
+        return;
+    }
+
+    xqc_moq_namespace_discovery_update_cb_t discovery_update_callbacks = {
+        .user_data = NULL,
+        .on_namespace = xqc_moq_discovery_send_publish_namespace,
+        .on_namespace_done = xqc_moq_discovery_send_publish_namespace_done,
+        .on_track = xqc_moq_discovery_send_publish_track,
+    };
+
+    xqc_int_t ret = xqc_moq_session_discovery_on_track_removed_with_cb(session, track,
+                                                                       &discovery_update_callbacks);
+    if (ret < 0) {
+        xqc_log(session->log, XQC_LOG_ERROR, "|discovery track removed failed|ret:%d|", ret);
+        xqc_moq_session_error(session, MOQ_INTERNAL_ERROR, "discovery track removed");
+    }
+}
+
+xqc_int_t
+xqc_moq_session_discovery_on_track_added_with_cb(xqc_moq_session_t *session, xqc_moq_track_t *track,
+    const xqc_moq_namespace_discovery_update_cb_t *discovery_update_callbacks)
+{
+    if (session == NULL || track == NULL || discovery_update_callbacks == NULL) {
+        return -XQC_EPARAM;
+    }
+    if (track->track_role != XQC_MOQ_TRACK_FOR_PUB) {
+        return XQC_OK;
+    }
+    if (xqc_list_empty(&session->peer_subscribe_namespace_list)) {
+        return XQC_OK;
+    }
+
+    xqc_moq_track_info_t *track_info = &track->track_info;
+    if (track_info->track_namespace_tuple == NULL || track_info->track_namespace_num == 0) {
+        return -XQC_EPARAM;
+    }
+
+    xqc_moq_namespace_prefix_t *subscription =
+        xqc_moq_session_find_matching_namespace_prefix(session,
+            track_info->track_namespace_tuple, track_info->track_namespace_num);
+    if (subscription == NULL) {
+        return XQC_OK;
+    }
+
+    return xqc_moq_session_discovery_subscription_on_track_added(session, subscription, track,
+                                                                 discovery_update_callbacks);
+}
+
+xqc_int_t
+xqc_moq_session_discovery_on_track_removed_with_cb(xqc_moq_session_t *session, xqc_moq_track_t *track,
+    const xqc_moq_namespace_discovery_update_cb_t *discovery_update_callbacks)
+{
+    if (session == NULL || track == NULL || discovery_update_callbacks == NULL) {
+        return -XQC_EPARAM;
+    }
+    if (track->track_role != XQC_MOQ_TRACK_FOR_PUB) {
+        return XQC_OK;
+    }
+    if (xqc_list_empty(&session->peer_subscribe_namespace_list)) {
+        return XQC_OK;
+    }
+
+    xqc_moq_track_info_t *track_info = &track->track_info;
+    if (track_info->track_namespace_tuple == NULL || track_info->track_namespace_num == 0) {
+        return -XQC_EPARAM;
+    }
+
+    xqc_moq_namespace_prefix_t *subscription =
+        xqc_moq_session_find_matching_namespace_prefix(session,
+            track_info->track_namespace_tuple, track_info->track_namespace_num);
+    if (subscription == NULL) {
+        return XQC_OK;
+    }
+
+    return xqc_moq_session_discovery_subscription_on_track_removed(session, subscription, track,
+                                                                   discovery_update_callbacks);
+}
+
+xqc_int_t
+xqc_moq_session_foreach_matching_publication(xqc_moq_session_t *session,
+    const xqc_moq_track_ns_field_t *namespace_prefix_tuple, uint64_t namespace_prefix_num,
+    const xqc_moq_namespace_discovery_cb_t *discovery_callbacks)
+{
+    if (session == NULL || namespace_prefix_tuple == NULL || namespace_prefix_num == 0
+        || discovery_callbacks == NULL)
+    {
+        return -XQC_EPARAM;
+    }
+
+    xqc_int_t ret = XQC_OK;
+    xqc_list_head_t sent_track_namespace_list;
+    xqc_init_list_head(&sent_track_namespace_list);
+
+    xqc_list_head_t *pos, *next;
+    xqc_list_head_t *cleanup_pos, *cleanup_next;
+    xqc_list_for_each_safe(pos, next, &session->track_list_for_pub) {
+        xqc_moq_track_t *track = xqc_list_entry(pos, xqc_moq_track_t, list_member);
+        xqc_moq_track_info_t *track_info = track ? &track->track_info : NULL;
+        if (track_info == NULL || track_info->track_name == NULL
+            || track_info->track_namespace_tuple == NULL || track_info->track_namespace_num == 0)
+        {
+            continue;
+        }
+
+        if (!xqc_moq_namespace_tuple_is_prefix(namespace_prefix_tuple, namespace_prefix_num,
+                                               track_info->track_namespace_tuple,
+                                               track_info->track_namespace_num))
+        {
+            continue;
+        }
+
+        if (discovery_callbacks->on_namespace != NULL) {
+            xqc_int_t track_namespace_already_sent = 0;
+            xqc_list_head_t *sent_pos, *sent_next;
+            xqc_list_for_each_safe(sent_pos, sent_next, &sent_track_namespace_list) {
+                xqc_moq_namespace_prefix_t *sent_track_namespace =
+                    xqc_list_entry(sent_pos, xqc_moq_namespace_prefix_t, list_member);
+                if (xqc_moq_namespace_tuple_equal(sent_track_namespace->prefix_tuple,
+                                                  sent_track_namespace->prefix_num,
+                                                  track_info->track_namespace_tuple,
+                                                  track_info->track_namespace_num))
+                {
+                    track_namespace_already_sent = 1;
+                    break;
+                }
+            }
+
+            if (!track_namespace_already_sent) {
+                xqc_moq_namespace_prefix_t *sent_track_namespace =
+                    xqc_moq_namespace_prefix_create_copy(track_info->track_namespace_tuple,
+                                                         track_info->track_namespace_num);
+                if (sent_track_namespace == NULL) {
+                    ret = -XQC_EMALLOC;
+                    goto cleanup;
+                }
+                xqc_list_add_tail(&sent_track_namespace->list_member, &sent_track_namespace_list);
+
+                ret = discovery_callbacks->on_namespace(session, discovery_callbacks->user_data,
+                                       track_info->track_namespace_tuple,
+                                       track_info->track_namespace_num);
+                if (ret < 0) {
+                    goto cleanup;
+                }
+            }
+        }
+
+        if (discovery_callbacks->on_track != NULL && track->subscribe_id == XQC_MOQ_INVALID_ID) {
+            ret = discovery_callbacks->on_track(session, discovery_callbacks->user_data, track);
+            if (ret < 0) {
+                goto cleanup;
+            }
+        }
+    }
+
+cleanup:
+    xqc_list_for_each_safe(cleanup_pos, cleanup_next, &sent_track_namespace_list) {
+        xqc_moq_namespace_prefix_t *sent_track_namespace =
+            xqc_list_entry(cleanup_pos, xqc_moq_namespace_prefix_t, list_member);
+        xqc_list_del(cleanup_pos);
+        xqc_moq_namespace_prefix_destroy(sent_track_namespace);
+    }
+
+    return ret;
 }
 
 void
@@ -303,24 +936,40 @@ xqc_moq_find_track_by_alias(xqc_moq_session_t *session,
 }
 
 xqc_moq_track_t *
-xqc_moq_find_track_by_name(xqc_moq_session_t *session,
-    const char *track_namespace, const char *track_name, xqc_moq_track_role_t role)
+xqc_moq_find_track_by_track_namespace_tuple(xqc_moq_session_t *session,
+    const xqc_moq_track_ns_field_t *track_namespace_tuple, uint64_t track_namespace_num,
+    const char *track_name, xqc_moq_track_role_t role)
 {
     xqc_moq_track_t *track = NULL;
     xqc_list_head_t *pos, *next;
     xqc_list_head_t *list;
+
+    if (session == NULL || track_namespace_tuple == NULL || track_namespace_num == 0 || track_name == NULL) {
+        return NULL;
+    }
+
     if (role == XQC_MOQ_TRACK_FOR_PUB) {
         list = &session->track_list_for_pub;
     } else {
         list = &session->track_list_for_sub;
     }
+
     xqc_list_for_each_safe(pos, next, list) {
         track = xqc_list_entry(pos, xqc_moq_track_t, list_member);
-        if (track->track_info.track_namespace && track_namespace && strcmp(track->track_info.track_namespace, track_namespace) == 0
-            && track->track_info.track_name && track_name && strcmp(track->track_info.track_name, track_name) == 0) {
+        if (track->track_info.track_name == NULL) {
+            continue;
+        }
+        if (strcmp(track->track_info.track_name, track_name) != 0) {
+            continue;
+        }
+        if (xqc_moq_namespace_tuple_equal(track->track_info.track_namespace_tuple,
+                                          track->track_info.track_namespace_num,
+                                          track_namespace_tuple, track_namespace_num))
+        {
             return track;
         }
     }
+
     return NULL;
 }
 

--- a/moq/moq_transport/xqc_moq_session.h
+++ b/moq/moq_transport/xqc_moq_session.h
@@ -38,6 +38,7 @@ typedef struct xqc_moq_session_s {
     xqc_moq_session_callbacks_t     session_callbacks;
     xqc_list_head_t                 local_subscribe_list;
     xqc_list_head_t                 peer_subscribe_list;
+    xqc_list_head_t                 peer_subscribe_namespace_list; // draft-14: active namespace subscriptions from peer (SUBSCRIBE_NAMESPACE)
     xqc_list_head_t                 track_list_for_pub;
     xqc_list_head_t                 track_list_for_sub;
     uint64_t                        subscribe_id_allocator;
@@ -46,6 +47,7 @@ typedef struct xqc_moq_session_s {
     xqc_int_t                       enable_fec;
     float                           fec_code_rate;
     xqc_int_t                       use_client_setup_v14;
+    uint8_t                         is_destroying;
 } xqc_moq_session_t;
 
 typedef enum {
@@ -74,10 +76,89 @@ uint64_t xqc_moq_session_alloc_track_alias(xqc_moq_session_t *session);
 xqc_moq_track_t *xqc_moq_find_track_by_alias(xqc_moq_session_t *session,
     uint64_t track_alias, xqc_moq_track_role_t role);
 
-xqc_moq_track_t *xqc_moq_find_track_by_name(xqc_moq_session_t *session,
-    const char *track_namespace, const char *track_name, xqc_moq_track_role_t role);
-
 xqc_moq_track_t *xqc_moq_find_track_by_subscribe_id(xqc_moq_session_t *session,
     uint64_t subscribe_id, xqc_moq_track_role_t role);
+
+xqc_moq_track_t *xqc_moq_find_track_by_track_namespace_tuple(xqc_moq_session_t *session,
+    const xqc_moq_track_ns_field_t *track_namespace_tuple, uint64_t track_namespace_num,
+    const char *track_name, xqc_moq_track_role_t role);
+
+/* draft-14 namespace subscription prefix management */
+xqc_int_t xqc_moq_session_namespace_prefix_overlaps(xqc_moq_session_t *session,
+    const xqc_moq_track_ns_field_t *namespace_prefix_tuple, uint64_t namespace_prefix_num);
+
+xqc_int_t xqc_moq_session_add_namespace_prefix(xqc_moq_session_t *session,
+    const xqc_moq_track_ns_field_t *namespace_prefix_tuple, uint64_t namespace_prefix_num);
+
+/* returns 1 if removed, 0 if not found, <0 on error */
+xqc_int_t xqc_moq_session_remove_namespace_prefix(xqc_moq_session_t *session,
+    const xqc_moq_track_ns_field_t *namespace_prefix_tuple, uint64_t namespace_prefix_num);
+
+typedef xqc_int_t (*xqc_moq_namespace_discovery_on_namespace_pt)(xqc_moq_session_t *session,
+    void *user_data, const xqc_moq_track_ns_field_t *track_namespace_tuple, uint64_t track_namespace_num);
+
+typedef xqc_int_t (*xqc_moq_namespace_discovery_on_track_pt)(xqc_moq_session_t *session,
+    void *user_data, xqc_moq_track_t *track);
+
+typedef struct {
+    void                                        *user_data;
+    xqc_moq_namespace_discovery_on_namespace_pt  on_namespace;
+    xqc_moq_namespace_discovery_on_track_pt      on_track;
+} xqc_moq_namespace_discovery_cb_t;
+
+typedef xqc_int_t (*xqc_moq_namespace_discovery_on_namespace_done_pt)(xqc_moq_session_t *session,
+    void *user_data, const xqc_moq_track_ns_field_t *track_namespace_tuple, uint64_t track_namespace_num);
+
+typedef struct {
+    void                                             *user_data;
+    xqc_moq_namespace_discovery_on_namespace_pt       on_namespace;
+    xqc_moq_namespace_discovery_on_namespace_done_pt  on_namespace_done;
+    xqc_moq_namespace_discovery_on_track_pt           on_track;
+} xqc_moq_namespace_discovery_update_cb_t;
+
+/**
+ * @brief Iterate local published state matching a namespace prefix.
+ *
+ * Used to fulfill draft-14 SUBSCRIBE_NAMESPACE behavior: immediately forward
+ * existing PUBLISH_NAMESPACE and PUBLISH messages that match the prefix.
+ */
+xqc_int_t xqc_moq_session_foreach_matching_publication(xqc_moq_session_t *session,
+    const xqc_moq_track_ns_field_t *namespace_prefix_tuple, uint64_t namespace_prefix_num,
+    const xqc_moq_namespace_discovery_cb_t *discovery_callbacks);
+
+/**
+ * @brief Populate and send discovery for an active namespace prefix subscription.
+ *
+ * For a successful SUBSCRIBE_NAMESPACE, this is used to send existing matching
+ * PUBLISH_NAMESPACE/PUBLISH and to initialize per-prefix tracking state.
+ */
+xqc_int_t xqc_moq_session_discovery_refresh_namespace_prefix(xqc_moq_session_t *session,
+    const xqc_moq_track_ns_field_t *namespace_prefix_tuple, uint64_t namespace_prefix_num,
+    const xqc_moq_namespace_discovery_update_cb_t *discovery_update_callbacks);
+
+/**
+ * @brief Notify session discovery logic of a newly created local published track.
+ *
+ * If the peer has an active SUBSCRIBE_NAMESPACE that matches this track's namespace,
+ * this will send incremental PUBLISH_NAMESPACE/PUBLISH updates (deduped).
+ */
+void xqc_moq_session_discovery_on_track_added(xqc_moq_session_t *session, xqc_moq_track_t *track);
+
+/**
+ * @brief Notify session discovery logic that a local published track is removed.
+ *
+ * If this removal causes a previously advertised namespace to become empty for an
+ * active prefix subscription, a PUBLISH_NAMESPACE_DONE update is sent.
+ *
+ * Note: only call this when the track is being removed from session->track_list_for_pub.
+ */
+void xqc_moq_session_discovery_on_track_removed(xqc_moq_session_t *session, xqc_moq_track_t *track);
+
+/* Testable variants: do not call session_error; use callbacks provided. */
+xqc_int_t xqc_moq_session_discovery_on_track_added_with_cb(xqc_moq_session_t *session, xqc_moq_track_t *track,
+    const xqc_moq_namespace_discovery_update_cb_t *discovery_update_callbacks);
+
+xqc_int_t xqc_moq_session_discovery_on_track_removed_with_cb(xqc_moq_session_t *session, xqc_moq_track_t *track,
+    const xqc_moq_namespace_discovery_update_cb_t *discovery_update_callbacks);
 
 #endif /* _XQC_MOQ_SESSION_H_INCLUDED_ */

--- a/moq/moq_transport/xqc_moq_stream.c
+++ b/moq/moq_transport/xqc_moq_stream.c
@@ -41,6 +41,7 @@ xqc_moq_stream_destroy(xqc_moq_stream_t *stream)
     xqc_moq_session_t *session = stream->session;
     xqc_stream_t *quic_stream = stream->trans_ops.quic_stream(stream->trans_stream);
     xqc_usec_t now = xqc_monotonic_timestamp();
+    xqc_moq_track_t *track = stream->track;
     
     if (stream == stream->session->ctl_stream) {
         stream->session->ctl_stream = NULL;
@@ -61,10 +62,9 @@ xqc_moq_stream_destroy(xqc_moq_stream_t *stream)
     }
     
     if (quic_stream && quic_stream->stream_stats.all_data_acked_time
-        && stream->track && stream->track->track_info.track_type == XQC_MOQ_TRACK_VIDEO)
+        && track && track->track_info.track_type == XQC_MOQ_TRACK_VIDEO)
     {
         xqc_usec_t latest_delay = quic_stream->stream_stats.all_data_acked_time - quic_stream->stream_stats.create_time;
-        xqc_moq_track_t *track = stream->track;
         xqc_moq_track_info_t *track_info = track ? &track->track_info : NULL;
         xqc_moq_bitrate_alloc_on_frame_acked(session, track, track_info, latest_delay, 
                                              quic_stream->stream_stats.create_time, now, 
@@ -79,8 +79,8 @@ xqc_moq_stream_destroy(xqc_moq_stream_t *stream)
         xqc_record_stream_state(quic_stream);
     }
 
-    if (stream->track && stream->track->subgroup_stream == stream) {
-        stream->track->subgroup_stream = NULL;
+    if (track && track->subgroup_stream == stream) {
+        track->subgroup_stream = NULL;
     }
 
     xqc_free(stream->read_buf);
@@ -92,6 +92,11 @@ xqc_moq_stream_destroy(xqc_moq_stream_t *stream)
     xqc_moq_stream_free_cur_decode_msg(stream);
 
     xqc_list_del_init(&stream->list_member);
+
+    if (track != NULL) {
+        stream->track = NULL;
+        xqc_moq_track_stream_ref_dec(track);
+    }
 
     xqc_free(stream);
 }
@@ -155,7 +160,11 @@ void
 xqc_moq_stream_on_track_write(xqc_moq_stream_t *moq_stream, xqc_moq_track_t *track,
     uint64_t group_id, uint64_t object_id, uint64_t seq_num)
 {
+    if (moq_stream->track != NULL) {
+        xqc_moq_track_stream_ref_dec(moq_stream->track);
+    }
     moq_stream->track = track;
+    xqc_moq_track_stream_ref_inc(track);
     moq_stream->group_id = group_id;
     moq_stream->object_id = object_id;
     moq_stream->seq_num = seq_num;
@@ -268,6 +277,10 @@ xqc_moq_stream_process(xqc_moq_stream_t *moq_stream, uint8_t *buf, size_t buf_le
                             "|decode message error|ret:%d|msg_type:0x%xi|cur_field_idx:%d|",
                             ret, moq_stream->decode_msg_ctx.cur_msg_type, moq_stream->decode_msg_ctx.cur_field_idx);
                     xqc_moq_stream_clean_decode_msg_ctx(moq_stream);
+                    if (ret == -MOQ_PROTOCOL_VIOLATION) {
+                        xqc_moq_session_error(moq_stream->session, MOQ_PROTOCOL_VIOLATION, "decode protocol violation");
+                        return ret;
+                    }
                     return -XQC_EILLEGAL_FRAME;
                 }
                 processed += ret;
@@ -388,4 +401,3 @@ xqc_moq_stream_process_msg(xqc_moq_stream_t *moq_stream, uint8_t stream_fin, xqc
 
     return processed;
 }
-

--- a/moq/moq_transport/xqc_moq_subscribe.c
+++ b/moq/moq_transport/xqc_moq_subscribe.c
@@ -1,21 +1,50 @@
 #include "moq/moq_transport/xqc_moq_subscribe.h"
 #include "moq/moq_transport/xqc_moq_session.h"
 #include "moq/moq_transport/xqc_moq_message_writer.h"
+#include "moq/moq_transport/xqc_moq_namespace.h"
+#include "moq/moq_transport/xqc_moq_track.h"
 
 xqc_moq_subscribe_t *
-xqc_moq_subscribe_create(xqc_moq_session_t *session, uint64_t subscribe_id,
-    uint64_t track_alias, const char *track_namespace, const char *track_name, xqc_moq_filter_type_t filter_type,
+xqc_moq_subscribe_create_with_namespace_tuple(xqc_moq_session_t *session, uint64_t subscribe_id,
+    uint64_t track_alias, const xqc_moq_track_ns_field_t *track_namespace_tuple, uint64_t track_namespace_num,
+    const char *track_name, size_t track_name_len, xqc_moq_filter_type_t filter_type,
     uint64_t start_group_id, uint64_t start_object_id, uint64_t end_group_id, uint64_t end_object_id,
     char *authinfo, xqc_int_t is_local)
 {
     xqc_moq_subscribe_t *subscribe;
     xqc_moq_subscribe_msg_t *msg;
 
-    size_t track_namespace_len = strlen(track_namespace);
-    size_t track_name_len = strlen(track_name);
-    if (track_namespace_len > XQC_MOQ_MAX_NAME_LEN || track_name_len > XQC_MOQ_MAX_NAME_LEN
-        || track_namespace_len == 0 || track_name_len == 0) {
-        xqc_log(session->log, XQC_LOG_ERROR, "|illegal track namespace or name|");
+    if (session == NULL || track_namespace_tuple == NULL || track_namespace_num == 0
+        || track_name == NULL || track_name_len == 0)
+    {
+        return NULL;
+    }
+
+    if (track_name_len > XQC_MOQ_MAX_NAME_LEN) {
+        xqc_log(session->log, XQC_LOG_ERROR, "|illegal track name|");
+        return NULL;
+    }
+
+    if (track_namespace_num > XQC_MOQ_MAX_NAMESPACE_TUPLE_ELEMS) {
+        xqc_log(session->log, XQC_LOG_ERROR, "|illegal track namespace tuple size|");
+        return NULL;
+    }
+
+    size_t track_namespace_len = 0;
+    for (uint64_t i = 0; i < track_namespace_num; i++) {
+        if (track_namespace_tuple[i].len > XQC_MOQ_MAX_NAME_LEN) {
+            xqc_log(session->log, XQC_LOG_ERROR, "|illegal track namespace tuple elem len|");
+            return NULL;
+        }
+        if (track_namespace_len > XQC_MOQ_MAX_FULL_TRACK_NAME_LEN - track_namespace_tuple[i].len) {
+            xqc_log(session->log, XQC_LOG_ERROR, "|track namespace too long|");
+            return NULL;
+        }
+        track_namespace_len += track_namespace_tuple[i].len;
+    }
+
+    if (track_namespace_len > XQC_MOQ_MAX_FULL_TRACK_NAME_LEN - track_name_len) {
+        xqc_log(session->log, XQC_LOG_ERROR, "|full track name too long|");
         return NULL;
     }
 
@@ -31,15 +60,28 @@ xqc_moq_subscribe_create(xqc_moq_session_t *session, uint64_t subscribe_id,
     }
 
     msg = xqc_calloc(1, sizeof(xqc_moq_subscribe_msg_t));
+    if (msg == NULL) {
+        return NULL;
+    }
+
     msg->subscribe_id = subscribe_id;
     msg->track_alias = track_alias;
-    msg->track_namespace_num = 1;
+    msg->track_namespace_num = track_namespace_num;
+    msg->track_namespace_tuple = xqc_moq_namespace_tuple_copy(track_namespace_tuple, track_namespace_num);
+    if (msg->track_namespace_tuple == NULL) {
+        xqc_free(msg);
+        return NULL;
+    }
     msg->track_namespace_len = track_namespace_len;
-    msg->track_namespace = xqc_calloc(1, track_namespace_len + 1);
-    xqc_memcpy(msg->track_namespace, track_namespace, track_namespace_len);
+
     msg->track_name_len = track_name_len;
     msg->track_name = xqc_calloc(1, track_name_len + 1);
+    if (msg->track_name == NULL) {
+        xqc_moq_msg_free_subscribe(msg);
+        return NULL;
+    }
     xqc_memcpy(msg->track_name, track_name, track_name_len);
+
     msg->subscriber_priority = 0;
     msg->group_order = 0x1;
     msg->forward = 0;
@@ -48,18 +90,31 @@ xqc_moq_subscribe_create(xqc_moq_session_t *session, uint64_t subscribe_id,
     msg->start_object_id = start_object_id;
     msg->end_group_id = end_group_id;
     msg->end_object_id = end_object_id;
+
     if (authinfo_len > 0) {
         msg->params_num = 1;
         msg->params = xqc_calloc(msg->params_num, sizeof(xqc_moq_message_parameter_t));
+        if (msg->params == NULL) {
+            xqc_moq_msg_free_subscribe(msg);
+            return NULL;
+        }
         msg->params[0].type = XQC_MOQ_PARAM_AUTH;
         msg->params[0].length = authinfo_len;
         msg->params[0].value = xqc_calloc(1, authinfo_len + 1);
+        if (msg->params[0].value == NULL) {
+            xqc_moq_msg_free_subscribe(msg);
+            return NULL;
+        }
         xqc_memcpy(msg->params[0].value, authinfo, authinfo_len);
     } else {
         msg->params_num = 0;
     }
 
     subscribe = xqc_calloc(1, sizeof(xqc_moq_subscribe_t));
+    if (subscribe == NULL) {
+        xqc_moq_msg_free_subscribe(msg);
+        return NULL;
+    }
     subscribe->subscribe_msg = msg;
 
     xqc_init_list_head(&subscribe->list_member);
@@ -93,14 +148,20 @@ xqc_moq_subscribe_update_msg(xqc_moq_subscribe_t *subscribe, xqc_moq_subscribe_u
 }
 
 xqc_int_t
-xqc_moq_subscribe(xqc_moq_session_t *session, const char *track_namespace, const char *track_name,
-    xqc_moq_filter_type_t filter_type, uint64_t start_group_id, uint64_t start_object_id,
-    uint64_t end_group_id, uint64_t end_object_id, char *authinfo)
+xqc_moq_subscribe_with_namespace_tuple(xqc_moq_session_t *session,
+    const xqc_moq_track_ns_field_t *track_namespace_tuple, uint64_t track_namespace_num,
+    const char *track_name,
+    xqc_moq_filter_type_t filter_type,
+    uint64_t start_group_id, uint64_t start_object_id,
+    uint64_t end_group_id, uint64_t end_object_id,
+    char *authinfo)
 {
-    xqc_moq_subscribe_t *subscribe;
-    xqc_moq_track_t *track;
-    xqc_int_t ret;
-    track = xqc_moq_find_track_by_name(session, track_namespace, track_name, XQC_MOQ_TRACK_FOR_SUB);
+    if (session == NULL || track_namespace_tuple == NULL || track_namespace_num == 0 || track_name == NULL) {
+        return -XQC_EPARAM;
+    }
+
+    xqc_moq_track_t *track = xqc_moq_find_track_by_track_namespace_tuple(session,
+        track_namespace_tuple, track_namespace_num, track_name, XQC_MOQ_TRACK_FOR_SUB);
     if (track == NULL) {
         xqc_log(session->log, XQC_LOG_ERROR, "|track not found|");
         return -XQC_ENULLPTR;
@@ -116,31 +177,65 @@ xqc_moq_subscribe(xqc_moq_session_t *session, const char *track_namespace, const
     xqc_moq_track_set_subscribe_id(track, subscribe_id);
     xqc_moq_track_set_alias(track, track_alias);
 
-    subscribe = xqc_moq_subscribe_create(session, subscribe_id, track->track_alias, track_namespace, track_name,
-                                         filter_type, start_group_id, start_object_id, end_group_id, end_object_id,
-                                         authinfo, 1);
+    size_t track_name_len = strlen(track_name);
+    xqc_moq_subscribe_t *subscribe = xqc_moq_subscribe_create_with_namespace_tuple(session, subscribe_id, track_alias,
+        track_namespace_tuple, track_namespace_num, track_name, track_name_len,
+        filter_type, start_group_id, start_object_id, end_group_id, end_object_id,
+        authinfo, 1);
     if (subscribe == NULL) {
         xqc_log(session->log, XQC_LOG_ERROR, "|create subscribe error|");
+        xqc_moq_track_set_subscribe_id(track, XQC_MOQ_INVALID_ID);
+        xqc_moq_track_set_alias(track, XQC_MOQ_INVALID_ID);
         return -XQC_ENULLPTR;
     }
 
-    ret = xqc_moq_write_subscribe(session, subscribe->subscribe_msg);
+    xqc_moq_subscribe_msg_t *msg = subscribe->subscribe_msg;
+
+    xqc_int_t ret = xqc_moq_write_subscribe(session, msg);
     if (ret < 0) {
         xqc_log(session->log, XQC_LOG_ERROR, "|write subscribe error|");
+        xqc_list_del(&subscribe->list_member);
+        xqc_moq_subscribe_destroy(subscribe);
+        xqc_moq_track_set_subscribe_id(track, XQC_MOQ_INVALID_ID);
+        xqc_moq_track_set_alias(track, XQC_MOQ_INVALID_ID);
         return ret;
     }
 
-    xqc_log(session->log, XQC_LOG_INFO, "|subscribe success|track_name:%s|track_alias:%ui|subscribe_id:%ui|",
+    xqc_log(session->log, XQC_LOG_INFO, "|subscribe_with_tuple success|track_name:%s|track_alias:%ui|subscribe_id:%ui|",
             track_name, track_alias, subscribe_id);
 
     return subscribe_id;
 }
 
 xqc_int_t
-xqc_moq_subscribe_latest(xqc_moq_session_t *session, const char *track_namespace, const char *track_name)
+xqc_moq_subscribe(xqc_moq_session_t *session,
+    const xqc_moq_track_ns_field_t *track_namespace_tuple, uint64_t track_namespace_num,
+    const char *track_name,
+    xqc_moq_filter_type_t filter_type, uint64_t start_group_id, uint64_t start_object_id,
+    uint64_t end_group_id, uint64_t end_object_id, char *authinfo)
 {
-    return xqc_moq_subscribe(session, track_namespace, track_name,
-                             XQC_MOQ_FILTER_LAST_GROUP, 0, 0, 0, 0, NULL);
+    return xqc_moq_subscribe_with_namespace_tuple(session,
+        track_namespace_tuple, track_namespace_num, track_name, filter_type,
+        start_group_id, start_object_id, end_group_id, end_object_id, authinfo);
+}
+
+xqc_int_t
+xqc_moq_subscribe_latest(xqc_moq_session_t *session,
+    const xqc_moq_track_ns_field_t *track_namespace_tuple, uint64_t track_namespace_num,
+    const char *track_name)
+{
+    return xqc_moq_subscribe(session, track_namespace_tuple, track_namespace_num, track_name,
+        XQC_MOQ_FILTER_LAST_GROUP, 0, 0, 0, 0, NULL);
+}
+
+xqc_int_t
+xqc_moq_subscribe_latest_with_namespace_tuple(xqc_moq_session_t *session,
+    const xqc_moq_track_ns_field_t *track_namespace_tuple, uint64_t track_namespace_num,
+    const char *track_name)
+{
+    return xqc_moq_subscribe_with_namespace_tuple(session,
+        track_namespace_tuple, track_namespace_num, track_name,
+        XQC_MOQ_FILTER_LAST_GROUP, 0, 0, 0, 0, NULL);
 }
 
 xqc_int_t
@@ -186,12 +281,18 @@ xqc_moq_publish(xqc_moq_session_t *session, xqc_moq_publish_msg_t *publish)
     xqc_int_t ret;
     uint64_t subscribe_id;
 
-    if (session == NULL || publish == NULL || publish->track_namespace == NULL || publish->track_name == NULL) {
+    if (session == NULL || publish == NULL || publish->track_name == NULL) {
         xqc_log(session->log, XQC_LOG_ERROR, "|publish invalid argument|");
         return -XQC_EPARAM;
     }
 
-    track = xqc_moq_find_track_by_name(session, publish->track_namespace, publish->track_name, XQC_MOQ_TRACK_FOR_PUB);
+    if (publish->track_namespace_tuple == NULL || publish->track_namespace_num == 0) {
+        xqc_log(session->log, XQC_LOG_ERROR, "|publish missing namespace tuple|");
+        return -XQC_EPARAM;
+    }
+    track = xqc_moq_find_track_by_track_namespace_tuple(session,
+        publish->track_namespace_tuple, publish->track_namespace_num,
+        publish->track_name, XQC_MOQ_TRACK_FOR_PUB);
     if (track == NULL) {
         xqc_log(session->log, XQC_LOG_ERROR, "|publish track not found|track_name:%s|", publish->track_name);
         return -XQC_ENULLPTR;
@@ -215,9 +316,6 @@ xqc_moq_publish(xqc_moq_session_t *session, xqc_moq_publish_msg_t *publish)
     xqc_moq_track_set_subscribe_id(track, subscribe_id);
     publish->subscribe_id = subscribe_id;
 
-    if (publish->track_namespace_len == 0) {
-        publish->track_namespace_len = strlen(publish->track_namespace);
-    }
     if (publish->track_name_len == 0) {
         publish->track_name_len = strlen(publish->track_name);
     }
@@ -225,9 +323,10 @@ xqc_moq_publish(xqc_moq_session_t *session, xqc_moq_publish_msg_t *publish)
         publish->group_order = 0x1;
     }
 
-    subscribe = xqc_moq_subscribe_create(session, subscribe_id, track->track_alias,
-                                         publish->track_namespace, publish->track_name, XQC_MOQ_FILTER_LAST_GROUP,
-                                         0, 0, 0, 0, NULL, 0);
+    subscribe = xqc_moq_subscribe_create_with_namespace_tuple(session, subscribe_id, track->track_alias,
+        publish->track_namespace_tuple, publish->track_namespace_num,
+        publish->track_name, publish->track_name_len,
+        XQC_MOQ_FILTER_LAST_GROUP, 0, 0, 0, 0, NULL, 0);
     if (subscribe == NULL) {
         xqc_log(session->log, XQC_LOG_ERROR, "|publish create subscribe error|");
         xqc_moq_track_set_subscribe_id(track, XQC_MOQ_INVALID_ID);
@@ -251,40 +350,51 @@ xqc_moq_publish(xqc_moq_session_t *session, xqc_moq_publish_msg_t *publish)
     xqc_log(session->log, XQC_LOG_INFO, "|publish send success|track_name:%s|track_alias:%ui|subscribe_id:%ui|",
             publish->track_name, track->track_alias, subscribe_id);
 
-    return (xqc_int_t)subscribe_id;
+    return subscribe_id;
 }
 
 xqc_int_t
-xqc_moq_create_datachannel(xqc_moq_session_t *session, const char *track_namespace, const char *track_name,
+xqc_moq_create_datachannel(xqc_moq_session_t *session,
+    const xqc_moq_track_ns_field_t *track_namespace_tuple, uint64_t track_namespace_num,
+    const char *track_name, xqc_moq_track_t **track, uint64_t *subscribe_id, xqc_int_t raw_object)
+{
+    return xqc_moq_create_datachannel_with_namespace_tuple(session,
+        track_namespace_tuple, track_namespace_num, track_name,
+        track, subscribe_id, raw_object);
+}
+
+xqc_int_t
+xqc_moq_create_datachannel_with_namespace_tuple(xqc_moq_session_t *session,
+    const xqc_moq_track_ns_field_t *track_namespace_tuple, uint64_t track_namespace_num,
+    const char *track_name,
     xqc_moq_track_t **track, uint64_t *subscribe_id, xqc_int_t raw_object)
 {
     xqc_moq_track_t *dc_track;
     xqc_moq_publish_msg_t publish_msg;
     xqc_int_t ret;
 
-    if (session == NULL || track_namespace == NULL || track_name == NULL) {
+    if (session == NULL || track_namespace_tuple == NULL || track_namespace_num == 0 || track_name == NULL) {
         return -XQC_EPARAM;
     }
 
-    dc_track = xqc_moq_track_create(session, (char *)track_namespace, (char *)track_name,
-                                    XQC_MOQ_TRACK_DATACHANNEL, NULL,
-                                    XQC_MOQ_CONTAINER_NONE, XQC_MOQ_TRACK_FOR_PUB);
+    dc_track = xqc_moq_track_create_with_namespace_tuple(session,track_namespace_num, track_namespace_tuple, 
+        (char *)track_name, XQC_MOQ_TRACK_DATACHANNEL, NULL, XQC_MOQ_CONTAINER_NONE, XQC_MOQ_TRACK_FOR_PUB);
     if (dc_track == NULL) {
-        xqc_log(session->log, XQC_LOG_ERROR, "|create datachannel track error|track:%s/%s|",
-                track_namespace, track_name);
+        xqc_log(session->log, XQC_LOG_ERROR, "|create datachannel track error|track:%s|",
+                xqc_moq_track_get_full_name(dc_track));
         return -XQC_ENULLPTR;
     }
     dc_track->raw_object = raw_object ? 1 : 0;
     xqc_log(session->log, XQC_LOG_INFO,
-            "|create_datachannel_track|track:%s/%s|track_type:%d|raw_object:%d|",
-            track_namespace, track_name, dc_track->track_info.track_type, dc_track->raw_object);
+            "|create_datachannel_track|track:%s|track_type:%d|raw_object:%d|",
+            xqc_moq_track_get_full_name(dc_track), dc_track->track_info.track_type, dc_track->raw_object);
 
     xqc_memzero(&publish_msg, sizeof(publish_msg));
-    publish_msg.track_namespace = (char *)track_namespace;
-    publish_msg.track_namespace_len = strlen(track_namespace);
-    publish_msg.track_namespace_num = 1;
-    publish_msg.track_name = (char *)track_name;
-    publish_msg.track_name_len = strlen(track_name);
+    publish_msg.track_namespace_num = dc_track->track_info.track_namespace_num;
+    publish_msg.track_namespace_tuple = dc_track->track_info.track_namespace_tuple;
+    publish_msg.track_namespace_len = 0;
+    publish_msg.track_name = dc_track->track_info.track_name;
+    publish_msg.track_name_len = strlen(dc_track->track_info.track_name);
     publish_msg.group_order = 0;
     publish_msg.content_exist = 0;
     publish_msg.largest_group_id = 0;
@@ -301,12 +411,12 @@ xqc_moq_create_datachannel(xqc_moq_session_t *session, const char *track_namespa
         publish_msg.params_num = 1;
         auth_param_valid = 1;
         xqc_log(session->log, XQC_LOG_INFO,
-                "|create_datachannel_build_catalog_ok|track:%s/%s|",
-                track_namespace, track_name);
+                "|create_datachannel_build_catalog_ok|track:%s|",
+                xqc_moq_track_get_full_name(dc_track));
     } else {
         xqc_log(session->log, XQC_LOG_ERROR,
-                "|create_datachannel_build_catalog_fail|ret:%d|track:%s/%s|",
-                ret, track_namespace, track_name);
+                "|create_datachannel_build_catalog_fail|ret:%d|track:%s|",
+                ret, xqc_moq_track_get_full_name(dc_track));
     }
 
     ret = xqc_moq_publish(session, &publish_msg);
@@ -314,8 +424,10 @@ xqc_moq_create_datachannel(xqc_moq_session_t *session, const char *track_namespa
         xqc_moq_free_catalog_param(&auth_param);
     }
     if (ret < 0) {
-        xqc_log(session->log, XQC_LOG_ERROR, "|xqc_moq_create_datachannel publish error|ret:%d|track:%s/%s|",
-                ret, track_namespace, track_name);
+        xqc_log(session->log, XQC_LOG_ERROR, "|xqc_moq_create_datachannel publish error|ret:%d|track:%s|",
+                ret, xqc_moq_track_get_full_name(dc_track));
+        xqc_list_del(&dc_track->list_member);
+        xqc_moq_track_destroy(dc_track);
         return ret;
     }
 

--- a/moq/moq_transport/xqc_moq_subscribe.h
+++ b/moq/moq_transport/xqc_moq_subscribe.h
@@ -10,8 +10,9 @@ typedef struct xqc_moq_subscribe_s {
 } xqc_moq_subscribe_t;
 
 xqc_moq_subscribe_t *
-xqc_moq_subscribe_create(xqc_moq_session_t *session, uint64_t subscribe_id,
-    uint64_t track_alias, const char *track_namespace, const char *track_name, xqc_moq_filter_type_t filter_type,
+xqc_moq_subscribe_create_with_namespace_tuple(xqc_moq_session_t *session, uint64_t subscribe_id,
+    uint64_t track_alias, const xqc_moq_track_ns_field_t *track_namespace_tuple, uint64_t track_namespace_num,
+    const char *track_name, size_t track_name_len, xqc_moq_filter_type_t filter_type,
     uint64_t start_group_id, uint64_t start_object_id, uint64_t end_group_id, uint64_t end_object_id,
     char *authinfo, xqc_int_t is_local);
 

--- a/moq/moq_transport/xqc_moq_track.c
+++ b/moq/moq_transport/xqc_moq_track.c
@@ -5,28 +5,59 @@
 #include "moq/moq_media/xqc_moq_datachannel.h"
 #include "moq/moq_media/xqc_moq_media_track.h"
 
+#define XQC_MOQ_TRACK_FULL_NAME_BUF_SIZE (XQC_MOQ_MAX_NAME_LEN * 2 + 2)
+
+static void
+xqc_moq_track_finalize_destroy(xqc_moq_track_t *track)
+{
+    if (track == NULL) {
+        return;
+    }
+
+    track->track_ops.on_destroy(track);
+    xqc_moq_track_free_fields(track);
+    xqc_free(track);
+}
+
 xqc_moq_track_t *
 xqc_moq_track_create(xqc_moq_session_t *session, char *track_namespace, char *track_name,
-    xqc_moq_track_type_t track_type, xqc_moq_selection_params_t *params,
+    xqc_moq_track_type_t track_type, xqc_moq_selection_params_t *params, xqc_moq_container_t container, xqc_moq_track_role_t role)
+{
+    if (session == NULL || track_namespace == NULL || track_name == NULL) {
+        return NULL;
+    }
+
+    xqc_moq_track_ns_field_t namespace_tuple[1];
+    namespace_tuple[0].data = (unsigned char *)track_namespace;
+    namespace_tuple[0].len = strlen(track_namespace);
+
+    // Compatibility: string namespace is treated as a single tuple element. 
+    return xqc_moq_track_create_with_namespace_tuple(session,
+        1, namespace_tuple, track_name, track_type, params, container, role);
+}
+
+xqc_moq_track_t *
+xqc_moq_track_create_with_namespace_tuple(xqc_moq_session_t *session,
+    uint64_t track_namespace_num, const xqc_moq_track_ns_field_t *track_namespace_tuple,
+    char *track_name, xqc_moq_track_type_t track_type, xqc_moq_selection_params_t *params,
     xqc_moq_container_t container, xqc_moq_track_role_t role)
 {
     xqc_moq_track_t *track;
     xqc_list_head_t *list;
 
-    if (track_namespace == NULL || track_name == NULL) {
+    if (track_namespace_tuple == NULL || track_namespace_num == 0 || track_name == NULL) {
         xqc_log(session->log, XQC_LOG_ERROR, "|NULL ptr|");
         return NULL;
     }
 
-    size_t track_namespace_len = strlen(track_namespace);
-    size_t track_name_len = strlen(track_name);
-    if (track_namespace_len > XQC_MOQ_MAX_NAME_LEN || track_name_len > XQC_MOQ_MAX_NAME_LEN
-        || track_namespace_len == 0 || track_name_len == 0) {
-        xqc_log(session->log, XQC_LOG_ERROR, "|namespace or name too long|");
+    if (track_namespace_num > XQC_MOQ_MAX_NAMESPACE_TUPLE_ELEMS) {
+        xqc_log(session->log, XQC_LOG_ERROR, "|namespace tuple too large|track_namespace_num:%ui|",
+                track_namespace_num);
         return NULL;
     }
 
-    track = xqc_moq_find_track_by_name(session, track_namespace, track_name, role);
+    track = xqc_moq_find_track_by_track_namespace_tuple(session, track_namespace_tuple,
+                                                  track_namespace_num, track_name, role);
     if (track) {
         return track;
     }
@@ -56,10 +87,47 @@ xqc_moq_track_create(xqc_moq_session_t *session, char *track_namespace, char *tr
     track->session = session;
     track->track_info.track_type = track_type;
     track->container_format = container;
-    track->track_info.track_namespace = xqc_calloc(1, track_namespace_len + 1);
-    xqc_memcpy(track->track_info.track_namespace, track_namespace, track_namespace_len);
+    track->track_info.track_namespace_num = track_namespace_num;
+    track->track_info.track_namespace_tuple =
+    xqc_calloc(track_namespace_num, sizeof(xqc_moq_track_ns_field_t));
+    if (track->track_info.track_namespace_tuple == NULL) {
+        xqc_log(session->log, XQC_LOG_ERROR, "|track namespace tuple alloc fail|");
+        xqc_moq_track_free_fields(track);
+        xqc_free(track);
+        return NULL;
+    }
+    for (uint64_t i = 0; i < track_namespace_num; i++) {
+        track->track_info.track_namespace_tuple[i].len = track_namespace_tuple[i].len;
+        if (track_namespace_tuple[i].len > 0 && track_namespace_tuple[i].data != NULL) {
+            track->track_info.track_namespace_tuple[i].data =
+                xqc_calloc(1, track_namespace_tuple[i].len + 1);
+            if (track->track_info.track_namespace_tuple[i].data == NULL) {
+                xqc_log(session->log, XQC_LOG_ERROR, "|track namespace tuple data alloc fail|");
+                xqc_moq_track_free_fields(track);
+                xqc_free(track);
+                return NULL;
+            }
+            xqc_memcpy(track->track_info.track_namespace_tuple[i].data,
+                       track_namespace_tuple[i].data, track_namespace_tuple[i].len);
+        }
+    }
+
+    size_t track_name_len = strlen(track_name);
+    if (track_name_len == 0 || track_name_len > XQC_MOQ_MAX_NAME_LEN) {
+        xqc_log(session->log, XQC_LOG_ERROR, "|track name too long|");
+        xqc_moq_track_free_fields(track);
+        xqc_free(track);
+        return NULL;
+    }
     track->track_info.track_name = xqc_calloc(1, track_name_len + 1);
+    if (track->track_info.track_name == NULL) {
+        xqc_log(session->log, XQC_LOG_ERROR, "|track name alloc fail|");
+        xqc_moq_track_free_fields(track);
+        xqc_free(track);
+        return NULL;
+    }
     xqc_memcpy(track->track_info.track_name, track_name, track_name_len);
+
     track->track_alias = XQC_MOQ_INVALID_ID;
     track->subscribe_id = XQC_MOQ_INVALID_ID;
     track->streams_count = 0;
@@ -68,8 +136,6 @@ xqc_moq_track_create(xqc_moq_session_t *session, char *track_namespace, char *tr
     track->cur_subgroup_id = 0;
     track->cur_subgroup_group_id = XQC_MOQ_INVALID_ID;
     track->raw_object = 0;
-    track->reuse_subgroup_stream = 0;
-    track->subgroup_stream = NULL;
 
     if (role == XQC_MOQ_TRACK_FOR_PUB) {
         list = &session->track_list_for_pub;
@@ -80,9 +146,13 @@ xqc_moq_track_create(xqc_moq_session_t *session, char *track_namespace, char *tr
     xqc_init_list_head(&track->list_member);
     xqc_list_add_tail(&track->list_member, list);
 
+    if (role == XQC_MOQ_TRACK_FOR_PUB) {
+        xqc_moq_session_discovery_on_track_added(session, track);
+    }
+
     track->track_ops.on_create(track);
 
-    xqc_log(session->log, XQC_LOG_INFO, "|track create success|track_name:%s|track_role:%d|", track_name, role);
+    xqc_log(session->log, XQC_LOG_INFO, "|track create success (tuple)|track_name:%s|track_role:%d|", track_name, role);
 
     return track;
 }
@@ -90,17 +160,41 @@ xqc_moq_track_create(xqc_moq_session_t *session, char *track_namespace, char *tr
 void
 xqc_moq_track_destroy(xqc_moq_track_t *track)
 {
-    track->track_ops.on_destroy(track);
+    if (track == NULL) {
+        return;
+    }
 
-    xqc_moq_track_free_fields(track);
-    xqc_free(track);
+    xqc_moq_session_t *session = track->session;
+    if (session != NULL && !session->is_destroying && track->track_role == XQC_MOQ_TRACK_FOR_PUB
+        && !track->discovery_removed)
+    {
+        xqc_moq_session_discovery_on_track_removed(session, track);
+        track->discovery_removed = 1;
+    }
+
+    if (track->active_stream_refcnt > 0) {
+        track->destroy_pending = 1;
+        return;
+    }
+
+    xqc_moq_track_finalize_destroy(track);
 }
 
 void
 xqc_moq_track_free_fields(xqc_moq_track_t *track)
 {
-    xqc_free(track->track_info.track_namespace);
-    track->track_info.track_namespace = NULL;
+    if (track->track_info.track_namespace_tuple) {
+        for (uint64_t i = 0; i < track->track_info.track_namespace_num; i++) {
+            if (track->track_info.track_namespace_tuple[i].data) {
+                xqc_free(track->track_info.track_namespace_tuple[i].data);
+                track->track_info.track_namespace_tuple[i].data = NULL;
+                track->track_info.track_namespace_tuple[i].len = 0;
+            }
+        }
+        xqc_free(track->track_info.track_namespace_tuple);
+        track->track_info.track_namespace_tuple = NULL;
+        track->track_info.track_namespace_num = 0;
+    }
     xqc_free(track->track_info.track_name);
     track->track_info.track_name = NULL;
     xqc_free(track->packaging);
@@ -109,12 +203,83 @@ xqc_moq_track_free_fields(xqc_moq_track_t *track)
 }
 
 void
+xqc_moq_track_stream_ref_inc(xqc_moq_track_t *track)
+{
+    if (track == NULL) {
+        return;
+    }
+    track->active_stream_refcnt++;
+}
+
+void
+xqc_moq_track_stream_ref_dec(xqc_moq_track_t *track)
+{
+    if (track == NULL) {
+        return;
+    }
+
+    if (track->active_stream_refcnt > 0) {
+        track->active_stream_refcnt--;
+    }
+
+    if (track->destroy_pending && track->active_stream_refcnt == 0) {
+        xqc_moq_track_finalize_destroy(track);
+    }
+}
+
+const char * xqc_moq_track_get_full_name(const xqc_moq_track_t *track)
+{
+    if (track == NULL) {
+        return "null";
+    }
+
+    // NOTE: for logging only; do not use this representation for comparisons. 
+    size_t off = 0;
+    static char xqc_moq_track_full_name_buf[XQC_MOQ_TRACK_FULL_NAME_BUF_SIZE];
+    xqc_moq_track_full_name_buf[0] = '\0';
+
+    if (track->track_info.track_namespace_tuple != NULL && track->track_info.track_namespace_num > 0) {
+        for (uint64_t i = 0; i < track->track_info.track_namespace_num && off < XQC_MOQ_TRACK_FULL_NAME_BUF_SIZE - 1; i++) {
+            const xqc_moq_track_ns_field_t *field = &track->track_info.track_namespace_tuple[i];
+            if (field->data != NULL && field->len > 0) {
+                size_t copy_len = field->len;
+                if (off + copy_len >= XQC_MOQ_TRACK_FULL_NAME_BUF_SIZE - 1) {
+                    copy_len = XQC_MOQ_TRACK_FULL_NAME_BUF_SIZE - 1 - off;
+                }
+                xqc_memcpy(xqc_moq_track_full_name_buf + off, field->data, copy_len);
+                off += copy_len;
+            }
+            if (i + 1 < track->track_info.track_namespace_num && off < XQC_MOQ_TRACK_FULL_NAME_BUF_SIZE - 1) {
+                xqc_moq_track_full_name_buf[off++] = '/';
+            }
+        }
+    }
+
+    if (track->track_info.track_name != NULL && off < XQC_MOQ_TRACK_FULL_NAME_BUF_SIZE - 2) {
+        xqc_moq_track_full_name_buf[off++] = '/';
+        size_t name_len = strlen(track->track_info.track_name);
+        if (off + name_len >= XQC_MOQ_TRACK_FULL_NAME_BUF_SIZE - 1) {
+            name_len = XQC_MOQ_TRACK_FULL_NAME_BUF_SIZE - 1 - off;
+        }
+        xqc_memcpy(xqc_moq_track_full_name_buf + off, track->track_info.track_name, name_len);
+        off += name_len;
+    }
+
+    xqc_moq_track_full_name_buf[off] = '\0';
+
+    if (off == 0) {
+        return "null";
+    }
+    return xqc_moq_track_full_name_buf;
+}
+
+void
 xqc_moq_track_set_alias(xqc_moq_track_t *track, uint64_t track_alias)
 {
     if (track->track_alias != track_alias) {
         xqc_log(track->session->log, XQC_LOG_DEBUG,
-                "|track_alias_update|track:%s/%s|old:%ui|new:%ui|",
-                track->track_info.track_namespace, track->track_info.track_name,
+                "|track_alias_update|track:%s|old:%ui|new:%ui|",
+                xqc_moq_track_get_full_name(track),
                 track->track_alias, track_alias);
     }
     track->track_alias = track_alias;
@@ -125,8 +290,8 @@ xqc_moq_track_set_subscribe_id(xqc_moq_track_t *track, uint64_t subscribe_id)
 {
     if (track->subscribe_id != subscribe_id) {
         xqc_log(track->session->log, XQC_LOG_DEBUG,
-                "|track_subscribe_id_update|track:%s/%s|old:%ui|new:%ui|",
-                track->track_info.track_namespace, track->track_info.track_name,
+                "|track_subscribe_id_update|track:%s|old:%ui|new:%ui|",
+                xqc_moq_track_get_full_name(track),
                 track->subscribe_id, subscribe_id);
     }
     track->subscribe_id = subscribe_id;

--- a/moq/moq_transport/xqc_moq_track.h
+++ b/moq/moq_transport/xqc_moq_track.h
@@ -44,11 +44,21 @@ typedef struct xqc_moq_track_s {
     xqc_moq_track_role_t                track_role;
     xqc_moq_stream_t                    *subgroup_stream;
     uint8_t                             reuse_subgroup_stream;  // whether to reuse the same stream for multiple objects
+    /* Active streams referencing this track via xqc_moq_stream_on_track_write. */
+    uint64_t                            active_stream_refcnt;
+    /* Track is logically destroyed but retained until active_stream_refcnt reaches 0. */
+    uint8_t                             destroy_pending;
+    /* Discovery removal notification already emitted (idempotency). */
+    uint8_t                             discovery_removed;
 } xqc_moq_track_t;
 
 void xqc_moq_track_destroy(xqc_moq_track_t *track);
 
 void xqc_moq_track_free_fields(xqc_moq_track_t *track);
+
+void xqc_moq_track_stream_ref_inc(xqc_moq_track_t *track);
+
+void xqc_moq_track_stream_ref_dec(xqc_moq_track_t *track);
 
 void xqc_moq_track_set_alias(xqc_moq_track_t *track, uint64_t track_alias);
 
@@ -63,5 +73,15 @@ void xqc_moq_track_copy_params(xqc_moq_selection_params_t *dst, xqc_moq_selectio
 void xqc_moq_track_free_params(xqc_moq_selection_params_t *params);
 
 void xqc_moq_track_set_params(xqc_moq_track_t *track, xqc_moq_selection_params_t *params);
+
+/**
+ * @brief Get track full name as "ns0/ns1/.../nsN/track_name" for logging.
+ */
+const char *xqc_moq_track_get_full_name(const xqc_moq_track_t *track);
+
+xqc_moq_track_t *xqc_moq_track_create_with_namespace_tuple(xqc_moq_session_t *session,
+    uint64_t track_namespace_num, const xqc_moq_track_ns_field_t *track_namespace_tuple,
+    char *track_name, xqc_moq_track_type_t track_type, xqc_moq_selection_params_t *params,
+    xqc_moq_container_t container, xqc_moq_track_role_t role);
 
 #endif /* _XQC_MOQ_TRACK_H_INCLUDED_ */

--- a/moq/tests/catalog_test.c
+++ b/moq/tests/catalog_test.c
@@ -1,6 +1,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "moq/moq_media/xqc_moq_catalog.h"
 #include "moq/moq_transport/xqc_moq_session.h"
 
@@ -12,7 +13,7 @@ main()
 //   "sequence": 0,
 //   "streamingFormat": 1,
 //   "streamingFormatVersion": "0.2",
-//   "namespace": "conference.example.com/conference123/alice",
+//   "namespace": ["conference.example.com","conference123","alice"],
 //   "packaging": "loc",
 //   "renderGroup": 1,
 //   "tracks": [
@@ -31,7 +32,7 @@ main()
      \"streamingFormat\": 1,\
      \"streamingFormatVersion\": \"0.2\",\
      \"commonTrackFields\": {\
-        \"namespace\": \"sports.example.com/games/08-08-23/12345\",\
+        \"namespace\": [\"sports.example.com\",\"games\",\"08-08-23\",\"12345\"],\
         \"packaging\": \"cmaf\",\
         \"renderGroup\":1\
      },\
@@ -51,16 +52,19 @@ main()
       ]\
    }\"";
 
-    xqc_moq_catalog_t *catalog = (xqc_moq_catalog_t *) malloc(sizeof(xqc_moq_catalog_t));
-    xqc_init_list_head(&catalog->track_list_for_sub);
+    xqc_moq_catalog_t catalog;
+    xqc_moq_catalog_init(&catalog);
     size_t catalog_len = strlen(demo_catalog);
-    catalog->log = NULL;
-    xqc_int_t decode_error = xqc_moq_catalog_decode(catalog, demo_catalog, catalog_len);
+    catalog.log = NULL;
+
+    xqc_int_t decode_error = xqc_moq_catalog_decode(&catalog, (uint8_t *)demo_catalog, catalog_len);
     fprintf(stderr, "decode error = %d \n", decode_error);
     char buf[800] = {0};
     xqc_int_t length = 0;
-    catalog->track_list_for_pub = &catalog->track_list_for_sub;
-    xqc_int_t encode_error = xqc_moq_catalog_encode(catalog, buf, 800, &length);
+    catalog.track_list_for_pub = &catalog.track_list_for_sub;
+    xqc_int_t encode_error = xqc_moq_catalog_encode(&catalog, buf, 800, &length);
     fprintf(stderr, "encode error = %d \n", encode_error);
+
+    xqc_moq_catalog_free_fields(&catalog);
     return 0;
 }

--- a/scripts/moq_scripts/moq_case_test_subscribe_namespace_relay.sh
+++ b/scripts/moq_scripts/moq_case_test_subscribe_namespace_relay.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+#
+# End-to-end test for draft-14 SUBSCRIBE_NAMESPACE relay forwarding (control + media data).
+#
+# Topology:
+#   client A (subscriber)  --> relay (server) <-- client B (publisher)
+#
+# Expected:
+#   - A sends SUBSCRIBE_NAMESPACE(prefix=["namespace","xquic"])
+#   - B publishes tracks under ["namespace","xquic"] and sends media frames
+#   - relay forwards PUBLISH to A and forwards video/audio frames from B to A
+#
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
+cd "${REPO_ROOT}/build" || exit 1
+
+MOQ_DEMO_DIR="moq/demo"
+RELAY_BIN="${MOQ_DEMO_DIR}/moq_demo_relay_v14"
+CLIENT_BIN="${MOQ_DEMO_DIR}/moq_demo_client"
+
+RELAY_PORT=4434
+CASE_TIMEOUT_SECONDS=40
+LINEBUF_PREFIX=()
+if command -v stdbuf >/dev/null 2>&1; then
+    LINEBUF_PREFIX=(stdbuf -oL -eL)
+fi
+
+run_with_timeout() {
+    local timeout_seconds=$1
+    shift
+    timeout -s INT -k 2 "${timeout_seconds}" "$@"
+}
+
+clear_log() {
+    : > clog
+    : > slog
+    : > relay.log
+}
+
+reset_runtime() {
+    rm -rf tp_localhost test_session xqc_token
+    clear_log
+}
+
+build_targets() {
+    cmake --build . -j 8 --target \
+        xquic-static \
+        moq_demo_client \
+        moq_demo_relay_v14 >/dev/null
+}
+
+RELAY_PID=""
+CLIENT_A_PID=""
+CLIENT_B_PID=""
+
+cleanup() {
+    if [ -n "${CLIENT_A_PID}" ]; then
+        kill "${CLIENT_A_PID}" 2>/dev/null || true
+        wait "${CLIENT_A_PID}" 2>/dev/null || true
+    fi
+    if [ -n "${CLIENT_B_PID}" ]; then
+        kill "${CLIENT_B_PID}" 2>/dev/null || true
+        wait "${CLIENT_B_PID}" 2>/dev/null || true
+    fi
+    if [ -n "${RELAY_PID}" ]; then
+        kill "${RELAY_PID}" 2>/dev/null || true
+        wait "${RELAY_PID}" 2>/dev/null || true
+    fi
+    killall moq_demo_relay_v14 2>/dev/null || true
+    killall moq_demo_client 2>/dev/null || true
+}
+trap cleanup EXIT
+
+build_targets
+reset_runtime
+
+echo "[ RUN      ] moq_case_subscribe_namespace_relay.relay_forward_control_and_media"
+
+${LINEBUF_PREFIX[@]} ${RELAY_BIN} -p "${RELAY_PORT}" -V > relay_case.log 2>&1 &
+RELAY_PID=$!
+sleep 1
+if ! kill -0 "${RELAY_PID}" 2>/dev/null; then
+    echo "[     FAIL ] relay did not start"
+    exit 1
+fi
+
+# Start subscriber A first: it subscribes the namespace prefix and waits for media frames.
+run_with_timeout "${CASE_TIMEOUT_SECONDS}" \
+    ${LINEBUF_PREFIX[@]} ${CLIENT_BIN} -a 127.0.0.1 -p "${RELAY_PORT}" -V -r sub -N -W -n 1 \
+    > client_a.log 2>&1 &
+CLIENT_A_PID=$!
+
+sleep 2
+
+# Start publisher B: publishes tracks under the tuple namespace and sends media frames.
+run_with_timeout "${CASE_TIMEOUT_SECONDS}" \
+    ${LINEBUF_PREFIX[@]} ${CLIENT_BIN} -a 127.0.0.1 -p "${RELAY_PORT}" -V -r pub -N -M -n 6 \
+    > client_b.log 2>&1 &
+CLIENT_B_PID=$!
+
+wait "${CLIENT_A_PID}" || true
+wait "${CLIENT_B_PID}" || true
+
+if ! kill -0 "${RELAY_PID}" 2>/dev/null; then
+    echo "[     FAIL ] relay crashed during test"
+    exit 1
+fi
+
+err_clog=$(grep "\[error\]" clog 2>/dev/null || true)
+err_slog=$(grep "\[error\]" slog 2>/dev/null || true)
+err_relay=$(grep "\[error\]" relay.log 2>/dev/null || true)
+
+a_sub_ns=$(grep -E "send subscribe_namespace:" client_a.log 2>/dev/null || true)
+a_publish=$(grep -E "on_publish:.*(video|audio)" client_a.log 2>/dev/null || true)
+a_video=$(grep -E "^subscribe_id:.*video_len:" client_a.log 2>/dev/null || true)
+a_audio=$(grep -E "on_audio_frame:" client_a.log 2>/dev/null || true)
+
+relay_publish=$(grep -E "relay on_publish:" relay_case.log 2>/dev/null || true)
+relay_forward=$(grep -E "relay forward publish:" relay_case.log 2>/dev/null || true)
+
+if [ -n "${a_sub_ns}" ] && [ -n "${a_publish}" ] && [ -n "${a_video}" ] && [ -n "${a_audio}" ] \
+   && [ -n "${relay_publish}" ] && [ -n "${relay_forward}" ] \
+   && [ -z "${err_clog}" ] && [ -z "${err_slog}" ] && [ -z "${err_relay}" ]; then
+    echo "[       OK ] moq_case_subscribe_namespace_relay.relay_forward_control_and_media (1 ms)"
+    exit 0
+fi
+
+echo "[     FAIL ] moq_case_subscribe_namespace_relay.relay_forward_control_and_media (1 ms)"
+echo "${err_clog}"
+echo "${err_slog}"
+echo "${err_relay}"
+echo "--- client_a ---"
+grep -E "send subscribe_namespace:|on_publish:|subscribe_id:|on_audio_frame:" client_a.log 2>/dev/null || true
+echo "--- relay ---"
+grep -E "relay on_publish:|relay forward publish:|publish_ok:" relay_case.log 2>/dev/null || true
+echo "--- client_b ---"
+grep -E "on_publish_ok:|send (video|audio) frame label:" client_b.log 2>/dev/null || true
+
+exit 1

--- a/scripts/moq_scripts/moq_case_test_subscribe_namespace_relay_done.sh
+++ b/scripts/moq_scripts/moq_case_test_subscribe_namespace_relay_done.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# Case 8 (PUBLISH_NAMESPACE_DONE):
+#   Subscriber A subscribes a prefix.
+#   Publisher B publishes tracks under the matching namespace.
+#   When B disconnects, relay should eventually emit PUBLISH_NAMESPACE_DONE to A.
+#
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
+cd "${REPO_ROOT}/build" || exit 1
+
+MOQ_DEMO_DIR="moq/demo"
+RELAY_BIN="${MOQ_DEMO_DIR}/moq_demo_relay_v14"
+CLIENT_BIN="${MOQ_DEMO_DIR}/moq_demo_client"
+
+RELAY_PORT=4437
+CASE_TIMEOUT_SECONDS=45
+LINEBUF_PREFIX=()
+if command -v stdbuf >/dev/null 2>&1; then
+    LINEBUF_PREFIX=(stdbuf -oL -eL)
+fi
+
+run_with_timeout() {
+    local timeout_seconds=$1
+    shift
+    timeout -s INT -k 2 "${timeout_seconds}" "$@"
+}
+
+reset_runtime() {
+    rm -rf tp_localhost test_session xqc_token
+    : > clog
+    : > slog
+    : > relay.log
+}
+
+build_targets() {
+    cmake --build . -j 8 --target xquic-static moq_demo_client moq_demo_relay_v14 >/dev/null
+}
+
+RELAY_PID=""
+PUB_PID=""
+SUB_PID=""
+
+cleanup() {
+    if [ -n "${SUB_PID}" ]; then
+        kill "${SUB_PID}" 2>/dev/null || true
+        wait "${SUB_PID}" 2>/dev/null || true
+    fi
+    if [ -n "${PUB_PID}" ]; then
+        kill "${PUB_PID}" 2>/dev/null || true
+        wait "${PUB_PID}" 2>/dev/null || true
+    fi
+    if [ -n "${RELAY_PID}" ]; then
+        kill "${RELAY_PID}" 2>/dev/null || true
+        wait "${RELAY_PID}" 2>/dev/null || true
+    fi
+    killall moq_demo_relay_v14 2>/dev/null || true
+    killall moq_demo_client 2>/dev/null || true
+}
+trap cleanup EXIT
+
+build_targets
+reset_runtime
+
+echo "[ RUN      ] moq_case_subscribe_namespace_relay.publish_namespace_done"
+
+${LINEBUF_PREFIX[@]} ${RELAY_BIN} -p "${RELAY_PORT}" -V > relay_case.log 2>&1 &
+RELAY_PID=$!
+sleep 1
+
+# Subscriber waits for namespace DONE and then closes (-D).
+run_with_timeout "${CASE_TIMEOUT_SECONDS}" \
+    ${LINEBUF_PREFIX[@]} ${CLIENT_BIN} -a 127.0.0.1 -p "${RELAY_PORT}" -V -r sub -N -D -T "namespace,xquic" -n 1 \
+    > subscriber.log 2>&1 &
+SUB_PID=$!
+
+sleep 2
+
+run_with_timeout "${CASE_TIMEOUT_SECONDS}" \
+    ${LINEBUF_PREFIX[@]} ${CLIENT_BIN} -a 127.0.0.1 -p "${RELAY_PORT}" -V -r pub -N -M -T "namespace,xquic" -n 6 \
+    > publisher.log 2>&1 &
+PUB_PID=$!
+
+sleep 4
+kill "${PUB_PID}" 2>/dev/null || true
+wait "${PUB_PID}" 2>/dev/null || true
+
+wait "${SUB_PID}" || true
+
+if ! kill -0 "${RELAY_PID}" 2>/dev/null; then
+    echo "[     FAIL ] relay crashed during test"
+    exit 1
+fi
+
+err_clog=$(grep "\[error\]" clog 2>/dev/null || true)
+err_slog=$(grep "\[error\]" slog 2>/dev/null || true)
+err_relay=$(grep "\[error\]" relay.log 2>/dev/null || true)
+
+done_lines=$(grep -E "on_publish_namespace_done: namespaces:namespace/xquic" subscriber.log 2>/dev/null || true)
+done_count=$(grep -c -E "on_publish_namespace_done: namespaces:" subscriber.log 2>/dev/null || true)
+
+if [ -n "${done_lines}" ] && [ "${done_count}" -eq 1 ] \
+   && [ -z "${err_clog}" ] && [ -z "${err_slog}" ] && [ -z "${err_relay}" ]; then
+    echo "[       OK ] moq_case_subscribe_namespace_relay.publish_namespace_done (1 ms)"
+    exit 0
+fi
+
+echo "[     FAIL ] moq_case_subscribe_namespace_relay.publish_namespace_done (1 ms)"
+echo "${err_clog}"
+echo "${err_slog}"
+echo "${err_relay}"
+echo "--- subscriber ---"
+grep -E "send subscribe_namespace:|on_publish_namespace:|on_publish_namespace_done:|on_publish:" subscriber.log 2>/dev/null || true
+echo "--- relay ---"
+grep -E "relay on_publish:|relay on_publish_done:|relay history forward publish:" relay_case.log 2>/dev/null || true
+exit 1
+

--- a/scripts/moq_scripts/moq_case_test_subscribe_namespace_relay_history.sh
+++ b/scripts/moq_scripts/moq_case_test_subscribe_namespace_relay_history.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# Case 2 (History replay):
+#   Publisher B publishes first.
+#   Subscriber A joins later and sends SUBSCRIBE_NAMESPACE(prefix).
+#   Relay must immediately forward existing PUBLISH_NAMESPACE/PUBLISH + media frames.
+#
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
+cd "${REPO_ROOT}/build" || exit 1
+
+MOQ_DEMO_DIR="moq/demo"
+RELAY_BIN="${MOQ_DEMO_DIR}/moq_demo_relay_v14"
+CLIENT_BIN="${MOQ_DEMO_DIR}/moq_demo_client"
+
+RELAY_PORT=4435
+CASE_TIMEOUT_SECONDS=40
+LINEBUF_PREFIX=()
+if command -v stdbuf >/dev/null 2>&1; then
+    LINEBUF_PREFIX=(stdbuf -oL -eL)
+fi
+
+run_with_timeout() {
+    local timeout_seconds=$1
+    shift
+    timeout -s INT -k 2 "${timeout_seconds}" "$@"
+}
+
+reset_runtime() {
+    rm -rf tp_localhost test_session xqc_token
+    : > clog
+    : > slog
+    : > relay.log
+}
+
+build_targets() {
+    cmake --build . -j 8 --target xquic-static moq_demo_client moq_demo_relay_v14 >/dev/null
+}
+
+RELAY_PID=""
+PUB_PID=""
+SUB_PID=""
+
+cleanup() {
+    if [ -n "${SUB_PID}" ]; then
+        kill "${SUB_PID}" 2>/dev/null || true
+        wait "${SUB_PID}" 2>/dev/null || true
+    fi
+    if [ -n "${PUB_PID}" ]; then
+        kill "${PUB_PID}" 2>/dev/null || true
+        wait "${PUB_PID}" 2>/dev/null || true
+    fi
+    if [ -n "${RELAY_PID}" ]; then
+        kill "${RELAY_PID}" 2>/dev/null || true
+        wait "${RELAY_PID}" 2>/dev/null || true
+    fi
+    killall moq_demo_relay_v14 2>/dev/null || true
+    killall moq_demo_client 2>/dev/null || true
+}
+trap cleanup EXIT
+
+build_targets
+reset_runtime
+
+echo "[ RUN      ] moq_case_subscribe_namespace_relay.history_replay"
+
+${LINEBUF_PREFIX[@]} ${RELAY_BIN} -p "${RELAY_PORT}" -V > relay_case.log 2>&1 &
+RELAY_PID=$!
+sleep 1
+
+run_with_timeout "${CASE_TIMEOUT_SECONDS}" \
+    ${LINEBUF_PREFIX[@]} ${CLIENT_BIN} -a 127.0.0.1 -p "${RELAY_PORT}" -V -r pub -N -M -T "namespace,xquic" -n 6 \
+    > publisher.log 2>&1 &
+PUB_PID=$!
+
+sleep 2
+
+run_with_timeout "${CASE_TIMEOUT_SECONDS}" \
+    ${LINEBUF_PREFIX[@]} ${CLIENT_BIN} -a 127.0.0.1 -p "${RELAY_PORT}" -V -r sub -N -W -T "namespace,xquic" -n 1 \
+    > subscriber.log 2>&1 &
+SUB_PID=$!
+
+wait "${SUB_PID}" || true
+kill "${PUB_PID}" 2>/dev/null || true
+wait "${PUB_PID}" 2>/dev/null || true
+
+if ! kill -0 "${RELAY_PID}" 2>/dev/null; then
+    echo "[     FAIL ] relay crashed during test"
+    exit 1
+fi
+
+err_clog=$(grep "\[error\]" clog 2>/dev/null || true)
+err_slog=$(grep "\[error\]" slog 2>/dev/null || true)
+err_relay=$(grep "\[error\]" relay.log 2>/dev/null || true)
+
+sub_send=$(grep -E "send subscribe_namespace:" subscriber.log 2>/dev/null || true)
+sub_publish=$(grep -E "on_publish:.*(video|audio)" subscriber.log 2>/dev/null || true)
+sub_video=$(grep -E "^subscribe_id:.*video_len:" subscriber.log 2>/dev/null || true)
+sub_audio=$(grep -E "on_audio_frame:" subscriber.log 2>/dev/null || true)
+relay_history=$(grep -E "relay history forward publish:" relay_case.log 2>/dev/null || true)
+
+if [ -n "${sub_send}" ] && [ -n "${sub_publish}" ] && [ -n "${sub_video}" ] && [ -n "${sub_audio}" ] \
+   && [ -n "${relay_history}" ] \
+   && [ -z "${err_clog}" ] && [ -z "${err_slog}" ] && [ -z "${err_relay}" ]; then
+    echo "[       OK ] moq_case_subscribe_namespace_relay.history_replay (1 ms)"
+    exit 0
+fi
+
+echo "[     FAIL ] moq_case_subscribe_namespace_relay.history_replay (1 ms)"
+echo "${err_clog}"
+echo "${err_slog}"
+echo "${err_relay}"
+echo "--- subscriber ---"
+grep -E "send subscribe_namespace:|on_publish:|subscribe_id:.*video_len:|on_audio_frame:" subscriber.log 2>/dev/null || true
+echo "--- relay ---"
+grep -E "relay on_publish:|relay history forward publish:" relay_case.log 2>/dev/null || true
+exit 1
+

--- a/scripts/moq_scripts/moq_case_test_subscribe_namespace_relay_prefix.sh
+++ b/scripts/moq_scripts/moq_case_test_subscribe_namespace_relay_prefix.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+#
+# Case 5 (Prefix discrimination, multi-segment tuples):
+#   Subscribers:
+#     A1 subscribes prefix ["namespace"]
+#     A2 subscribes prefix ["namespace","xquic"]
+#   Publishers:
+#     B publishes namespace ["namespace","xquic"]
+#     C publishes namespace ["namespace","other"]
+#
+# Expected:
+#   - A1 receives both namespaces
+#   - A2 receives only ["namespace","xquic"]
+#
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
+cd "${REPO_ROOT}/build" || exit 1
+
+MOQ_DEMO_DIR="moq/demo"
+RELAY_BIN="${MOQ_DEMO_DIR}/moq_demo_relay_v14"
+CLIENT_BIN="${MOQ_DEMO_DIR}/moq_demo_client"
+
+RELAY_PORT=4436
+CASE_TIMEOUT_SECONDS=25
+LINEBUF_PREFIX=()
+if command -v stdbuf >/dev/null 2>&1; then
+    LINEBUF_PREFIX=(stdbuf -oL -eL)
+fi
+
+run_with_timeout() {
+    local timeout_seconds=$1
+    shift
+    timeout -s INT -k 2 "${timeout_seconds}" "$@"
+}
+
+reset_runtime() {
+    rm -rf tp_localhost test_session xqc_token
+    : > clog
+    : > slog
+    : > relay.log
+}
+
+build_targets() {
+    cmake --build . -j 8 --target xquic-static moq_demo_client moq_demo_relay_v14 >/dev/null
+}
+
+RELAY_PID=""
+SUB1_PID=""
+SUB2_PID=""
+PUB_B_PID=""
+PUB_C_PID=""
+
+cleanup() {
+    for pid in "${SUB1_PID}" "${SUB2_PID}" "${PUB_B_PID}" "${PUB_C_PID}" "${RELAY_PID}"; do
+        if [ -n "${pid}" ]; then
+            kill "${pid}" 2>/dev/null || true
+            wait "${pid}" 2>/dev/null || true
+        fi
+    done
+    killall moq_demo_relay_v14 2>/dev/null || true
+    killall moq_demo_client 2>/dev/null || true
+}
+trap cleanup EXIT
+
+build_targets
+reset_runtime
+
+echo "[ RUN      ] moq_case_subscribe_namespace_relay.prefix_discrimination"
+
+${LINEBUF_PREFIX[@]} ${RELAY_BIN} -p "${RELAY_PORT}" -V > relay_case.log 2>&1 &
+RELAY_PID=$!
+sleep 1
+
+# Keep subscribers alive; the script will terminate them via timeout.
+run_with_timeout "${CASE_TIMEOUT_SECONDS}" \
+    ${LINEBUF_PREFIX[@]} ${CLIENT_BIN} -a 127.0.0.1 -p "${RELAY_PORT}" -V -r sub -N -E 4 -T "namespace" -n 1 \
+    > subscriber_a1.log 2>&1 &
+SUB1_PID=$!
+
+run_with_timeout "${CASE_TIMEOUT_SECONDS}" \
+    ${LINEBUF_PREFIX[@]} ${CLIENT_BIN} -a 127.0.0.1 -p "${RELAY_PORT}" -V -r sub -N -E 2 -T "namespace,xquic" -n 1 \
+    > subscriber_a2.log 2>&1 &
+SUB2_PID=$!
+
+sleep 2
+
+run_with_timeout "${CASE_TIMEOUT_SECONDS}" \
+    ${LINEBUF_PREFIX[@]} ${CLIENT_BIN} -a 127.0.0.1 -p "${RELAY_PORT}" -V -r pub -N -M -T "namespace,xquic" -n 6 \
+    > publisher_b.log 2>&1 &
+PUB_B_PID=$!
+
+run_with_timeout "${CASE_TIMEOUT_SECONDS}" \
+    ${LINEBUF_PREFIX[@]} ${CLIENT_BIN} -a 127.0.0.1 -p "${RELAY_PORT}" -V -r pub -N -M -T "namespace,other" -n 6 \
+    > publisher_c.log 2>&1 &
+PUB_C_PID=$!
+
+wait "${SUB1_PID}" || true
+wait "${SUB2_PID}" || true
+wait "${PUB_B_PID}" || true
+wait "${PUB_C_PID}" || true
+
+if ! kill -0 "${RELAY_PID}" 2>/dev/null; then
+    echo "[     FAIL ] relay crashed during test"
+    exit 1
+fi
+
+err_clog=$(grep "\[error\]" clog 2>/dev/null || true)
+err_slog=$(grep "\[error\]" slog 2>/dev/null || true)
+err_relay=$(grep "\[error\]" relay.log 2>/dev/null || true)
+
+a1_xquic=$(grep -E "on_publish:.*track:namespace/xquic/(video|audio)" subscriber_a1.log 2>/dev/null || true)
+a1_other=$(grep -E "on_publish:.*track:namespace/other/(video|audio)" subscriber_a1.log 2>/dev/null || true)
+a2_xquic=$(grep -E "on_publish:.*track:namespace/xquic/(video|audio)" subscriber_a2.log 2>/dev/null || true)
+a2_other=$(grep -E "on_publish:.*track:namespace/other/(video|audio)" subscriber_a2.log 2>/dev/null || true)
+
+if [ -n "${a1_xquic}" ] && [ -n "${a1_other}" ] && [ -n "${a2_xquic}" ] && [ -z "${a2_other}" ] \
+   && [ -z "${err_clog}" ] && [ -z "${err_slog}" ] && [ -z "${err_relay}" ]; then
+    echo "[       OK ] moq_case_subscribe_namespace_relay.prefix_discrimination (1 ms)"
+    exit 0
+fi
+
+echo "[     FAIL ] moq_case_subscribe_namespace_relay.prefix_discrimination (1 ms)"
+echo "${err_clog}"
+echo "${err_slog}"
+echo "${err_relay}"
+echo "--- subscriber_a1 ---"
+grep -E "send subscribe_namespace:|on_publish:" subscriber_a1.log 2>/dev/null || true
+echo "--- subscriber_a2 ---"
+grep -E "send subscribe_namespace:|on_publish:" subscriber_a2.log 2>/dev/null || true
+exit 1

--- a/scripts/moq_scripts/moq_case_test_track_namespace_tuple.sh
+++ b/scripts/moq_scripts/moq_case_test_track_namespace_tuple.sh
@@ -1,0 +1,385 @@
+#!/usr/bin/env bash
+#
+# End-to-end-ish sanity checks for track_namespace_tuple (namespace tuple support).
+# This script follows the style of moq_case_test_v14.sh and runs:
+#  1) catalog_test: verifies JSON namespace array decodes/encodes successfully (multi-segment tuple)
+#  2) subscribe_namespace_forward_test: verifies tuple prefix matching + discovery idempotency + DONE behavior
+#  3) moq_demo_server/client smoke: verifies demo runs without protocol errors (control/data plane basic)
+#  4) moq_demo_server/client subscribe-namespace mode (-N): subscriber sends SUBSCRIBE_NAMESPACE and receives PUBLISH
+#
+# Note: The demo smoke case cannot distinguish ["a","b"] from "a/b" (single tuple element containing '/')
+# from logs alone, so the multi-segment tuple coverage comes from catalog_test + subscribe_namespace_forward_test.
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
+cd "${REPO_ROOT}/build" || exit 1
+
+MOQ_TEST_DIR="moq/tests"
+MOQ_DEMO_DIR="moq/demo"
+
+CATALOG_TEST_BIN="${MOQ_TEST_DIR}/catalog_test"
+SUBSCRIBE_NAMESPACE_FORWARD_TEST_BIN="${MOQ_TEST_DIR}/subscribe_namespace_forward_test"
+CLIENT_BIN="${MOQ_DEMO_DIR}/moq_demo_client"
+SERVER_BIN="${MOQ_DEMO_DIR}/moq_demo_server"
+
+SERVER_PID=""
+CLIENT_STDLOG=""
+SERVER_STDLOG=""
+
+SERVER_BASE_ARGS=("-c" "b" "-p" "4433" "-V" "-M" "-n" "5")
+CLIENT_BASE_ARGS=("-a" "127.0.0.1" "-p" "4433" "-V" "-M" "-n" "5")
+
+# Per-case timeout (seconds). Prevents demo runs from hanging indefinitely.
+CASE_TIMEOUT_SECONDS=30
+LINEBUF_PREFIX=()
+if command -v stdbuf >/dev/null 2>&1; then
+    LINEBUF_PREFIX=(stdbuf -oL -eL)
+fi
+
+TOTAL_CASES=0
+PASSED_CASES=0
+FAILED_CASES=()
+
+case_print_result() {
+    echo "[ RUN      ] moq_case_namespace_tuple.$1"
+    if [ "$2" = "pass" ]; then
+        echo "[       OK ] moq_case_namespace_tuple.$1 (1 ms)"
+    else
+        echo "[     FAIL ] moq_case_namespace_tuple.$1 (1 ms)"
+    fi
+}
+
+record_case_result() {
+    local name=$1
+    local status=$2
+    TOTAL_CASES=$((TOTAL_CASES + 1))
+    if [ "${status}" = "pass" ]; then
+        PASSED_CASES=$((PASSED_CASES + 1))
+    else
+        FAILED_CASES+=("${name}")
+    fi
+}
+
+clear_log() {
+    : > clog
+    : > slog
+}
+
+reset_runtime() {
+    rm -rf tp_localhost test_session xqc_token
+    clear_log
+}
+
+build_targets() {
+    cmake --build . -j 8 --target \
+        xquic-static \
+        subscribe_namespace_forward_test \
+        catalog_test \
+        moq_demo_client \
+        moq_demo_server >/dev/null
+}
+
+run_with_timeout() {
+    local timeout_seconds=$1
+    shift
+
+    if command -v timeout >/dev/null 2>&1; then
+        timeout -s INT -k 2 "${timeout_seconds}" "$@"
+        return $?
+    fi
+
+    if command -v gtimeout >/dev/null 2>&1; then
+        gtimeout -s INT -k 2 "${timeout_seconds}" "$@"
+        return $?
+    fi
+
+    "$@" &
+    local cmd_pid=$!
+    (
+        sleep "${timeout_seconds}"
+        if kill -0 "${cmd_pid}" 2>/dev/null; then
+            kill -INT "${cmd_pid}" 2>/dev/null || true
+            sleep 2
+            if kill -0 "${cmd_pid}" 2>/dev/null; then
+                kill -KILL "${cmd_pid}" 2>/dev/null || true
+            fi
+        fi
+    ) &
+    local killer_pid=$!
+
+    wait "${cmd_pid}"
+    local rc=$?
+    kill "${killer_pid}" 2>/dev/null || true
+    wait "${killer_pid}" 2>/dev/null || true
+    return "${rc}"
+}
+
+start_server() {
+    local case_name=$1
+    shift
+    SERVER_STDLOG="server_${case_name}.log"
+    ${LINEBUF_PREFIX[@]} ${SERVER_BIN} "$@" > "${SERVER_STDLOG}" 2>&1 &
+    SERVER_PID=$!
+    sleep 1
+
+    if ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+        echo "server failed to start (pid:${SERVER_PID})"
+        return 1
+    fi
+    return 0
+}
+
+stop_server() {
+    if [ -n "${SERVER_PID}" ]; then
+        kill "${SERVER_PID}" 2>/dev/null || true
+        wait "${SERVER_PID}" 2>/dev/null || true
+        SERVER_PID=""
+    fi
+    killall moq_demo_server 2>/dev/null || true
+}
+
+run_client() {
+    local case_name=$1
+    shift
+    CLIENT_STDLOG="client_${case_name}.log"
+    run_with_timeout "${CASE_TIMEOUT_SECONDS}" ${LINEBUF_PREFIX[@]} ${CLIENT_BIN} "$@" > "${CLIENT_STDLOG}" 2>&1
+    return $?
+}
+
+get_err_log() {
+    local err_clog err_slog output=""
+    err_clog=$(grep "\[error\]" clog 2>/dev/null || true)
+    err_slog=$(grep "\[error\]" slog 2>/dev/null || true)
+    if [ -n "${err_clog}" ]; then
+        output="${err_clog}"
+    fi
+    if [ -n "${err_slog}" ]; then
+        if [ -n "${output}" ]; then
+            output="${output}"$'\n'"${err_slog}"
+        else
+            output="${err_slog}"
+        fi
+    fi
+    printf "%s" "${output}"
+}
+
+run_catalog_namespace_tuple_case() {
+    local case_name="catalog_namespace_tuple"
+    local status="fail"
+    echo -e "catalog json namespace tuple (array) decode/encode ...\c"
+
+    build_targets
+
+    local output
+    output=$(${CATALOG_TEST_BIN} 2>&1 || true)
+    local decode_ok encode_ok
+    decode_ok=$(echo "${output}" | grep -E "decode error = 0" || true)
+    encode_ok=$(echo "${output}" | grep -E "encode error = 0" || true)
+
+    if [ -n "${decode_ok}" ] && [ -n "${encode_ok}" ]; then
+        echo ">>>>>>>> pass:1"
+        status="pass"
+    else
+        echo ">>>>>>>> pass:0"
+        echo "${output}"
+    fi
+    case_print_result "${case_name}" "${status}"
+    record_case_result "${case_name}" "${status}"
+}
+
+run_subscribe_namespace_forward_case() {
+    local case_name="subscribe_namespace_forward"
+    local status="fail"
+    echo -e "subscribe_namespace forward/idempotency (tuple aware) ...\c"
+
+    build_targets
+
+    local output
+    output=$(${SUBSCRIBE_NAMESPACE_FORWARD_TEST_BIN} 2>&1 || true)
+    local exit_code=$?
+    local errlog
+    errlog=$(echo "${output}" | grep -v "^profiling:" || true)
+
+    if [ "${exit_code}" -eq 0 ]; then
+        echo ">>>>>>>> pass:1"
+        status="pass"
+    else
+        echo ">>>>>>>> pass:0"
+        echo "${errlog}"
+    fi
+    case_print_result "${case_name}" "${status}"
+    record_case_result "${case_name}" "${status}"
+}
+
+run_demo_namespace_tuple_smoke_case() {
+    local case_name="demo_smoke"
+    local status="fail"
+    echo -e "demo client/server smoke ...\c"
+
+    build_targets
+    reset_runtime
+    if ! start_server "${case_name}" "${SERVER_BASE_ARGS[@]}"; then
+        echo ">>>>>>>> pass:0"
+        case_print_result "${case_name}" "${status}"
+        record_case_result "${case_name}" "${status}"
+        stop_server
+        return
+    fi
+    run_client "${case_name}" "${CLIENT_BASE_ARGS[@]}"
+    local client_rc=$?
+    sleep 1
+
+    local errlog cli_publish svr_publish
+    errlog=$(get_err_log)
+    cli_publish=$(grep -E "on_publish:" "${CLIENT_STDLOG}" 2>/dev/null || true)
+    svr_publish=$(grep -E "on_publish:" "${SERVER_STDLOG}" 2>/dev/null || true)
+
+    if [ "${client_rc}" -eq 0 ] && [ -n "${cli_publish}" ] && [ -n "${svr_publish}" ] && [ -z "${errlog}" ]; then
+        echo ">>>>>>>> pass:1"
+        status="pass"
+    else
+        echo ">>>>>>>> pass:0"
+        echo "client_rc:${client_rc}"
+        echo "${errlog}"
+        echo "${cli_publish}"
+        echo "${svr_publish}"
+    fi
+    case_print_result "${case_name}" "${status}"
+    record_case_result "${case_name}" "${status}"
+    stop_server
+}
+
+run_demo_subscribe_namespace_mode_case() {
+    local case_name="demo_subscribe_namespace_mode"
+    local status="fail"
+    echo -e "demo subscribe_namespace mode (-N) ...\c"
+
+    build_targets
+    reset_runtime
+
+    # Publisher-only server: creates local tracks; should forward PUBLISH when it receives SUBSCRIBE_NAMESPACE.
+    if ! start_server "${case_name}" -c b -p 4433 -V -r pub -N -n 1; then
+        echo ">>>>>>>> pass:0"
+        case_print_result "${case_name}" "${status}"
+        record_case_result "${case_name}" "${status}"
+        stop_server
+        return
+    fi
+
+    # Subscriber-only client: sends SUBSCRIBE_NAMESPACE; should receive PUBLISH for video/audio.
+    run_client "${case_name}" -a 127.0.0.1 -p 4433 -V -r sub -N -M -n 1
+    local client_rc=$?
+    sleep 1
+
+    local errlog cli_sub_ns cli_on_publish svr_publish_ok
+    errlog=$(get_err_log)
+    cli_sub_ns=$(grep -E "send subscribe_namespace:" "${CLIENT_STDLOG}" 2>/dev/null || true)
+    cli_on_publish=$(grep -E "on_publish:.*(video|audio)" "${CLIENT_STDLOG}" 2>/dev/null || true)
+    svr_publish_ok=$(grep -E "on_publish_ok:" "${SERVER_STDLOG}" 2>/dev/null || true)
+
+    if { [ "${client_rc}" -eq 0 ] || [ "${client_rc}" -eq 124 ]; } \
+       && [ -n "${cli_sub_ns}" ] && [ -n "${cli_on_publish}" ] && [ -n "${svr_publish_ok}" ] && [ -z "${errlog}" ]; then
+        echo ">>>>>>>> pass:1"
+        status="pass"
+    else
+        echo ">>>>>>>> pass:0"
+        echo "client_rc:${client_rc}"
+        echo "${errlog}"
+        echo "${cli_sub_ns}"
+        echo "${cli_on_publish}"
+        echo "${svr_publish_ok}"
+    fi
+
+    case_print_result "${case_name}" "${status}"
+    record_case_result "${case_name}" "${status}"
+    stop_server
+}
+
+run_demo_subscribe_namespace_broadcast_case() {
+    local case_name="demo_subscribe_namespace_broadcast"
+    local status="fail"
+    echo -e "demo subscribe_namespace broadcast (2 clients, -N) ...\c"
+
+    build_targets
+    reset_runtime
+
+    if ! start_server "${case_name}" -c b -p 4433 -V -r pub -N -n 1; then
+        echo ">>>>>>>> pass:0"
+        case_print_result "${case_name}" "${status}"
+        record_case_result "${case_name}" "${status}"
+        stop_server
+        return
+    fi
+
+    local client_count=2
+    local client_pids=()
+    local client_logs=()
+
+    for ((i=1; i<=client_count; i++)); do
+        local client_log="client_${case_name}_${i}.log"
+        client_logs+=("${client_log}")
+        run_with_timeout "${CASE_TIMEOUT_SECONDS}" \
+            ${LINEBUF_PREFIX[@]} ${CLIENT_BIN} -a 127.0.0.1 -p 4433 -V -r sub -N -M -n 1 \
+            > "${client_log}" 2>&1 &
+        client_pids+=("$!")
+    done
+
+    local client_failed=0
+    for i in "${!client_pids[@]}"; do
+        local pid="${client_pids[$i]}"
+        local log_file="${client_logs[$i]}"
+        local rc=0
+        wait "${pid}" || rc=$?
+        if [ "${rc}" -ne 0 ]; then
+            client_failed=1
+        fi
+    done
+
+    sleep 1
+
+    local errlog
+    errlog=$(get_err_log)
+
+    local all_clients_ok=1
+    for log_file in "${client_logs[@]}"; do
+        local has_sub_ns has_video has_audio
+        has_sub_ns=$(grep -E "send subscribe_namespace:" "${log_file}" 2>/dev/null || true)
+        has_video=$(grep -E "on_publish:.*video" "${log_file}" 2>/dev/null || true)
+        has_audio=$(grep -E "on_publish:.*audio" "${log_file}" 2>/dev/null || true)
+        if [ -z "${has_sub_ns}" ] || [ -z "${has_video}" ] || [ -z "${has_audio}" ]; then
+            all_clients_ok=0
+        fi
+    done
+
+    if [ "${client_failed}" -eq 0 ] && [ "${all_clients_ok}" -eq 1 ] && [ -z "${errlog}" ]; then
+        echo ">>>>>>>> pass:1"
+        status="pass"
+    else
+        echo ">>>>>>>> pass:0"
+        echo "client_failed:${client_failed}"
+        echo "${errlog}"
+        for log_file in "${client_logs[@]}"; do
+            echo "--- ${log_file} ---"
+            grep -E "send subscribe_namespace:|on_publish:" "${log_file}" 2>/dev/null || true
+        done
+    fi
+
+    case_print_result "${case_name}" "${status}"
+    record_case_result "${case_name}" "${status}"
+    stop_server
+}
+
+run_catalog_namespace_tuple_case
+run_subscribe_namespace_forward_case
+run_demo_namespace_tuple_smoke_case
+run_demo_subscribe_namespace_mode_case
+run_demo_subscribe_namespace_broadcast_case
+
+echo
+echo "moq_case_namespace_tuple summary: ${PASSED_CASES}/${TOTAL_CASES} passed"
+if [ "${PASSED_CASES}" -ne "${TOTAL_CASES}" ]; then
+    echo "failed cases: ${FAILED_CASES[*]}"
+    exit 1
+fi
+
+exit 0

--- a/src/tls/xqc_tls.c
+++ b/src/tls/xqc_tls.c
@@ -1094,8 +1094,8 @@ xqc_ssl_cert_cb(SSL *ssl, void *arg)
 
     hostname = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
     if (NULL == hostname) {
-        xqc_log(tls->log, XQC_LOG_ERROR, "|hostname is NULL");
-        return XQC_SSL_FAIL;
+        xqc_log(tls->log, XQC_LOG_INFO, "|hostname is NULL, using default cert");
+        return XQC_SSL_SUCCESS;
     }
 
     /* callback to upper layer to get SSL_CTX */


### PR DESCRIPTION
**This PR is still WIP and we need more tests. Wish you can try this version and offer more advice for xquic-moq. Enjoy!**

We also enhanced testing scripts in this PR.

Change details are shown following:

- Updated xqc_moq_track_t structure to include fields for active stream reference count, destroy pending state, and discovery removal notification.
- Introduced functions for incrementing and decrementing stream references.
- Added new function to get the full name of a track for logging purposes.
- Modified catalog_test to handle multi-segment namespace tuples in JSON format.
- Refactored catalog initialization in tests to use stack allocation instead of heap allocation.
- Created multiple test scripts for end-to-end testing of SUBSCRIBE_NAMESPACE relay functionality, including:
  - Testing relay forwarding of control and media data.
  - Verifying PUBLISH_NAMESPACE_DONE behavior upon publisher disconnection.
  - Ensuring history replay works correctly when subscribers join after publishers.
  - Implementing prefix discrimination for subscribers with different namespace subscriptions.
  - Conducting smoke tests for demo server and client interactions.
- Enhanced error logging and output for better debugging in test cases.