### PR TITLE
fix(fec): free repair_key and recv_mask in fec_recv_rpr_syb_list cleanup

### DIFF
--- a/src/transport/xqc_fec.c
+++ b/src/transport/xqc_fec.c
@@ -661,6 +661,8 @@ xqc_fec_ctl_destroy(xqc_fec_ctl_t *fec_ctl)
     xqc_list_for_each_safe(pos, next, &fec_ctl->fec_recv_rpr_syb_list) {
         xqc_fec_rpr_syb_t *symbol = xqc_list_entry(pos, xqc_fec_rpr_syb_t, fec_list);
         xqc_free(symbol->payload);
+        xqc_free(symbol->repair_key);
+        xqc_free(symbol->recv_mask);
         xqc_free(symbol);
     }
 


### PR DESCRIPTION

`xqc_create_rpr_symbol` calls `xqc_calloc` 4 times (struct + payload + repair_key + recv_mask), 
https://github.com/alibaba/xquic/blob/64b8df3ac3f64111eb9e00be1a952ba5b07144bb/src/transport/xqc_fec.c#L1066-L1072
but `xqc_fec_ctl_destroy`'s `fec_recv_rpr_syb_list` cleanup loop frees only payload + struct. `repair_key` and `recv_mask` leak whenever the connection closes with any unflushed repair symbol still in the recv list.

## Trigger
Any FEC-negotiated connection that receives a repair frame and then closes — the symbol typically hasn't moved out of the recv list yet, so it leaks.
Caught by ASan in a downstream consumer.