### PR TITLE
fix: collapsed BBR throughput due to 'next_round_delivered' overflow

### DIFF
--- a/src/congestion_control/xqc_bbr.c
+++ b/src/congestion_control/xqc_bbr.c
@@ -797,7 +797,7 @@ xqc_bbr_modulate_cwnd_for_recovery(xqc_bbr_t *bbr, xqc_sample_t *sampler)
             "|before ModulateCwndForRecovery|cwnd:%ud"
             "|packet_lost:%ud|acked:%ud|po_sent_time:%ui"
             "|recovery:%ud|recovery_start:%ui|packet_conservation:%ud|"
-            "next_round_delivered:%ud|",
+            "next_round_delivered:%ui|",
             bbr->congestion_window, sampler->loss, sampler->acked, 
             sampler->po_sent_time, bbr->recovery_mode, bbr->recovery_start_time,
             bbr->packet_conservation, bbr->next_round_delivered);
@@ -848,7 +848,7 @@ xqc_bbr_modulate_cwnd_for_recovery(xqc_bbr_t *bbr, xqc_sample_t *sampler)
             "|after ModulateCwndForRecovery|cwnd:%ud"
             "|packet_lost:%ud|acked:%ud|po_sent_time:%ui"
             "|recovery:%ud|recovery_start:%ui|packet_conservation:%ud|"
-            "next_round_delivered:%ud|",
+            "next_round_delivered:%ui|",
             bbr->congestion_window, sampler->loss, sampler->acked, 
             sampler->po_sent_time, bbr->recovery_mode, bbr->recovery_start_time,
             bbr->packet_conservation, bbr->next_round_delivered);

--- a/src/congestion_control/xqc_bbr.h
+++ b/src/congestion_control/xqc_bbr.h
@@ -53,7 +53,7 @@ typedef struct xqc_bbr_s {
     /* Start of an measurement? */
     bool                   round_start;
     /* packet delivered value denoting the end of a packet-timed round trip */
-    uint32_t               next_round_delivered;
+    uint64_t               next_round_delivered;
     uint64_t               aggregation_epoch_start_time;
     /* Number of bytes acked during the aggregation time */
     uint32_t               aggregation_epoch_bytes;

--- a/src/congestion_control/xqc_bbr2.h
+++ b/src/congestion_control/xqc_bbr2.h
@@ -72,7 +72,7 @@ typedef struct xqc_bbr2_s {
     /* Start of an measurement? */
     bool                round_start;
     /* packet delivered value denoting the end of a packet-timed round trip */
-    uint32_t            next_round_delivered;
+    uint64_t            next_round_delivered;
     uint64_t            aggregation_epoch_start_time;
     /* Number of bytes acked during the aggregation time */
     uint32_t            aggregation_epoch_bytes;


### PR DESCRIPTION
QUIC stream throughput collapse to ~20 Mbps after ~4.3 GB data delivered and never recover.  Here is the log from xquic_goodput (a xquic test tool):

```log
[11:10:51.384] [I] [115] === XQUIC Goodput Test ===
[11:10:51.385] [I] [115]   mode: client, addr: 10.0.0.2, port: 8443, body_size: 10000 bytes, count: 0, loop: libevent, transport: udp, data_mode: stream, multipath: off, paths: 2
[11:10:51.385] [I] [115] UdpSender: fd 7, local address assigned as 0.0.0.0:42539
[11:10:51.385] [I] [115] XquicClient: connecting to 10.0.0.2:8443 over udp [stream], sending 10000 bytes x 0, multipath=off(paths=2)
[ ID] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams
[ 5]  0.00-1.00 sec   111.02 MBytes  888.18 Mbits/sec  0.000 ms   0/0 (0%)

....

[ 5]  40.00-41.00 sec   103.38 MBytes  827.04 Mbits/sec  0.000 ms   0/0 (0%)
[ 5]  41.00-42.00 sec   90.76 MBytes  726.12 Mbits/sec  0.000 ms   0/0 (0%)
[ 5]  42.00-43.00 sec   80.81 MBytes  646.46 Mbits/sec  0.000 ms   0/0 (0%)
[ 5]  43.00-44.00 sec   101.82 MBytes  814.59 Mbits/sec  0.000 ms   0/0 (0%)
[ 5]  44.00-45.00 sec   84.70 MBytes  677.59 Mbits/sec  0.000 ms   0/0 (0%)
[ 5]  45.00-46.00 sec   22.81 MBytes  182.49 Mbits/sec  0.000 ms   0/0 (0%)
[ 5]  46.00-47.00 sec   3.72 MBytes  29.74 Mbits/sec  0.000 ms   0/0 (0%)
[ 5]  47.00-48.00 sec   2.96 MBytes  23.66 Mbits/sec  0.000 ms   0/0 (0%)
[ 5]  48.00-49.00 sec   1.92 MBytes  15.33 Mbits/sec  0.000 ms   0/0 (0%)
[ 5]  49.00-50.00 sec   3.05 MBytes  24.44 Mbits/sec  0.000 ms   0/0 (0%)
[ 5]  50.00-51.00 sec   2.41 MBytes  19.24 Mbits/sec  0.000 ms   0/0 (0%)

....

[ 5]  222.00-223.00 sec   1.87 MBytes  14.96 Mbits/sec  0.000 ms   0/0 (0%)
[ 5]  223.00-224.00 sec   2.43 MBytes  19.45 Mbits/sec  0.000 ms   0/0 (0%)
```

## **Root cause**: BBR next_round_delivered overflow
   bbr->next_round_delivered was uint32_t but stores cumulative byte counts from uint64_t counters. After ~4.3 GB delivered, the truncated value is always ≤ sampler->prior_delivered (uint64_t), so round_start = TRUE fires on every ACK instead of once per RTT. This causes the bandwidth window filter (10 rounds) to expire in ~10 ACKs, rapidly collapsing the BW estimate via positive feedback.
   
## **Validation**

220-second goodput test on the path(40ms RTT, 1 Gbps) with xquic_goodput: average throughput ~700 Mbps after ramp-up, no interval below 357 Mbps. 
