### PR TITLE
fix issue 599: use peer-advertised max_ack_delay in PTO estimate

### DIFF
--- a/src/transport/xqc_send_ctl.h
+++ b/src/transport/xqc_send_ctl.h
@@ -175,11 +175,21 @@ typedef struct xqc_send_ctl_s {
 } xqc_send_ctl_t;
 
 
+/*
+ * Per-path connection-level PTO estimate used by callers that do not need
+ * pns granularity (e.g. xqc_conn_get_max_pto). Per RFC 9002 6.2.1, PTO must
+ * be computed using the peer-reported max_ack_delay, hence remote_settings.
+ *
+ * The pns-specific Initial/Handshake rule (max_ack_delay term must be 0
+ * before handshake confirmation) is enforced by
+ * xqc_send_ctl_get_pto_time_and_space; callers needing that granularity
+ * must use it instead. See xqc_send_ctl.c for the canonical formula.
+ */
 static inline xqc_usec_t
 xqc_send_ctl_calc_pto(xqc_send_ctl_t *send_ctl)
 {
     return send_ctl->ctl_srtt + xqc_max(4 * send_ctl->ctl_rttvar, XQC_kGranularity * 1000)
-        + send_ctl->ctl_conn->local_settings.max_ack_delay * 1000;
+        + send_ctl->ctl_conn->remote_settings.max_ack_delay * 1000;
 }
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -113,6 +113,7 @@ if(HAVE_CUNIT)
         ${UNIT_TEST_DIR}/xqc_datagram_test.c
         ${UNIT_TEST_DIR}/xqc_h3_ext_test.c
         ${UNIT_TEST_DIR}/xqc_ack_with_timestamp_test.c
+        ${UNIT_TEST_DIR}/xqc_send_ctl_test.c
     )
 
     if(XQC_ENABLE_FEC)

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -41,6 +41,7 @@
 #include "xqc_fec_scheme_test.h"
 #include "xqc_fec_test.h"
 #include "xqc_ack_with_timestamp_test.h"
+#include "xqc_send_ctl_test.h"
 
 static int xqc_init_suite(void) { return 0; }
 static int xqc_clean_suite(void) { return 0; }
@@ -111,6 +112,10 @@ main()
         || !CU_add_test(pSuite, "xqc_test_fec", xqc_test_fec)
 #endif
         || !CU_add_test(pSuite, "xqc_test_ack_with_timestamp", xqc_test_ack_with_timestamp)
+        || !CU_add_test(pSuite, "xqc_test_pto_uses_remote_max_ack_delay",
+                        xqc_test_pto_uses_remote_max_ack_delay)
+        || !CU_add_test(pSuite, "xqc_test_pto_remote_default_when_unset",
+                        xqc_test_pto_remote_default_when_unset)
         /* ADD TESTS HERE */) 
     {
         CU_cleanup_registry();

--- a/tests/unittest/xqc_send_ctl_test.c
+++ b/tests/unittest/xqc_send_ctl_test.c
@@ -1,0 +1,101 @@
+/**
+ * @copyright Copyright (c) 2022, Alibaba Group Holding Limited
+ */
+
+#include <CUnit/CUnit.h>
+
+#include "xqc_send_ctl_test.h"
+#include "xqc_common_test.h"
+#include "src/transport/xqc_send_ctl.h"
+#include "src/transport/xqc_conn.h"
+#include "src/transport/xqc_multipath.h"
+#include "src/transport/xqc_transport_params.h"
+
+
+/*
+ * Issue #599 regression test.
+ *
+ * RFC 9002 6.2.1 requires PTO to be computed from the peer-reported
+ * max_ack_delay. Pre-fix, xqc_send_ctl_calc_pto used local_settings,
+ * which collapsed to the right value only when both endpoints happened
+ * to advertise the same delay. This test sets local and remote to
+ * distinct values and asserts the formula consumes remote_settings.
+ *
+ * Formula (xqc_send_ctl.h):
+ *   pto = srtt + max(4*rttvar, kGranularity*1000)
+ *       + remote_settings.max_ack_delay * 1000
+ *
+ * We pin srtt and rttvar so the floor term collapses to
+ * XQC_kGranularity * 1000, isolating the max_ack_delay contribution.
+ */
+void
+xqc_test_pto_uses_remote_max_ack_delay(void)
+{
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_FATAL(conn != NULL);
+    CU_ASSERT_FATAL(conn->conn_initial_path != NULL);
+
+    xqc_send_ctl_t *send_ctl = conn->conn_initial_path->path_send_ctl;
+    CU_ASSERT_FATAL(send_ctl != NULL);
+
+    /* Pin RTT terms so floor = XQC_kGranularity * 1000. */
+    send_ctl->ctl_srtt   = 1000; /* 1 ms in usec */
+    send_ctl->ctl_rttvar = 0;    /* 4*rttvar = 0 -> floor wins */
+
+    /* Distinct local vs remote so a wrong source is observable. */
+    conn->local_settings.max_ack_delay  = 25;
+    conn->remote_settings.max_ack_delay = 100;
+
+    xqc_usec_t got = xqc_send_ctl_calc_pto(send_ctl);
+
+    xqc_usec_t expected_remote = 1000
+        + XQC_kGranularity * 1000
+        + conn->remote_settings.max_ack_delay * 1000;
+    xqc_usec_t expected_local_bug = 1000
+        + XQC_kGranularity * 1000
+        + conn->local_settings.max_ack_delay * 1000;
+
+    /* Positive assertion: matches RFC 9002 6.2.1 formula with remote. */
+    CU_ASSERT_EQUAL(got, expected_remote);
+
+    /* Negative control: must NOT equal the buggy local-based formula.
+     * Difference is (remote - local) * 1000 = 75000 usec. */
+    CU_ASSERT_NOT_EQUAL(got, expected_local_bug);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
+/*
+ * Defensive guard: even when the peer has not yet advertised transport
+ * parameters, remote_settings.max_ack_delay is initialized to
+ * XQC_DEFAULT_MAX_ACK_DELAY (25) by xqc_conn_set_default_settings. The
+ * formula must yield a sane positive value with no UB.
+ */
+void
+xqc_test_pto_remote_default_when_unset(void)
+{
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_FATAL(conn != NULL);
+    CU_ASSERT_FATAL(conn->conn_initial_path != NULL);
+
+    xqc_send_ctl_t *send_ctl = conn->conn_initial_path->path_send_ctl;
+    CU_ASSERT_FATAL(send_ctl != NULL);
+
+    /* Do NOT touch remote_settings: keep the default from conn create. */
+    CU_ASSERT_EQUAL(conn->remote_settings.max_ack_delay,
+                    XQC_DEFAULT_MAX_ACK_DELAY);
+
+    send_ctl->ctl_srtt   = 1000;
+    send_ctl->ctl_rttvar = 0;
+
+    xqc_usec_t got = xqc_send_ctl_calc_pto(send_ctl);
+    xqc_usec_t expected = 1000
+        + XQC_kGranularity * 1000
+        + XQC_DEFAULT_MAX_ACK_DELAY * 1000;
+
+    CU_ASSERT_EQUAL(got, expected);
+    CU_ASSERT(got > 0);
+
+    xqc_engine_destroy(conn->engine);
+}

--- a/tests/unittest/xqc_send_ctl_test.h
+++ b/tests/unittest/xqc_send_ctl_test.h
@@ -1,0 +1,16 @@
+/**
+ * @copyright Copyright (c) 2022, Alibaba Group Holding Limited
+ */
+
+#ifndef XQC_SEND_CTL_TEST_H
+#define XQC_SEND_CTL_TEST_H
+
+/*
+ * Regression tests for issue #599 (RFC 9002 6.2.1):
+ * xqc_send_ctl_calc_pto must use peer-reported max_ack_delay
+ * (remote_settings), not local_settings.
+ */
+void xqc_test_pto_uses_remote_max_ack_delay(void);
+void xqc_test_pto_remote_default_when_unset(void);
+
+#endif


### PR DESCRIPTION
Fixes: #599

### What

`xqc_send_ctl_calc_pto` was computing the PTO term with
`local_settings.max_ack_delay`, but per RFC 9002 §6.2.1 the formula
must use the peer-reported value. PTO is the budget *we* wait for
the *peer* to ACK, so the peer's advertised delay is what bounds it.

In stock interop the bug stays hidden because both endpoints often
advertise the 25 ms default, so the formula collapses to the right
answer. With a peer that advertises something different the local
side declares the peer's packets lost too early or too late.

### Fix

```c
return send_ctl->ctl_srtt
     + xqc_max(4 * send_ctl->ctl_rttvar, XQC_kGranularity * 1000)
     + send_ctl->ctl_conn->remote_settings.max_ack_delay * 1000;
```

Three sibling sites in `xqc_send_ctl.c` already use
`remote_settings.max_ack_delay`:

- line 1159 — ACK-delay clamp on RTT sample (§5.3)
- line 1439 — persistent congestion duration (§7.6)
- line 1685 — pns-aware PTO arming (§6.2.1)

The helper at `xqc_send_ctl.h:182` was the lone outlier. The log
line at `xqc_send_ctl.c:1651` already prints
`c->remote_settings.max_ack_delay`, which is good internal
evidence that `remote` is the intended source of truth.

### Why not a bigger refactor

The Initial/Handshake "`max_ack_delay` term must be 0" rule is
the responsibility of `xqc_send_ctl_get_pto_time_and_space`, which
already gates on `pns == XQC_PNS_APP_DATA`. Plumbing a `pns`
parameter through `calc_pto` would touch 5+ files and the only
caller (`xqc_conn_get_max_pto`) deliberately wants a 1-RTT-space
worst case across paths for idle / close timers. Adding pns
granularity at that aggregation layer is the wrong abstraction.

I added a comment at the helper documenting that contract so the
next reader does not get surprised.

### Pre-handshake

`remote_settings.max_ack_delay` is initialized to
`XQC_DEFAULT_MAX_ACK_DELAY = 25` by `xqc_conn_set_default_settings`
before any path / send_ctl exists, so the formula never reads
garbage. Pre-handshake the result is conservative-larger, which
is the safe direction for idle-timer floors.

### Tests

Two CUnit tests in `tests/unittest/xqc_send_ctl_test.c`:

- `xqc_test_pto_uses_remote_max_ack_delay` — sets `local=25`,
  `remote=100`, pins `srtt=1000us`, `rttvar=0` so the floor term
  collapses to `XQC_kGranularity * 1000`. Asserts the formula
  consumes `remote * 1000`, not `local * 1000`.
- `xqc_test_pto_remote_default_when_unset` — defensive guard that
  the formula yields a sane positive value at default settings.

I ran the negative-control sanity check: temporarily reverted the
swap, rebuilt, re-ran. The first test failed at both its
assertions; restoring the patch made both tests pass. The test
actually exercises the regression.

### Out of scope

While auditing I noticed two adjacent items, leaving them for
separate issues:

- `XQC_kGranularity` is 2 ms in `xqc_send_ctl.h:26`; RFC 9002 §A.2
  fixes it at 1 ms. Likely a deliberate tuning choice but
  undocumented.
- `xqc_decode_max_ack_delay` (`xqc_transport_params.c:621`) has
  no `< 2^14` clamp; per RFC 9000 §18.2 a peer advertising a
  larger value MUST be rejected with `TRANSPORT_PARAMETER_ERROR`.
  Same exposure exists at the three sibling sites that already
  use `remote_settings`; this PR doesn't widen it.