### PR TITLE
[+] Fix:  Support more specific idletimeout calculation

### DIFF
--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -943,6 +943,9 @@ xqc_conn_create(xqc_engine_t *engine, xqc_cid_t *dcid, xqc_cid_t *scid,
         goto fail;
     }
 
+    // Initial here as idle_timeout dependency
+    xqc_init_list_head(&xc->conn_paths_list);
+
     xqc_conn_init_timer_manager(xc);
 
     if (xc->conn_settings.datagram_redundant_probe) {
@@ -5818,17 +5821,6 @@ xqc_conn_get_local_transport_params(xqc_connection_t *conn, xqc_transport_params
                      conn->original_dcid.cid_buf, conn->original_dcid.cid_len);
         params->original_dest_connection_id_present = 1;
 
-        xqc_gen_reset_token(&conn->original_dcid, 
-                            params->stateless_reset_token,
-                            XQC_STATELESS_RESET_TOKENLEN, 
-                            conn->engine->config->reset_token_key, 
-                            conn->engine->config->reset_token_keylen);
-        params->stateless_reset_token_present = 1;
-
-        xqc_log(conn->log, XQC_LOG_INFO, "|generate sr_token[%s] for cid[%s]",
-                xqc_sr_token_str(conn->engine, params->stateless_reset_token),
-                xqc_scid_str(conn->engine, &conn->original_dcid));
-
     } else {
         params->original_dest_connection_id_present = 0;
     }
@@ -5836,6 +5828,22 @@ xqc_conn_get_local_transport_params(xqc_connection_t *conn, xqc_transport_params
     xqc_cid_set(&params->initial_source_connection_id,
                  conn->initial_scid.cid_buf, conn->initial_scid.cid_len);
     params->initial_source_connection_id_present = 1;
+
+    /* RFC 9000: server's stateless_reset_token is associated with its CID */
+    if (conn->conn_type == XQC_CONN_TYPE_SERVER
+        && conn->initial_scid.cid_len > 0)
+    {
+        xqc_gen_reset_token(&conn->initial_scid,
+                            params->stateless_reset_token,
+                            XQC_STATELESS_RESET_TOKENLEN,
+                            conn->engine->config->reset_token_key,
+                            conn->engine->config->reset_token_keylen);
+        params->stateless_reset_token_present = 1;
+
+        xqc_log(conn->log, XQC_LOG_INFO, "|generate sr_token[%s] for cid[%s]|",
+                xqc_sr_token_str(conn->engine, params->stateless_reset_token),
+                xqc_scid_str(conn->engine, &conn->initial_scid));
+    }
 
     if (conn->conn_type == XQC_CONN_TYPE_SERVER 
         && conn->conn_flag & XQC_CONN_FLAG_RETRY_SENT 
@@ -6393,8 +6401,19 @@ xqc_conn_get_idle_timeout(xqc_connection_t *conn)
             ? XQC_CONN_INITIAL_IDLE_TIMEOUT : conn->conn_settings.init_idle_time_out;
 
     } else {
-        return conn->local_settings.max_idle_timeout == 0
+        xqc_msec_t local = conn->local_settings.max_idle_timeout == 0
             ? XQC_CONN_DEFAULT_IDLE_TIMEOUT : conn->local_settings.max_idle_timeout;
+
+        xqc_msec_t remote_idle_timeout = (xqc_msec_t)conn->remote_settings.max_idle_timeout;
+        xqc_msec_t idle_timeout = (remote_idle_timeout > 0) ? xqc_min(local, remote_idle_timeout) : local;
+
+        xqc_usec_t pto = xqc_conn_get_max_pto(conn);
+        if (pto > 0) {
+            xqc_msec_t min_idle_timeout = (xqc_msec_t)((3 * pto + 999) / 1000);
+            idle_timeout = xqc_max(idle_timeout, min_idle_timeout);
+        }
+
+        return idle_timeout;
     }
 }
 

--- a/src/transport/xqc_conn.h
+++ b/src/transport/xqc_conn.h
@@ -369,6 +369,7 @@ struct xqc_connection_s {
     xqc_usec_t                      conn_close_recv_time;
     xqc_usec_t                      conn_close_send_time;
     xqc_usec_t                      conn_last_send_time;
+    xqc_usec_t                      conn_last_ack_eliciting_send_time;
     xqc_usec_t                      conn_last_recv_time;
     xqc_usec_t                      conn_hsk_recv_time;
 

--- a/src/transport/xqc_packet_parser.c
+++ b/src/transport/xqc_packet_parser.c
@@ -1482,7 +1482,7 @@ xqc_int_t
 xqc_packet_parse_stateless_reset(const unsigned char *buf, size_t buf_size,
     const uint8_t **sr_token)
 {
-    if (buf_size <= XQC_STATELESS_RESET_PKT_MIN_LEN) {
+    if (buf_size < XQC_STATELESS_RESET_PKT_MIN_LEN) {
         return -XQC_EILLPKT;
     }
 

--- a/src/transport/xqc_send_ctl.c
+++ b/src/transport/xqc_send_ctl.c
@@ -666,6 +666,17 @@ xqc_send_ctl_on_packet_sent(xqc_send_ctl_t *send_ctl, xqc_pn_ctl_t *pn_ctl, xqc_
     if (XQC_CAN_IN_FLIGHT(packet_out->po_frame_types)) {
 
         if (XQC_IS_ACK_ELICITING(packet_out->po_frame_types)) {
+            xqc_connection_t *conn = send_ctl->ctl_conn;
+
+            if (conn->conn_last_ack_eliciting_send_time <= conn->conn_last_recv_time) {
+                xqc_msec_t idle_timeout = xqc_conn_get_idle_timeout(conn);
+                if (idle_timeout > 0) {
+                    xqc_timer_set(&conn->conn_timer_manager, XQC_TIMER_CONN_IDLE,
+                                  now, idle_timeout * 1000);
+                }
+            }
+            conn->conn_last_ack_eliciting_send_time = now;
+
             send_ctl->ctl_time_of_last_sent_ack_eliciting_packet[pns] =
             packet_out->po_sent_time;
             send_ctl->ctl_last_sent_ack_eliciting_packet_number[pns] =


### PR DESCRIPTION
As RFC 9000 wrote [here](https://www.rfc-editor.org/rfc/rfc9000.html#name-idle-timeout) :

> Each endpoint advertises a max_idle_timeout, but the effective value at an endpoint is computed as the minimum of the two advertised values (or the sole advertised value, if only one endpoint advertises a non-zero value). By announcing a max_idle_timeout, an endpoint commits to initiating an immediate close ([Section 10.2](https://www.rfc-editor.org/rfc/rfc9000.html#immediate-close)) if it abandons the connection prior to the effective value.
> 
> ....
>
> The closing and draining connection states exist to ensure that connections close cleanly and that delayed or reordered packets are properly discarded. These states SHOULD persist for at least three times the current PTO interval as defined in [[QUIC-RECOVERY](https://www.rfc-editor.org/rfc/rfc9000.html#QUIC-RECOVERY)].
