### PR TITLE
Update packet type for new_packet in FEC scheme

### DIFF
--- a/src/transport/xqc_fec_scheme.c
+++ b/src/transport/xqc_fec_scheme.c
@@ -84,6 +84,9 @@ xqc_process_recovered_packet(xqc_connection_t *conn, unsigned char *recovered_pa
     new_packet->pi_path_id = 0;
     new_packet->pi_flag |= XQC_PIF_FEC_RECOVERED;
     new_packet->pi_fec_process_time = rpr_recv_time;
+    // Without setting pkt_type, the zero-initialized value equals XQC_PTYPE_INIT;
+    // Set it to XQC_PTYPE_SHORT_HEADER for 1-rtt data.
+    new_packet->pi_pkt.pkt_type = XQC_PTYPE_SHORT_HEADER;
 
     ret = xqc_process_frames(conn, new_packet);
     xqc_free(new_packet);


### PR DESCRIPTION
Set packet type to XQC_PTYPE_SHORT_HEADER for 1-rtt data. I believe this patch can fix the failure tests in following log:

```log
check fec recovery function of stream using XOR ...>>>>>>>> pass:0
check fec recovery function of stream using RSC ...>>>>>>>> pass:0
check fec recovery function of stream using PM ...>>>>>>>> pass:0
check fec recovery when send repair packets ahead ...>>>>>>>> pass:0
```
log from https://github.com/alibaba/xquic/actions/runs/23532512561/job/68499532016


The recovered packets will be dropped due to this commit<https://github.com/alibaba/xquic/commit/4764604a0e487eeb49338b4498aecda2194eae84>