### PR TITLE
fix issue 577: harden STREAM frame boundary validation

### DIFF
--- a/src/transport/xqc_frame_parser.c
+++ b/src/transport/xqc_frame_parser.c
@@ -289,6 +289,7 @@ xqc_parse_stream_frame(xqc_packet_in_t *packet_in, xqc_connection_t *conn,
 {
     uint64_t offset;
     uint64_t length;
+    uint64_t max_stream_data_offset = (UINT64_C(1) << 62) - 1;
     int      vlen;
 
     const unsigned char *p = packet_in->pos;
@@ -332,8 +333,8 @@ xqc_parse_stream_frame(xqc_packet_in_t *packet_in, xqc_connection_t *conn,
         length = frame->data_length;
     }
 
-    /* RFC 9000 §19.8: offset + length MUST NOT exceed 2^62-1 */
-    if (frame->data_offset + length > ((UINT64_C(1) << 62) - 1)) {
+    /* RFC 9000 19.8: offset + length MUST NOT exceed 2^62 - 1. */
+    if (length > max_stream_data_offset - frame->data_offset) {
         xqc_log(conn->log, XQC_LOG_ERROR,
                 "|stream offset+length exceeds 2^62-1|offset:%ui|length:%ui|",
                 frame->data_offset, length);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -157,7 +157,8 @@ if(HAVE_CUNIT)
         ${CUTEST_DEPEND_LIBS}
     )
 
-    add_test(run_tests run_tests)
+    add_test(NAME run_tests COMMAND run_tests)
+    set_tests_properties(run_tests PROPERTIES
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
     add_dependencies(check run_tests)
 endif()
-

--- a/tests/unittest/xqc_engine_test.c
+++ b/tests/unittest/xqc_engine_test.c
@@ -42,6 +42,9 @@ xqc_test_engine_packet_process()
 
     xqc_engine_t *engine = test_create_engine_server();
     CU_ASSERT(engine != NULL);
+    if (engine == NULL) {
+        return;
+    }
 
     xqc_msec_t recv_time = xqc_monotonic_timestamp();
 
@@ -61,19 +64,9 @@ xqc_test_engine_packet_process()
                               sizeof(XQC_TEST_LONG_HEADER_PACKET_B) - 1);
     CU_ASSERT(rc == XQC_OK);
 
-    xqc_connection_t *conn = xqc_engine_conns_hash_find(engine, &scid, 's');
-    CU_ASSERT(conn != NULL);
-
-    /* set handshake completed */
-    conn->conn_flag |= XQC_CONN_FLAG_HANDSHAKE_COMPLETED;
-
-    recv_time = xqc_monotonic_timestamp();
-    rc = xqc_engine_packet_process(engine, XQC_TEST_SHORT_HEADER_PACKET_A,
-                                   sizeof(XQC_TEST_SHORT_HEADER_PACKET_A) - 1,
-                                   (struct sockaddr *)&local_addr, local_addrlen,
-                                   (struct sockaddr *)&peer_addr, peer_addrlen, recv_time, NULL);
-    //CU_ASSERT(rc == XQC_OK);
-
+    /*
+     * This packet is synthetic and does not complete a TLS handshake.  Do not
+     * force 1-RTT short-header processing without installed packet keys.
+     */
     xqc_engine_destroy(engine);
 }
-

--- a/tests/unittest/xqc_packet_test.c
+++ b/tests/unittest/xqc_packet_test.c
@@ -165,6 +165,9 @@ test_create_engine_buf_server(test_ctx *tctx)
     xqc_conn_settings_t conn_settings;
     xqc_engine_t *engine = xqc_engine_create(XQC_ENGINE_SERVER, NULL, &engine_ssl_config,
                                              &callback, &tcbs, tctx);
+    if (engine == NULL) {
+        return NULL;
+    }
 
     /* transport ALPN */
     xqc_engine_register_alpn(engine, "transport", 9, &transport_cbs, NULL);
@@ -200,6 +203,9 @@ test_create_engine_buf_client(test_ctx *tctx)
     xqc_conn_settings_t conn_settings;
     xqc_engine_t *engine = xqc_engine_create(XQC_ENGINE_CLIENT, NULL, &engine_ssl_config,
                                              &callback, &tcbs, tctx);
+    if (engine == NULL) {
+        return NULL;
+    }
 
     /* transport ALPN */
     xqc_engine_register_alpn(engine, "transport", 9, &transport_cbs, NULL);
@@ -273,10 +279,16 @@ xqc_test_empty_pkt()
 {
     test_ctx         svr_tctx   = {0};
     test_ctx         cli_tctx   = {0};
+    xqc_packet_out_t *po        = NULL;
 
     svr_tctx.engine = test_create_engine_buf_server(&svr_tctx);
     cli_tctx.engine = test_create_engine_buf_client(&cli_tctx);
 
+    CU_ASSERT(svr_tctx.engine != NULL);
+    CU_ASSERT(cli_tctx.engine != NULL);
+    if (svr_tctx.engine == NULL || cli_tctx.engine == NULL) {
+        goto finish;
+    }
 
     xqc_conn_settings_t conn_settings;
     memset(&conn_settings, 0, sizeof(xqc_conn_settings_t));
@@ -285,8 +297,14 @@ xqc_test_empty_pkt()
     memset(&conn_ssl_config, 0, sizeof(conn_ssl_config));
 
     /* create client instance, will trigger create_notiry and write_socket */
-    xqc_connect(cli_tctx.engine, &conn_settings, NULL, 0, "", 0,
-                &conn_ssl_config, NULL, 0, "transport", &cli_tctx);
+    const xqc_cid_t *cid = xqc_connect(cli_tctx.engine, &conn_settings,
+                                       NULL, 0, "", 0, &conn_ssl_config,
+                                       NULL, 0, "transport", &cli_tctx);
+    CU_ASSERT(cid != NULL);
+    CU_ASSERT(cli_tctx.c != NULL);
+    if (cid == NULL || cli_tctx.c == NULL) {
+        goto finish;
+    }
 
     struct sockaddr_in6 peer_addr;
     socklen_t peer_addrlen = sizeof(peer_addr);
@@ -299,10 +317,17 @@ xqc_test_empty_pkt()
                               (struct sockaddr *)&local_addr, local_addrlen,
                               (struct sockaddr *)&peer_addr, peer_addrlen, xqc_now(), &svr_tctx);
 
+    CU_ASSERT(svr_tctx.c != NULL);
+    if (svr_tctx.c == NULL) {
+        goto finish;
+    }
 
     /* generate an Initial pkt with no payload */
-    xqc_packet_out_t   *po = xqc_packet_out_create(2048);
+    po = xqc_packet_out_create(2048);
     CU_ASSERT(po != NULL);
+    if (po == NULL) {
+        goto finish;
+    }
 
     memcpy(po->po_pkt.pkt_scid.cid_buf, cli_tctx.c->scid_set.user_scid.cid_buf,
            cli_tctx.c->scid_set.user_scid.cid_len);
@@ -329,10 +354,22 @@ xqc_test_empty_pkt()
     CU_ASSERT(svr_tctx.c->conn_err == TRA_PROTOCOL_VIOLATION);
 
 
-    xqc_packet_out_destroy(po);
-    xqc_conn_close(cli_tctx.engine, &cli_tctx.cid);
-    xqc_engine_destroy(cli_tctx.engine);
+finish:
+    if (po != NULL) {
+        xqc_packet_out_destroy(po);
+    }
 
-    xqc_conn_close(svr_tctx.engine, &svr_tctx.cid);
-    xqc_engine_destroy(svr_tctx.engine);
+    if (cli_tctx.engine != NULL) {
+        if (cli_tctx.c != NULL) {
+            xqc_conn_close(cli_tctx.engine, &cli_tctx.cid);
+        }
+        xqc_engine_destroy(cli_tctx.engine);
+    }
+
+    if (svr_tctx.engine != NULL) {
+        if (svr_tctx.c != NULL) {
+            xqc_conn_close(svr_tctx.engine, &svr_tctx.cid);
+        }
+        xqc_engine_destroy(svr_tctx.engine);
+    }
 }

--- a/tests/unittest/xqc_process_frame_test.c
+++ b/tests/unittest/xqc_process_frame_test.c
@@ -6,6 +6,7 @@
 #include "xqc_process_frame_test.h"
 #include "xqc_common_test.h"
 #include "src/transport/xqc_frame.h"
+#include "src/transport/xqc_frame_parser.h"
 #include "src/transport/xqc_packet_in.h"
 #include "src/common/utils/vint/xqc_variable_len_int.h"
 #include "src/transport/xqc_conn.h"
@@ -13,6 +14,29 @@
 char XQC_TEST_ILL_FRAME_1[] = {0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 char XQC_TEST_ZERO_LEN_NEW_TOKEN_FRAME[] = {0x07, 0x00};
 char XQC_TEST_STREAM_FRAME[] = {0x0a, 0x00, 0x01, 0x00};
+
+
+static xqc_int_t
+xqc_test_parse_stream_frame_inner(unsigned char *frame_buf,
+    size_t frame_buf_len,
+    xqc_stream_frame_t *frame, xqc_stream_id_t *stream_id,
+    xqc_connection_t **conn)
+{
+    xqc_packet_in_t pi;
+
+    *conn = test_engine_connect();
+    CU_ASSERT(*conn != NULL);
+    if (*conn == NULL) {
+        return XQC_ERROR;
+    }
+
+    memset(&pi, 0, sizeof(pi));
+    memset(frame, 0, sizeof(*frame));
+    pi.pos = frame_buf;
+    pi.last = frame_buf + frame_buf_len;
+
+    return xqc_parse_stream_frame(&pi, *conn, frame, stream_id);
+}
 
 
 void
@@ -115,10 +139,9 @@ xqc_test_large_ack_frame()
 void
 xqc_test_stream_frame_offset_overflow()
 {
-    xqc_connection_t *conn = test_engine_connect();
-    CU_ASSERT(conn != NULL);
-
-    xqc_packet_in_t pi;
+    xqc_connection_t *conn;
+    xqc_stream_frame_t frame;
+    xqc_stream_id_t stream_id;
     int ret;
 
     /*
@@ -129,11 +152,11 @@ xqc_test_stream_frame_offset_overflow()
      * data = 1 byte (0x00)
      *
      * 8-byte varint: high 2 bits = 0xC0, remaining 62 bits = value
-     * (1<<62)-1 = 0x3FFFFFFFFFFFFFFF → encoded: 0xFF FF FF FF FF FF FF FF
-     * (1<<62)-2 = 0x3FFFFFFFFFFFFFFE → encoded: 0xFF FF FF FF FF FF FF FE
+     * (1 << 62) - 1 is encoded as 0xFF FF FF FF FF FF FF FF
+     * (1 << 62) - 2 is encoded as 0xFF FF FF FF FF FF FF FE
      */
 
-    /* Case 1: offset=(1<<62)-1, length=1 → sum exceeds 2^62-1, expect error */
+    /* Case 1: offset=(1 << 62) - 1, length=1 exceeds 2^62 - 1. */
     unsigned char frame_overflow[] = {
         0x0e,                                           /* STREAM + OFF + LEN */
         0x00,                                           /* stream_id = 0 */
@@ -141,14 +164,14 @@ xqc_test_stream_frame_offset_overflow()
         0x01,                                           /* length = 1 */
         0x00                                            /* 1 byte data */
     };
-    memset(&pi, 0, sizeof(pi));
-    pi.pos = (unsigned char *)frame_overflow;
-    pi.last = pi.pos + sizeof(frame_overflow);
-    pi.pi_pkt.pkt_type = XQC_PTYPE_SHORT_HEADER;
-    ret = xqc_process_frames(conn, &pi);
+    ret = xqc_test_parse_stream_frame_inner(frame_overflow,
+                                            sizeof(frame_overflow), &frame,
+                                            &stream_id, &conn);
     CU_ASSERT(ret == -XQC_EILLEGAL_FRAME);
+    CU_ASSERT(conn->conn_err == TRA_FRAME_ENCODING_ERROR);
+    xqc_engine_destroy(conn->engine);
 
-    /* Case 2: offset=(1<<62)-2, length=1 → sum = 2^62-1, exact boundary, expect OK */
+    /* Case 2: offset=(1 << 62) - 2, length=1 reaches the boundary. */
     unsigned char frame_boundary[] = {
         0x0e,
         0x00,
@@ -156,42 +179,63 @@ xqc_test_stream_frame_offset_overflow()
         0x01,                                           /* length = 1 */
         0x00                                            /* 1 byte data */
     };
-    memset(&pi, 0, sizeof(pi));
-    pi.pos = (unsigned char *)frame_boundary;
-    pi.last = pi.pos + sizeof(frame_boundary);
-    pi.pi_pkt.pkt_type = XQC_PTYPE_SHORT_HEADER;
-    ret = xqc_process_frames(conn, &pi);
+    ret = xqc_test_parse_stream_frame_inner(frame_boundary,
+                                            sizeof(frame_boundary), &frame,
+                                            &stream_id, &conn);
     CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(stream_id == 0);
+    CU_ASSERT(frame.data_offset == ((UINT64_C(1) << 62) - 2));
+    CU_ASSERT(frame.data_length == 1);
+    CU_ASSERT(conn->conn_err == 0);
+    xqc_free(frame.data);
+    xqc_engine_destroy(conn->engine);
 
-    /* Case 3: offset=(1<<62)-1, length=0 → sum = 2^62-1, expect OK */
+    /* Case 3: offset=(1 << 62) - 1, length=0 reaches the boundary. */
     unsigned char frame_zero_len[] = {
         0x0e,
         0x00,
-        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, /* offset = (1<<62)-1 */
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
         0x00,                                           /* length = 0 */
     };
-    memset(&pi, 0, sizeof(pi));
-    pi.pos = (unsigned char *)frame_zero_len;
-    pi.last = pi.pos + sizeof(frame_zero_len);
-    pi.pi_pkt.pkt_type = XQC_PTYPE_SHORT_HEADER;
-    ret = xqc_process_frames(conn, &pi);
+    ret = xqc_test_parse_stream_frame_inner(frame_zero_len,
+                                            sizeof(frame_zero_len), &frame,
+                                            &stream_id, &conn);
     CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(stream_id == 0);
+    CU_ASSERT(frame.data_offset == ((UINT64_C(1) << 62) - 1));
+    CU_ASSERT(frame.data_length == 0);
+    CU_ASSERT(conn->conn_err == 0);
+    xqc_engine_destroy(conn->engine);
 
-    /* Case 4: implicit length (no LEN bit), offset=(1<<62)-1, 1 byte trailing data
-     * → implicit length = end - p = 1, sum exceeds 2^62-1, expect error */
-    unsigned char frame_implicit_overflow[] = {
-        0x0c,                                           /* STREAM + OFF, no LEN */
+    /* Case 4: implicit length can also reach the boundary. */
+    unsigned char frame_implicit_boundary[] = {
+        0x0c,                                           /* STREAM + OFF */
         0x00,                                           /* stream_id = 0 */
-        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, /* offset = (1<<62)-1 */
-        0x00                                            /* 1 byte implicit data */
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE,
+        0x00                                            /* 1 byte data */
     };
-    memset(&pi, 0, sizeof(pi));
-    pi.pos = (unsigned char *)frame_implicit_overflow;
-    pi.last = pi.pos + sizeof(frame_implicit_overflow);
-    pi.pi_pkt.pkt_type = XQC_PTYPE_SHORT_HEADER;
-    ret = xqc_process_frames(conn, &pi);
-    CU_ASSERT(ret == -XQC_EILLEGAL_FRAME);
+    ret = xqc_test_parse_stream_frame_inner(frame_implicit_boundary,
+                                            sizeof(frame_implicit_boundary),
+                                            &frame, &stream_id, &conn);
+    CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(stream_id == 0);
+    CU_ASSERT(frame.data_offset == ((UINT64_C(1) << 62) - 2));
+    CU_ASSERT(frame.data_length == 1);
+    CU_ASSERT(conn->conn_err == 0);
+    xqc_free(frame.data);
+    xqc_engine_destroy(conn->engine);
 
+    /* Case 5: implicit length, offset=(1 << 62) - 1, 1 byte data. */
+    unsigned char frame_implicit_overflow[] = {
+        0x0c,                                           /* STREAM + OFF */
+        0x00,                                           /* stream_id = 0 */
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0x00                                            /* 1 byte data */
+    };
+    ret = xqc_test_parse_stream_frame_inner(frame_implicit_overflow,
+                                            sizeof(frame_implicit_overflow),
+                                            &frame, &stream_id, &conn);
+    CU_ASSERT(ret == -XQC_EILLEGAL_FRAME);
+    CU_ASSERT(conn->conn_err == TRA_FRAME_ENCODING_ERROR);
     xqc_engine_destroy(conn->engine);
 }
-


### PR DESCRIPTION
### Summary

Harden the STREAM frame offset/length boundary validation added in #634 for
issue #577 and make the related unit-test harness deterministic on local CTest
runs.

### Changes

- Avoid computing `offset + length` directly in the STREAM parser bound check.
- Cover explicit and implicit STREAM length boundary cases with independent
  connections.
- Assert `TRA_FRAME_ENCODING_ERROR` for overflow cases and clean connection
  state for valid boundary cases.
- Run `run_tests` from the build root under CTest so certificate-relative unit
  tests use the expected `server.key` and `server.crt`.
- Guard packet-engine unit tests against setup failures and avoid processing a
  synthetic short-header packet without negotiated 1-RTT keys.

### Related Issue

Fixes: #577

### Tests

- `cmake --build build-pr634-validation-x86 --target run_tests --parallel 4`
- `ctest --output-on-failure --timeout 30`

### Notes

An AddressSanitizer validation build confirmed the previous
`xqc_test_empty_pkt` and `xqc_test_engine_packet_process` crashes are gone. The
ASan run later reports an existing `xqc_test_encoder` global-buffer-overflow
outside the issue #577 STREAM-frame path.
