### PR TITLE
fix issue 596: use compile-time constants for retry integrity tag key/nonce length

### DIFF
--- a/src/tls/xqc_tls.c
+++ b/src/tls/xqc_tls.c
@@ -11,9 +11,9 @@
 #include <openssl/rand.h>
 #include <openssl/hmac.h>
 
-/* RFC 9001 §5.8: use fixed lengths (not strlen) since binary keys may contain '\0' */
-#define XQC_RETRY_INTEGRITY_KEY_LEN     16  /* RFC 9001 §5.8: K = 128 bits */
-#define XQC_RETRY_INTEGRITY_NONCE_LEN   12  /* RFC 9001 §5.8: N = 96 bits  */
+/* RFC 9001 Section 5.8: fixed binary lengths, not strlen(). */
+#define XQC_RETRY_INTEGRITY_KEY_LEN     16  /* K = 128 bits */
+#define XQC_RETRY_INTEGRITY_NONCE_LEN   12  /* N = 96 bits */
 
 
 typedef enum xqc_tls_flag_e {
@@ -801,6 +801,10 @@ xqc_tls_cal_retry_integrity_tag(xqc_log_t *log,
 {
     xqc_int_t ret = XQC_OK;
 
+    if (ver < XQC_IDRAFT_INIT_VER || ver >= XQC_VERSION_MAX) {
+        return -XQC_TLS_INVALID_ARGUMENT;
+    }
+
     xqc_crypto_t *crypto = xqc_crypto_create(XQC_TLS13_AES_128_GCM_SHA256, log);
     if (crypto == NULL) {
         xqc_log(log, XQC_LOG_ERROR, "|create retry crypto error|");
@@ -808,8 +812,10 @@ xqc_tls_cal_retry_integrity_tag(xqc_log_t *log,
     }
 
     ret = xqc_crypto_aead_encrypt(crypto, "", 0,
-                                  xqc_crypto_retry_key[ver],   XQC_RETRY_INTEGRITY_KEY_LEN,
-                                  xqc_crypto_retry_nonce[ver], XQC_RETRY_INTEGRITY_NONCE_LEN,
+                                  xqc_crypto_retry_key[ver],
+                                  XQC_RETRY_INTEGRITY_KEY_LEN,
+                                  xqc_crypto_retry_nonce[ver],
+                                  XQC_RETRY_INTEGRITY_NONCE_LEN,
                                   retry_pseudo_packet, retry_pseudo_packet_len,
                                   dst, dst_cap, dst_len);
     if (ret != XQC_OK) {

--- a/src/tls/xqc_tls.c
+++ b/src/tls/xqc_tls.c
@@ -11,6 +11,10 @@
 #include <openssl/rand.h>
 #include <openssl/hmac.h>
 
+/* RFC 9001 §5.8: use fixed lengths (not strlen) since binary keys may contain '\0' */
+#define XQC_RETRY_INTEGRITY_KEY_LEN     16  /* RFC 9001 §5.8: K = 128 bits */
+#define XQC_RETRY_INTEGRITY_NONCE_LEN   12  /* RFC 9001 §5.8: N = 96 bits  */
+
 
 typedef enum xqc_tls_flag_e {
     /* initial state */
@@ -804,8 +808,8 @@ xqc_tls_cal_retry_integrity_tag(xqc_log_t *log,
     }
 
     ret = xqc_crypto_aead_encrypt(crypto, "", 0,
-                                  xqc_crypto_retry_key[ver], strlen(xqc_crypto_retry_key[ver]),
-                                  xqc_crypto_retry_nonce[ver], strlen(xqc_crypto_retry_nonce[ver]),
+                                  xqc_crypto_retry_key[ver],   XQC_RETRY_INTEGRITY_KEY_LEN,
+                                  xqc_crypto_retry_nonce[ver], XQC_RETRY_INTEGRITY_NONCE_LEN,
                                   retry_pseudo_packet, retry_pseudo_packet_len,
                                   dst, dst_cap, dst_len);
     if (ret != XQC_OK) {

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -98,7 +98,10 @@ main()
         || !CU_add_test(pSuite, "xqc_cid_test", xqc_test_cid)
         || !CU_add_test(pSuite, "xqc_test_id_hash", xqc_test_id_hash)
         || !CU_add_test(pSuite, "xqc_test_retry", xqc_test_retry)
-        || !CU_add_test(pSuite, "xqc_test_retry_integrity_tag_rfc9001", xqc_test_retry_integrity_tag_rfc9001)
+        || !CU_add_test(pSuite, "xqc_test_retry_integrity_tag_rfc9001",
+                        xqc_test_retry_integrity_tag_rfc9001)
+        || !CU_add_test(pSuite, "xqc_test_retry_integrity_tag_binary_lengths",
+                        xqc_test_retry_integrity_tag_binary_lengths)
         || !CU_add_test(pSuite, "xqc_test_receive_invalid_dgram", xqc_test_receive_invalid_dgram)
         || !CU_add_test(pSuite, "xqc_test_h3_ext_frame", xqc_test_h3_ext_frame)
 #ifdef XQC_ENABLE_FEC

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -98,6 +98,7 @@ main()
         || !CU_add_test(pSuite, "xqc_cid_test", xqc_test_cid)
         || !CU_add_test(pSuite, "xqc_test_id_hash", xqc_test_id_hash)
         || !CU_add_test(pSuite, "xqc_test_retry", xqc_test_retry)
+        || !CU_add_test(pSuite, "xqc_test_retry_integrity_tag_rfc9001", xqc_test_retry_integrity_tag_rfc9001)
         || !CU_add_test(pSuite, "xqc_test_receive_invalid_dgram", xqc_test_receive_invalid_dgram)
         || !CU_add_test(pSuite, "xqc_test_h3_ext_frame", xqc_test_h3_ext_frame)
 #ifdef XQC_ENABLE_FEC

--- a/tests/unittest/xqc_retry_test.c
+++ b/tests/unittest/xqc_retry_test.c
@@ -59,16 +59,14 @@ xqc_test_retry()
  * Ground truth: RFC 9001 Appendix A.4 (Retry).
  *   ODCID: 8394c8f03e515708 (8 bytes)
  *   Full Retry packet (with integrity tag):
- *     ff000000010008f067a5502a4262b574 6f6b656e04a265ba2eff4d829058fb3f 0f2496ba
+ *     ff000000010008f067a5502a4262b574 6f6b656e
+ *     04a265ba2eff4d829058fb3f0f2496ba
  *   Expected integrity tag (last 16 bytes):
  *     04a265ba2eff4d829058fb3f0f2496ba
  *
  * Pre-fix (using strlen): V1 key/nonce happen to contain no NUL byte, so the
- * V1 path keeps working by accident. But placeholder versions
- * (XQC_IDRAFT_INIT_VER / XQC_IDRAFT_VER_NEGOTIATION) are all-zero -- strlen
- * returns 0, which causes the AEAD call to use zero-length key/nonce. This
- * test pins V1 down to RFC ground truth so any future revert to strlen will
- * also be caught (because compile-time constants are required by the patch).
+ * V1 path keeps working by accident. This test pins V1 down to RFC ground
+ * truth; the binary-length test catches strlen regressions.
  */
 void
 xqc_test_retry_integrity_tag_rfc9001()
@@ -84,7 +82,7 @@ xqc_test_retry_integrity_tag_rfc9001()
      * Layout: type(1) + version(4) + DCID_len(1)=0 + SCID_len(1)=8 +
      *         SCID(8) + token "token"(5) = 20 bytes pre-tag. */
     uint8_t retry_no_tag[] = {
-        0xff,                                             /* long header, retry */
+        0xff,                                             /* long header */
         0x00, 0x00, 0x00, 0x01,                           /* version = V1 */
         0x00,                                             /* DCID len = 0 */
         0x08,                                             /* SCID len = 8 */
@@ -117,6 +115,49 @@ xqc_test_retry_integrity_tag_rfc9001()
     CU_ASSERT(ret == XQC_OK);
     CU_ASSERT(tag_len == sizeof(expected_tag));
     CU_ASSERT(memcmp(tag, expected_tag, sizeof(expected_tag)) == 0);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
+/*
+ * Regression guard for binary Retry integrity key/nonce lengths.
+ *
+ * The in-range placeholder entry uses all-zero binary key/nonce material. A
+ * strlen-based implementation passes a zero-length nonce to AEAD, while the
+ * fixed-length implementation computes this GMAC with a 16-byte zero key and
+ * 12-byte zero nonce.
+ */
+void
+xqc_test_retry_integrity_tag_binary_lengths()
+{
+    uint8_t pseudo[] = {
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+        0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
+    };
+    uint8_t expected_tag[16] = {
+        0x8a, 0x44, 0xec, 0x70, 0xda, 0x3a, 0x66, 0xff,
+        0x6d, 0x07, 0xc5, 0x7b, 0x3f, 0x60, 0x72, 0x45
+    };
+
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_FATAL(conn != NULL);
+
+    uint8_t tag[16];
+    size_t tag_len = 0;
+    xqc_int_t ret = xqc_tls_cal_retry_integrity_tag(conn->log,
+                                                    pseudo, sizeof(pseudo),
+                                                    tag, sizeof(tag), &tag_len,
+                                                    XQC_IDRAFT_INIT_VER);
+    CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(tag_len == sizeof(expected_tag));
+    CU_ASSERT(memcmp(tag, expected_tag, sizeof(expected_tag)) == 0);
+
+    ret = xqc_tls_cal_retry_integrity_tag(conn->log,
+                                          pseudo, sizeof(pseudo),
+                                          tag, sizeof(tag), &tag_len,
+                                          XQC_VERSION_MAX);
+    CU_ASSERT(ret == -XQC_TLS_INVALID_ARGUMENT);
 
     xqc_engine_destroy(conn->engine);
 }

--- a/tests/unittest/xqc_retry_test.c
+++ b/tests/unittest/xqc_retry_test.c
@@ -8,6 +8,7 @@
 #include "xqc_common_test.h"
 #include "src/transport/xqc_conn.h"
 #include "src/transport/xqc_packet_parser.h"
+#include "src/tls/xqc_tls.h"
 
 
 #define XQC_TEST_RETRY_PACKET \
@@ -45,6 +46,77 @@ xqc_test_retry()
     ret = xqc_packet_parse_long_header(conn, packet_in);
     CU_ASSERT(ret == XQC_OK);
     CU_ASSERT(conn->conn_flag & XQC_CONN_FLAG_RETRY_RECVD);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
+/*
+ * Issue #596 regression: xqc_tls_cal_retry_integrity_tag must use the binary
+ * key/nonce lengths defined by RFC 9001 Section 5.8 (K = 128 bits = 16 bytes,
+ * N = 96 bits = 12 bytes), not strlen() which stops at the first NUL byte.
+ *
+ * Ground truth: RFC 9001 Appendix A.4 (Retry).
+ *   ODCID: 8394c8f03e515708 (8 bytes)
+ *   Full Retry packet (with integrity tag):
+ *     ff000000010008f067a5502a4262b574 6f6b656e04a265ba2eff4d829058fb3f 0f2496ba
+ *   Expected integrity tag (last 16 bytes):
+ *     04a265ba2eff4d829058fb3f0f2496ba
+ *
+ * Pre-fix (using strlen): V1 key/nonce happen to contain no NUL byte, so the
+ * V1 path keeps working by accident. But placeholder versions
+ * (XQC_IDRAFT_INIT_VER / XQC_IDRAFT_VER_NEGOTIATION) are all-zero -- strlen
+ * returns 0, which causes the AEAD call to use zero-length key/nonce. This
+ * test pins V1 down to RFC ground truth so any future revert to strlen will
+ * also be caught (because compile-time constants are required by the patch).
+ */
+void
+xqc_test_retry_integrity_tag_rfc9001()
+{
+    /* RFC 9001 A.4 ODCID: 8394c8f03e515708 */
+    uint8_t odcid[] = {
+        0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08
+    };
+
+    /* RFC 9001 A.4 Retry packet without the trailing 16-byte integrity tag.
+     * Full RFC vector (36 bytes total):
+     *   ff 00000001 00 08 f067a5502a4262b5 746f6b656e [16-byte tag]
+     * Layout: type(1) + version(4) + DCID_len(1)=0 + SCID_len(1)=8 +
+     *         SCID(8) + token "token"(5) = 20 bytes pre-tag. */
+    uint8_t retry_no_tag[] = {
+        0xff,                                             /* long header, retry */
+        0x00, 0x00, 0x00, 0x01,                           /* version = V1 */
+        0x00,                                             /* DCID len = 0 */
+        0x08,                                             /* SCID len = 8 */
+        0xf0, 0x67, 0xa5, 0x50, 0x2a, 0x42, 0x62, 0xb5,   /* SCID */
+        0x74, 0x6f, 0x6b, 0x65, 0x6e                      /* token "token" */
+    };
+
+    /* RFC 9001 A.4 expected integrity tag */
+    uint8_t expected_tag[16] = {
+        0x04, 0xa2, 0x65, 0xba, 0x2e, 0xff, 0x4d, 0x82,
+        0x90, 0x58, 0xfb, 0x3f, 0x0f, 0x24, 0x96, 0xba
+    };
+
+    /* Build retry pseudo-packet = odcid_len + odcid + retry_no_tag */
+    uint8_t pseudo[1 + sizeof(odcid) + sizeof(retry_no_tag)];
+    pseudo[0] = (uint8_t)sizeof(odcid);
+    memcpy(pseudo + 1, odcid, sizeof(odcid));
+    memcpy(pseudo + 1 + sizeof(odcid), retry_no_tag, sizeof(retry_no_tag));
+
+    /* Get a log handle from a throwaway engine */
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_FATAL(conn != NULL);
+
+    uint8_t  tag[16];
+    size_t   tag_len = 0;
+    xqc_int_t ret = xqc_tls_cal_retry_integrity_tag(conn->log,
+                                                    pseudo, sizeof(pseudo),
+                                                    tag, sizeof(tag), &tag_len,
+                                                    XQC_VERSION_V1);
+    CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(tag_len == sizeof(expected_tag));
+    CU_ASSERT(memcmp(tag, expected_tag, sizeof(expected_tag)) == 0);
 
     xqc_engine_destroy(conn->engine);
 }

--- a/tests/unittest/xqc_retry_test.h
+++ b/tests/unittest/xqc_retry_test.h
@@ -6,5 +6,6 @@
 #define XQC_RETRY_TEST_H
 
 void xqc_test_retry();
+void xqc_test_retry_integrity_tag_rfc9001();
 
 #endif

--- a/tests/unittest/xqc_retry_test.h
+++ b/tests/unittest/xqc_retry_test.h
@@ -7,5 +7,6 @@
 
 void xqc_test_retry();
 void xqc_test_retry_integrity_tag_rfc9001();
+void xqc_test_retry_integrity_tag_binary_lengths();
 
 #endif


### PR DESCRIPTION
Use compile-time constants for retry integrity tag key/nonce length instead of hardcoded values.

Closes #596