### PR TITLE
fix issue 724: cap ack_delay by default max_ack_delay before handshake confirmation

### DIFF
--- a/src/transport/xqc_send_ctl.c
+++ b/src/transport/xqc_send_ctl.c
@@ -21,6 +21,7 @@
 #include "src/transport/xqc_utils.h"
 #include "src/transport/xqc_datagram.h"
 #include "src/transport/xqc_reinjection.h"
+#include "src/transport/xqc_transport_params.h"
 
 int 
 xqc_send_ctl_may_remove_unacked_dgram(xqc_connection_t *conn, xqc_packet_out_t *po)
@@ -1155,8 +1156,19 @@ xqc_send_ctl_update_rtt(xqc_send_ctl_t *send_ctl, xqc_usec_t *latest_rtt, xqc_us
     } else {
         send_ctl->ctl_minrtt = xqc_min(*latest_rtt, send_ctl->ctl_minrtt);
 
+        /*
+         * RFC 9002 5.3: ack_delay MUST be clamped by max_ack_delay before
+         * being subtracted from latest_rtt. Until the handshake is
+         * confirmed the peer is required to use the default max_ack_delay
+         * (RFC 9000 18.2), so use that constant; after confirmation the
+         * negotiated value from the peer's transport parameters applies.
+         */
         if (xqc_conn_is_handshake_confirmed(send_ctl->ctl_conn)) {
-            ack_delay = xqc_min(ack_delay, send_ctl->ctl_conn->remote_settings.max_ack_delay * 1000);
+            ack_delay = xqc_min(ack_delay,
+                                send_ctl->ctl_conn->remote_settings.max_ack_delay * 1000);
+
+        } else {
+            ack_delay = xqc_min(ack_delay, XQC_DEFAULT_MAX_ACK_DELAY * 1000);
         }
 
         /* Adjust for ack delay if it's plausible. */

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -127,7 +127,9 @@ main()
                         xqc_test_pto_uses_remote_max_ack_delay)
         || !CU_add_test(pSuite, "xqc_test_pto_remote_default_when_unset",
                         xqc_test_pto_remote_default_when_unset)
-        /* ADD TESTS HERE */) 
+        || !CU_add_test(pSuite, "xqc_test_send_ctl_update_rtt_ack_delay_cap",
+                        xqc_test_send_ctl_update_rtt_ack_delay_cap)
+        /* ADD TESTS HERE */)
     {
         CU_cleanup_registry();
         return (int)CU_get_error();

--- a/tests/unittest/xqc_send_ctl_test.c
+++ b/tests/unittest/xqc_send_ctl_test.c
@@ -3,9 +3,12 @@
  */
 
 #include <CUnit/CUnit.h>
+#include <xquic/xquic_typedef.h>
 
 #include "xqc_send_ctl_test.h"
 #include "xqc_common_test.h"
+
+#include "src/common/xqc_malloc.h"
 #include "src/transport/xqc_send_ctl.h"
 #include "src/transport/xqc_conn.h"
 #include "src/transport/xqc_multipath.h"
@@ -98,4 +101,221 @@ xqc_test_pto_remote_default_when_unset(void)
     CU_ASSERT(got > 0);
 
     xqc_engine_destroy(conn->engine);
+}
+
+
+typedef struct xqc_rtt_case_s {
+    const char     *name;
+    xqc_bool_t      hsk_confirmed;
+    xqc_bool_t      first_sample;
+    uint64_t        remote_max_ack_delay_ms;
+    xqc_usec_t      input_ack_delay;
+    xqc_usec_t      latest_rtt;
+    xqc_usec_t      pre_minrtt;
+    xqc_usec_t      pre_srtt;
+    xqc_usec_t      pre_rttvar;
+    xqc_usec_t      expected_srtt;
+    xqc_usec_t      expected_rttvar;
+    xqc_usec_t      expected_minrtt;
+} xqc_rtt_case_t;
+
+
+static void
+xqc_test_send_ctl_run_rtt_case(xqc_connection_t *conn, xqc_path_ctx_t *path,
+    const xqc_rtt_case_t *tc)
+{
+    xqc_send_ctl_t *send_ctl = path->path_send_ctl;
+
+    send_ctl->ctl_conn  = conn;
+    send_ctl->ctl_srtt  = tc->pre_srtt;
+    send_ctl->ctl_rttvar = tc->pre_rttvar;
+    send_ctl->ctl_minrtt = tc->pre_minrtt;
+    send_ctl->ctl_first_rtt_sample_time = tc->first_sample ? 0 : 1;
+
+    if (tc->hsk_confirmed) {
+        conn->conn_flag |= XQC_CONN_FLAG_HANDSHAKE_CONFIRMED;
+
+    } else {
+        conn->conn_flag &= ~XQC_CONN_FLAG_HANDSHAKE_CONFIRMED;
+    }
+    conn->remote_settings.max_ack_delay = tc->remote_max_ack_delay_ms;
+
+    xqc_usec_t latest = tc->latest_rtt;
+    xqc_send_ctl_update_rtt(send_ctl, &latest, tc->input_ack_delay);
+
+    if (send_ctl->ctl_srtt != tc->expected_srtt
+        || send_ctl->ctl_rttvar != tc->expected_rttvar
+        || send_ctl->ctl_minrtt != tc->expected_minrtt)
+    {
+        fprintf(stderr,
+                "case [%s] mismatch: srtt got=%llu want=%llu, "
+                "rttvar got=%llu want=%llu, minrtt got=%llu want=%llu\n",
+                tc->name,
+                (unsigned long long) send_ctl->ctl_srtt,
+                (unsigned long long) tc->expected_srtt,
+                (unsigned long long) send_ctl->ctl_rttvar,
+                (unsigned long long) tc->expected_rttvar,
+                (unsigned long long) send_ctl->ctl_minrtt,
+                (unsigned long long) tc->expected_minrtt);
+    }
+
+    CU_ASSERT(send_ctl->ctl_srtt == tc->expected_srtt);
+    CU_ASSERT(send_ctl->ctl_rttvar == tc->expected_rttvar);
+    CU_ASSERT(send_ctl->ctl_minrtt == tc->expected_minrtt);
+}
+
+
+void
+xqc_test_send_ctl_update_rtt_ack_delay_cap(void)
+{
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_FATAL(conn != NULL);
+
+    xqc_path_ctx_t *path = xqc_calloc(1, sizeof(xqc_path_ctx_t));
+    CU_ASSERT_FATAL(path != NULL);
+    path->path_send_ctl = xqc_calloc(1, sizeof(xqc_send_ctl_t));
+    CU_ASSERT_FATAL(path->path_send_ctl != NULL);
+
+    conn->conn_initial_path = path;
+
+    /*
+     * Pre-condition: srtt=200ms, rttvar=50ms, minrtt=10ms, second-or-later
+     * sample. The handshake-not-confirmed cap is 25ms regardless of the
+     * negotiated max_ack_delay; after confirmation it is the negotiated
+     * value clamped per RFC 9000 18.2.
+     */
+    xqc_rtt_case_t cases[] = {
+        {
+            .name = "hsk_not_confirmed_large_ack_delay",
+            .hsk_confirmed = XQC_FALSE,
+            .first_sample  = XQC_FALSE,
+            .remote_max_ack_delay_ms = 100,
+            .input_ack_delay = 200000,
+            .latest_rtt      = 250000,
+            .pre_minrtt      = 10000,
+            .pre_srtt        = 200000,
+            .pre_rttvar      = 50000,
+            /* ack_delay capped to 25ms; adjusted = 225ms */
+            .expected_srtt   = 203125,
+            .expected_rttvar = 43750,
+            .expected_minrtt = 10000,
+        },
+        {
+            .name = "hsk_confirmed_large_ack_delay",
+            .hsk_confirmed = XQC_TRUE,
+            .first_sample  = XQC_FALSE,
+            .remote_max_ack_delay_ms = 100,
+            .input_ack_delay = 200000,
+            .latest_rtt      = 250000,
+            .pre_minrtt      = 10000,
+            .pre_srtt        = 200000,
+            .pre_rttvar      = 50000,
+            /* ack_delay capped to negotiated 100ms; adjusted = 150ms */
+            .expected_srtt   = 193750,
+            .expected_rttvar = 50000,
+            .expected_minrtt = 10000,
+        },
+        {
+            .name = "hsk_not_confirmed_small_ack_delay",
+            .hsk_confirmed = XQC_FALSE,
+            .first_sample  = XQC_FALSE,
+            .remote_max_ack_delay_ms = 100,
+            .input_ack_delay = 10000,
+            .latest_rtt      = 50000,
+            .pre_minrtt      = 10000,
+            .pre_srtt        = 200000,
+            .pre_rttvar      = 50000,
+            /* 10ms < 25ms cap, unchanged; adjusted = 40ms */
+            .expected_srtt   = 180000,
+            .expected_rttvar = 77500,
+            .expected_minrtt = 10000,
+        },
+        {
+            .name = "hsk_confirmed_remote_smaller_than_default",
+            .hsk_confirmed = XQC_TRUE,
+            .first_sample  = XQC_FALSE,
+            .remote_max_ack_delay_ms = 5,
+            .input_ack_delay = 30000,
+            .latest_rtt      = 50000,
+            .pre_minrtt      = 10000,
+            .pre_srtt        = 200000,
+            .pre_rttvar      = 50000,
+            /* capped to negotiated 5ms; adjusted = 45ms */
+            .expected_srtt   = 180625,
+            .expected_rttvar = 76250,
+            .expected_minrtt = 10000,
+        },
+        {
+            .name = "first_sample_skips_ack_delay_cap",
+            .hsk_confirmed = XQC_FALSE,
+            .first_sample  = XQC_TRUE,
+            .remote_max_ack_delay_ms = 100,
+            .input_ack_delay = 200000,
+            .latest_rtt      = 50000,
+            .pre_minrtt      = 0,
+            .pre_srtt        = 0,
+            .pre_rttvar      = 0,
+            /* first sample: srtt = latest_rtt, rttvar = latest_rtt/2 */
+            .expected_srtt   = 50000,
+            .expected_rttvar = 25000,
+            .expected_minrtt = 50000,
+        },
+        {
+            .name = "ack_delay_zero",
+            .hsk_confirmed = XQC_FALSE,
+            .first_sample  = XQC_FALSE,
+            .remote_max_ack_delay_ms = 100,
+            .input_ack_delay = 0,
+            .latest_rtt      = 50000,
+            .pre_minrtt      = 10000,
+            .pre_srtt        = 200000,
+            .pre_rttvar      = 50000,
+            /* cap path harmless; adjusted = 50ms */
+            .expected_srtt   = 181250,
+            .expected_rttvar = 75000,
+            .expected_minrtt = 10000,
+        },
+        {
+            .name = "plausibility_blocks_subtraction",
+            .hsk_confirmed = XQC_FALSE,
+            .first_sample  = XQC_FALSE,
+            .remote_max_ack_delay_ms = 100,
+            .input_ack_delay = 10000,
+            .latest_rtt      = 12000,
+            .pre_minrtt      = 11000,
+            .pre_srtt        = 12000,
+            .pre_rttvar      = 1000,
+            /*
+             * adjusted_rtt + 1000us = 13000us, minrtt + ack_delay = 21000us;
+             * plausibility check fails, ack_delay not subtracted.
+             */
+            .expected_srtt   = 12000,
+            .expected_rttvar = 750,
+            .expected_minrtt = 11000,
+        },
+        {
+            .name = "hsk_confirmed_remote_zero_cap",
+            .hsk_confirmed = XQC_TRUE,
+            .first_sample  = XQC_FALSE,
+            .remote_max_ack_delay_ms = 0,
+            .input_ack_delay = 50000,
+            .latest_rtt      = 50000,
+            .pre_minrtt      = 10000,
+            .pre_srtt        = 200000,
+            .pre_rttvar      = 50000,
+            /* cap to 0 forces ack_delay to 0; adjusted = 50ms */
+            .expected_srtt   = 181250,
+            .expected_rttvar = 75000,
+            .expected_minrtt = 10000,
+        },
+    };
+
+    size_t n = sizeof(cases) / sizeof(cases[0]);
+    for (size_t i = 0; i < n; i++) {
+        xqc_test_send_ctl_run_rtt_case(conn, path, &cases[i]);
+    }
+
+    xqc_engine_destroy(conn->engine);
+    xqc_free(path->path_send_ctl);
+    xqc_free(path);
 }

--- a/tests/unittest/xqc_send_ctl_test.h
+++ b/tests/unittest/xqc_send_ctl_test.h
@@ -13,4 +13,12 @@
 void xqc_test_pto_uses_remote_max_ack_delay(void);
 void xqc_test_pto_remote_default_when_unset(void);
 
+/*
+ * Regression test for issue #724 (RFC 9002 5.3):
+ * xqc_send_ctl_update_rtt must cap ack_delay by max_ack_delay
+ * before subtracting it from latest_rtt, using the default 25ms
+ * cap until the handshake is confirmed.
+ */
+void xqc_test_send_ctl_update_rtt_ack_delay_cap(void);
+
 #endif


### PR DESCRIPTION
RFC 9002 §5.3 says an endpoint SHOULD ignore the peer's `max_ack_delay` until the handshake is confirmed, and MUST use the lesser of the acknowledgement delay and the peer's `max_ack_delay` after that. xquic only applied the clamp in `xqc_send_ctl_update_rtt()` once the handshake was confirmed — before that the value the peer put in the ACK frame went straight into `adjusted_rtt = latest_rtt - ack_delay`, unbounded.

Most of the time this is harmless because `remote_settings.max_ack_delay` is initialised to the spec default (25ms, see `xqc_conn_set_default_settings`), so the post-confirmation path would clamp to the same value anyway. The window where it matters is 0-RTT resumption: `xqc_conn_set_early_remote_transport_params` overwrites `remote_settings.max_ack_delay` with the cached value from the previous session, which can be much larger. If an early ACK arrives with a big `ack_delay`, `adjusted_rtt` ends up far below `latest_rtt`, srtt is underestimated, PTO shrinks, and we trigger spurious loss detection.

## What this PR does

- In the handshake-not-confirmed branch, cap `ack_delay` by `XQC_DEFAULT_MAX_ACK_DELAY` (25ms, RFC 9000 §18.2) instead of leaving it unbounded. Using the constant directly — rather than relying on `remote_settings.max_ack_delay` already holding the default — keeps the behaviour correct even when the cached transport parameters from a previous 0-RTT session have a non-default value.
- The post-confirmation branch is unchanged.
- The plausibility check below (`adjusted_rtt + 1000 >= minrtt + ack_delay`) is left alone; its purpose and the 1ms fudge are unrelated to this fix.

## Tests

`tests/unittest/xqc_send_ctl_test.c::xqc_test_send_ctl_update_rtt_ack_delay_cap` is a table-driven test with 8 cases:

- Handshake not confirmed, large `ack_delay` (100ms) → clamped to 25ms.
- Handshake confirmed, large `ack_delay` → clamped to negotiated `remote_settings.max_ack_delay`.
- Small `ack_delay` (below either cap) → unchanged.
- First RTT sample shortcut (sets srtt directly, no cap).
- `ack_delay == 0` corner.
- Plausibility guard rejects subtraction when it would drop below `min_rtt`.
- Post-confirmation with `remote_settings.max_ack_delay == 0` → cap is 0, subtraction skipped.

All 8 pass; existing test suite is green. The fix was mutation-tested: removing the new `else` branch fails case 1, and dropping the `* 1000` unit conversion fails it too — confirming both the branch and the unit math are actually exercised.

Fixes: #724
