### PR TITLE
fix issue 624: abandon connection attempt on Version Negotiation per RFC 9000 6.2

### DIFF
--- a/include/xquic/xqc_errno.h
+++ b/include/xquic/xqc_errno.h
@@ -26,6 +26,15 @@ typedef enum {
     TRA_APPLICATION_ERROR           =  0xC,
     TRA_CRYPTO_BUFFER_EXCEEDED      =  0xD,
     TRA_0RTT_TRANS_PARAMS_ERROR     =  0xE,   /**< MUST delete the current saved 0RTT transport parameters */
+    /*
+     * RFC 9000 Section 6.2 does not assign a CONNECTION_CLOSE code for
+     * the Version Negotiation abort path, because the client cannot
+     * send CONNECTION_CLOSE before keys are established. This value is
+     * therefore library-internal: it is exposed via xqc_conn_get_errno
+     * so the upper layer can distinguish a VN-driven abort from other
+     * close reasons, but it is never serialised onto the wire.
+     */
+    TRA_VERSION_NEGOTIATION_ERROR   =  0x53,
     TRA_HS_CERTIFICATE_VERIFY_FAIL  =  0x1FE, /**< for handshake certificate verify error */
     TRA_CRYPTO_ERROR                =  0x1FF, /**< 0x1XX */
 } xqc_trans_err_code_t;
@@ -129,6 +138,7 @@ typedef enum {
     XQC_EALPN_NOT_REGISTERED            = 640,      /**< alpn is not registered */
     XQC_ESTATELESS_RESET                = 641,      /**< connection is reset by peer */
     XQC_EPACKET_FILETER_CALLBACK        = 642,      /**< error with packet filter callback function */
+    XQC_EVERSION_NEGOTIATION            = 643,      /**< client received a Version Negotiation packet, RFC 9000 §6.2 mandates abandoning the connection attempt */
 
     XQC_EMP_NOT_SUPPORT_MP              = 650,      /**< Multipath - don't support multipath */
     XQC_EMP_NO_AVAIL_PATH_ID            = 651,      /**< Multipath - no available path id */

--- a/scripts/case_test.sh
+++ b/scripts/case_test.sh
@@ -1417,7 +1417,9 @@ sleep 1
 
 clear_log
 echo -e "version negotiation ...\c"
-${CLIENT_BIN} -l d -E -x 33 >> clog
+${CLIENT_BIN} -l d -E -x 33 >> clog 2>&1
+
+# Wire-level: VN packet was received and recognised by the receiver.
 result=`grep -e "|====>|.*VERSION_NEGOTIATION" clog`
 if [ -n "$result" ]; then
     echo ">>>>>>>> pass:1"
@@ -1425,6 +1427,31 @@ if [ -n "$result" ]; then
 else
     echo ">>>>>>>> pass:0"
     case_print_result "version_negotiation" "fail"
+fi
+
+# RFC 9000 §6.2 mandates the client MUST abandon the connection attempt on
+# a valid VN. Verify xqc_packet_parse_version_negotiation took the abort
+# branch instead of the legacy silent-version-switch behaviour.
+abort_log=`grep "version negotiation: aborting connection attempt" clog`
+if [ -n "$abort_log" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "version_negotiation_abort_path" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "version_negotiation_abort_path" "fail"
+fi
+
+# The abort must be surfaced to the upper layer through conn_close_notify
+# with a non-zero errno: either TRA_VERSION_NEGOTIATION_ERROR (0x53 = 83)
+# from the transport conn_err, or XQC_EVERSION_NEGOTIATION (643) when the
+# error is propagated through xqc_conn_get_errno on a transport-only path.
+errno_log=`grep -E "conn errno:(83|643)" clog`
+if [ -n "$errno_log" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "version_negotiation_close_errno" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "version_negotiation_close_errno" "fail"
 fi
 
 

--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -929,7 +929,6 @@ xqc_conn_create(xqc_engine_t *engine, xqc_cid_t *dcid, xqc_cid_t *scid,
     xc->log->scid = xc->scid_set.original_scid_str;
     xc->transport_cbs = engine->transport_cbs;
     xc->user_data = user_data;
-    xc->discard_vn_flag = 0;
     xc->conn_type = type;
     xc->conn_flag = 0;
     xc->conn_state = (type == XQC_CONN_TYPE_SERVER) ? XQC_CONN_STATE_SERVER_INIT : XQC_CONN_STATE_CLIENT_INIT;

--- a/src/transport/xqc_conn.h
+++ b/src/transport/xqc_conn.h
@@ -302,8 +302,6 @@ struct xqc_connection_s {
     xqc_engine_t                   *engine;
 
     xqc_proto_version_t             version;
-    /* set when client receives a non-VN package from server or receives a VN package and processes it */
-    uint32_t                        discard_vn_flag;
 
     /* original destination connection id, RFC 9000, Section 7.3. */
     xqc_cid_t                       original_dcid;

--- a/src/transport/xqc_packet_parser.c
+++ b/src/transport/xqc_packet_parser.c
@@ -291,10 +291,6 @@ xqc_packet_parse_short_header(xqc_connection_t *c, xqc_packet_in_t *packet_in)
         return -XQC_EILLPKT;
     }
 
-    if (c->conn_type == XQC_CONN_TYPE_CLIENT) {
-        c->discard_vn_flag = 1;
-    }
-
     return XQC_OK;
 }
 
@@ -1145,16 +1141,37 @@ Version Negotiation Packet {
 xqc_int_t
 xqc_packet_parse_version_negotiation(xqc_connection_t *c, xqc_packet_in_t *packet_in)
 {
-    /* check original DCID */
+    unsigned char  *pos;
+    unsigned char  *end;
+    uint32_t       *config_version_list;
+    uint32_t        config_version_count;
+    uint32_t        version_chosen;
+    uint32_t        current_wire_version;
+    uint32_t        supported_version_count;
+    uint32_t        supported_version_list[256];
+
+    /*
+     * RFC 9000 Section 17.2.1 requires the VN packet to mirror the
+     * client's Initial CIDs: SCID echoes the client's DCID, DCID
+     * echoes the client's SCID. Validate both directions so that an
+     * off-path attacker cannot forge a VN packet for an unrelated
+     * connection.
+     */
     if (xqc_cid_is_equal(&c->original_dcid, &packet_in->pi_pkt.pkt_scid) != XQC_OK) {
-        xqc_log(c->log, XQC_LOG_ERROR, "|version negotiation pkt SCID error|original_dcid:%s|scid:%s|", 
+        xqc_log(c->log, XQC_LOG_ERROR, "|version negotiation pkt SCID error|original_dcid:%s|scid:%s|",
                 xqc_dcid_str(c->engine, &c->original_dcid), xqc_scid_str(c->engine, &packet_in->pi_pkt.pkt_scid));
         return -XQC_EILLPKT;
     }
 
+    if (xqc_cid_is_equal(&c->initial_scid, &packet_in->pi_pkt.pkt_dcid) != XQC_OK) {
+        xqc_log(c->log, XQC_LOG_ERROR, "|version negotiation pkt DCID error|initial_scid:%s|dcid:%s|",
+                xqc_scid_str(c->engine, &c->initial_scid), xqc_dcid_str(c->engine, &packet_in->pi_pkt.pkt_dcid));
+        return -XQC_EILLPKT;
+    }
+
     xqc_log(c->log, XQC_LOG_DEBUG, "|packet parse|version negotiation|");
-    unsigned char *pos = packet_in->pos;
-    unsigned char *end = packet_in->last;
+    pos = packet_in->pos;
+    end = packet_in->last;
     packet_in->pi_pkt.pkt_type = XQC_PTYPE_VERSION_NEGOTIATION;
 
     /* at least one version is carried in the VN packet */
@@ -1164,28 +1181,28 @@ xqc_packet_parse_version_negotiation(xqc_connection_t *c, xqc_packet_in_t *packe
         return -XQC_EILLPKT;
     }
 
-    /* check available states */
+    /*
+     * RFC 9000 Section 6.2: a VN packet is only valid in response to
+     * the client's initial flight. Any VN observed after the client
+     * has accepted a server response is ignored as required.
+     */
     if (c->conn_state != XQC_CONN_STATE_CLIENT_INITIAL_SENT) {
-        /* drop packet */
         xqc_log(c->log, XQC_LOG_WARN, "|packet_parse_version_negotiation|invalid state|%d|", c->conn_state);
         return -XQC_ESTATE;
     }
 
-    /* check conn type, only client can receive a VN packet */
+    /* only a client is permitted to receive a VN packet */
     if (c->conn_type != XQC_CONN_TYPE_CLIENT) {
         xqc_log(c->log, XQC_LOG_WARN, "|packet_parse_version_negotiation|invalid conn_type|%d|", c->conn_type);
         return -XQC_EPROTO;
     }
 
-    /* check discard vn flag */
-    if (c->discard_vn_flag != 0) {
-        packet_in->pos = packet_in->last;
-        return XQC_OK;
-    }
-
-    /* get Supported Version list */
-    uint32_t supported_version_list[256];
-    uint32_t supported_version_count = 0;
+    /*
+     * Collect the server's Supported Version list. The list is parsed
+     * purely for observability (event log + INFO trace); the abort
+     * decision below does not depend on its contents.
+     */
+    supported_version_count = 0;
     while (XQC_BUFF_LEFT_SIZE(pos, end) >= XQC_PACKET_VERSION_LENGTH) {
         uint32_t version = ntohl(*(uint32_t*)pos);
         if (version) {
@@ -1202,47 +1219,67 @@ xqc_packet_parse_version_negotiation(xqc_connection_t *c, xqc_packet_in_t *packe
     }
     packet_in->pos = packet_in->last;
 
-    /* VN packet returns the same version, nothing to be changed */
-    if (xqc_uint32_list_find(supported_version_list, supported_version_count, c->version) != -1) {
+    /*
+     * RFC 9000 Section 6.2: "A client that supports a version offered
+     * by the server MUST abandon the current connection attempt." If
+     * the server's list happens to include the client's chosen
+     * version, the spec still requires the client to discard the VN
+     * packet and treat it as a stray datagram (do NOT abort), since
+     * it cannot have been generated in response to this Initial.
+     * The list carries wire-format version values, so compare against
+     * the wire value of the client's current version rather than the
+     * internal enum (which only matches by coincidence for V1).
+     */
+    current_wire_version = (c->version < XQC_VERSION_MAX)
+                           ? xqc_proto_version_value[c->version] : 0;
+    if (xqc_uint32_list_find(supported_version_list, supported_version_count,
+                             current_wire_version) != -1)
+    {
+        xqc_log(c->log, XQC_LOG_WARN,
+                "|VN lists current version, discarding per RFC 9000 §6.2"
+                "|version:%ud|wire:0x%xL|",
+                c->version, current_wire_version);
         return XQC_OK;
     }
 
-    /* chose a version both client and server support */
-    uint32_t *config_version_list = c->engine->config->support_version_list;
-    uint32_t config_version_count = c->engine->config->support_version_count;
-    uint32_t version_chosen = 0;
+    config_version_list = c->engine->config->support_version_list;
+    config_version_count = c->engine->config->support_version_count;
+    version_chosen = 0;
     for (uint32_t i = 0; i < supported_version_count; ++i) {
         if (xqc_uint32_list_find(config_version_list, config_version_count, supported_version_list[i]) != -1) {
             version_chosen = supported_version_list[i];
-            xqc_log(c->log, XQC_LOG_INFO, "|version negotiation|version:%ui|", version_chosen);
             break;
         }
     }
-    xqc_log_event(c->log, TRA_VERSION_INFORMATION, config_version_count, config_version_list, supported_version_count,
-                  supported_version_list, version_chosen);
+    xqc_log_event(c->log, TRA_VERSION_INFORMATION, config_version_count, config_version_list,
+                  supported_version_count, supported_version_list, version_chosen);
 
-    /* can't chose a version, abort the connection attempt */
-    if (version_chosen == 0) {
-        xqc_log(c->log, XQC_LOG_ERROR, "|can't negotiate a version|");
-        return -XQC_ESYS;
-    }
+    /*
+     * RFC 9000 Section 6.2 mandates the client MUST abandon the
+     * connection attempt on any valid VN packet, regardless of
+     * whether a mutually supported version exists. The decision to
+     * retry with a different version is explicitly left to the
+     * application (MAY, not MUST), so we surface the abort to the
+     * upper layer and let it decide. Reconnecting in-place would
+     * also be unsafe here because the Initial keys are derived from
+     * the original version and cannot be reused once the version
+     * changes; retransmissions of the in-flight Initial would still
+     * carry the old keys.
+     *
+     * VN packets are not protected, so CONNECTION_CLOSE MUST NOT be
+     * emitted. Move directly to CLOSED to short-circuit the closing
+     * machinery in xqc_conn_immediate_close (which already refuses
+     * to write CONNECTION_CLOSE once state >= DRAINING).
+     */
+    xqc_log(c->log, XQC_LOG_WARN,
+            "|version negotiation: aborting connection attempt|peer_versions:%ud|mutual:%ud|",
+            supported_version_count, version_chosen);
 
-    /* translate version to enum, and set to the connection */
-    for (uint32_t i = XQC_IDRAFT_INIT_VER + 1; i < XQC_IDRAFT_VER_NEGOTIATION; i++) {
-        if (xqc_proto_version_value[i] == version_chosen) {
-            c->version = i;
-            break;
-        }
-    }
+    XQC_CONN_ERR(c, TRA_VERSION_NEGOTIATION_ERROR);
+    c->conn_state = XQC_CONN_STATE_CLOSED;
+    xqc_log_event(c->log, CON_CONNECTION_STATE_UPDATED, c);
 
-    /* TODO: connect the server with the new version, which is not defined by protocol */
-
-    xqc_log(c->log, XQC_LOG_INFO, "|parse version negotiation packet suc|");
-
-    /* set the discard vn flag to avoid a second negotiation */
-    c->discard_vn_flag = 1;
-
-    return XQC_OK;
+    return -XQC_EVERSION_NEGOTIATION;
 }
 
 
@@ -1379,10 +1416,6 @@ xqc_packet_parse_long_header(xqc_connection_t *c,
         xqc_log(c->log, XQC_LOG_ERROR, "|invalid packet type|%ui|", type);
         ret = -XQC_EILLPKT;
         break;
-    }
-
-    if (ret == XQC_OK && c->conn_type == XQC_CONN_TYPE_CLIENT) {
-        c->discard_vn_flag = 1;
     }
 
     return ret;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -114,6 +114,7 @@ if(HAVE_CUNIT)
         ${UNIT_TEST_DIR}/xqc_h3_ext_test.c
         ${UNIT_TEST_DIR}/xqc_ack_with_timestamp_test.c
         ${UNIT_TEST_DIR}/xqc_send_ctl_test.c
+        ${UNIT_TEST_DIR}/xqc_vn_test.c
     )
 
     if(XQC_ENABLE_FEC)

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -42,6 +42,7 @@
 #include "xqc_fec_test.h"
 #include "xqc_ack_with_timestamp_test.h"
 #include "xqc_send_ctl_test.h"
+#include "xqc_vn_test.h"
 
 static int xqc_init_suite(void) { return 0; }
 static int xqc_clean_suite(void) { return 0; }
@@ -130,6 +131,13 @@ main()
                         xqc_test_pto_remote_default_when_unset)
         || !CU_add_test(pSuite, "xqc_test_send_ctl_update_rtt_ack_delay_cap",
                         xqc_test_send_ctl_update_rtt_ack_delay_cap)
+        /* RFC 9000 §6.2 Version Negotiation abort suite */
+        || !CU_add_test(pSuite, "xqc_test_vn_abort_on_unsupported_version", xqc_test_vn_abort_on_unsupported_version)
+        || !CU_add_test(pSuite, "xqc_test_vn_downgrade_protection_when_version_matches", xqc_test_vn_downgrade_protection_when_version_matches)
+        || !CU_add_test(pSuite, "xqc_test_vn_reject_when_dcid_mismatch", xqc_test_vn_reject_when_dcid_mismatch)
+        || !CU_add_test(pSuite, "xqc_test_vn_reject_when_scid_mismatch", xqc_test_vn_reject_when_scid_mismatch)
+        || !CU_add_test(pSuite, "xqc_test_vn_reject_when_state_not_initial_sent", xqc_test_vn_reject_when_state_not_initial_sent)
+        || !CU_add_test(pSuite, "xqc_test_vn_abort_on_multi_unsupported_versions", xqc_test_vn_abort_on_multi_unsupported_versions)
         /* ADD TESTS HERE */)
     {
         CU_cleanup_registry();

--- a/tests/unittest/xqc_vn_test.c
+++ b/tests/unittest/xqc_vn_test.c
@@ -1,0 +1,554 @@
+/**
+ * @copyright Copyright (c) 2022, Alibaba Group Holding Limited
+ */
+
+#include <CUnit/CUnit.h>
+#include <string.h>
+
+#include "xqc_vn_test.h"
+#include "xquic/xquic.h"
+#include "xquic/xquic_typedef.h"
+#include "xquic/xqc_errno.h"
+#include "src/transport/xqc_packet.h"
+#include "src/transport/xqc_packet_in.h"
+#include "src/transport/xqc_packet_parser.h"
+#include "src/transport/xqc_engine.h"
+#include "src/transport/xqc_conn.h"
+#include "src/transport/xqc_cid.h"
+#include "src/transport/xqc_client.h"
+#include "src/common/xqc_log.h"
+
+
+/*
+ * Walkthrough
+ * -----------
+ *
+ *   client engine + connection in CLIENT_INITIAL_SENT state
+ *                            |
+ *                            v
+ *   hand-crafted VN datagram (long header, version=0)
+ *                            |
+ *           +----------------+-----------------+
+ *           |                                  |
+ *           v                                  v
+ *   xqc_conn_process_packet (T1/T2/T6)  xqc_packet_parse_version_negotiation (T3/T4/T5)
+ *           |                                  |
+ *           v                                  v
+ *   assertions on conn_state / conn_err / conn_flag / buf
+ *
+ * The connection lives behind a buf-backed write_socket so we can prove
+ * "no CONNECTION_CLOSE was emitted" by snapshotting buf_len before and
+ * after the VN injection and asserting they are identical.
+ */
+
+
+/* ----- minimal test context (separate from xqc_packet_test.c) ----- */
+
+typedef struct vn_ctx_s {
+    xqc_engine_t        *engine;
+    xqc_connection_t    *c;
+    xqc_cid_t            cid;
+    unsigned char        buf[2048];
+    size_t               buf_len;
+    int                  write_count;
+} vn_ctx_t;
+
+
+static ssize_t
+vn_test_client_write(const unsigned char *buf, size_t size,
+    const struct sockaddr *peer_addr, socklen_t peer_addrlen, void *conn_user_data)
+{
+    vn_ctx_t *ctx = (vn_ctx_t *)conn_user_data;
+    if (size <= sizeof(ctx->buf)) {
+        memcpy(ctx->buf, buf, size);
+        ctx->buf_len = size;
+    }
+    ctx->write_count++;
+    return (ssize_t)size;
+}
+
+
+static int
+vn_test_client_conn_create_notify(xqc_connection_t *conn, const xqc_cid_t *cid,
+    void *user_data, void *conn_proto_data)
+{
+    vn_ctx_t *ctx = (vn_ctx_t *)user_data;
+    ctx->c = conn;
+    memcpy(&ctx->cid, cid, sizeof(xqc_cid_t));
+    xqc_conn_set_alp_user_data(conn, ctx);
+    return 0;
+}
+
+
+static void
+vn_test_set_event_timer(xqc_msec_t wake_after, void *engine_user_data)
+{
+    return;
+}
+
+
+static xqc_engine_t *
+vn_test_create_client_engine(vn_ctx_t *ctx)
+{
+    xqc_engine_ssl_config_t  ssl_cfg;
+    memset(&ssl_cfg, 0, sizeof(ssl_cfg));
+    ssl_cfg.private_key_file = "./server.key";
+    ssl_cfg.cert_file = "./server.crt";
+    ssl_cfg.ciphers = XQC_TLS_CIPHERS;
+    ssl_cfg.groups = XQC_TLS_GROUPS;
+
+    xqc_engine_callback_t cb = {
+        .set_event_timer = vn_test_set_event_timer,
+    };
+
+    xqc_transport_callbacks_t tcbs = {
+        .write_socket = vn_test_client_write,
+    };
+
+    xqc_app_proto_callbacks_t alp_cbs = {
+        .conn_cbs.conn_create_notify = vn_test_client_conn_create_notify,
+    };
+
+    xqc_engine_t *engine = xqc_engine_create(XQC_ENGINE_CLIENT, NULL, &ssl_cfg,
+                                             &cb, &tcbs, ctx);
+    if (engine == NULL) {
+        return NULL;
+    }
+
+    xqc_engine_register_alpn(engine, "transport", 9, &alp_cbs, NULL);
+    return engine;
+}
+
+
+/* Bootstrap a client connection in CLIENT_INITIAL_SENT. Returns 1 on success. */
+static int
+vn_test_start_client(vn_ctx_t *ctx)
+{
+    ctx->engine = vn_test_create_client_engine(ctx);
+    if (ctx->engine == NULL) {
+        return 0;
+    }
+
+    xqc_conn_settings_t cs;
+    memset(&cs, 0, sizeof(cs));
+    cs.proto_version = XQC_VERSION_V1;
+
+    xqc_conn_ssl_config_t cssl;
+    memset(&cssl, 0, sizeof(cssl));
+
+    const xqc_cid_t *cid = xqc_connect(ctx->engine, &cs, NULL, 0, "", 0, &cssl,
+                                       NULL, 0, "transport", ctx);
+    if (cid == NULL || ctx->c == NULL) {
+        return 0;
+    }
+
+    /* xqc_connect drives conn_logic synchronously, so the Initial datagram
+     * has already been handed to vn_test_client_write by the time we get
+     * here.  State should be CLIENT_INITIAL_SENT.
+     */
+    return 1;
+}
+
+
+static void
+vn_test_teardown(vn_ctx_t *ctx)
+{
+    if (ctx->engine != NULL) {
+        if (ctx->c != NULL) {
+            xqc_conn_close(ctx->engine, &ctx->cid);
+        }
+        xqc_engine_destroy(ctx->engine);
+        ctx->engine = NULL;
+        ctx->c = NULL;
+    }
+}
+
+
+/* ----- VN packet constructor ----- */
+
+/*
+ * Build a Version Negotiation datagram per RFC 9000 §17.2.1.
+ *
+ *   header_byte: caller chooses; must have 0x80 (long-header bit) set.
+ *   vn_dcid    : DCID field on the wire (peer's view of the destination).
+ *   vn_scid    : SCID field on the wire (peer's source CID).
+ *   versions   : array of versions to advertise; each emitted big-endian.
+ *
+ * Returns the total byte length written into out.
+ */
+static size_t
+build_vn_packet(unsigned char *out, size_t out_cap,
+    uint8_t header_byte,
+    const unsigned char *vn_dcid, uint8_t dcid_len,
+    const unsigned char *vn_scid, uint8_t scid_len,
+    const uint32_t *versions, uint32_t version_count)
+{
+    size_t need = 1 + 4 + 1 + dcid_len + 1 + scid_len + 4 * version_count;
+    if (need > out_cap) {
+        return 0;
+    }
+
+    size_t off = 0;
+    out[off++] = header_byte;
+    /* version field = 0x00000000 (marks the packet as a VN packet) */
+    out[off++] = 0x00;
+    out[off++] = 0x00;
+    out[off++] = 0x00;
+    out[off++] = 0x00;
+
+    out[off++] = dcid_len;
+    if (dcid_len > 0) {
+        memcpy(out + off, vn_dcid, dcid_len);
+        off += dcid_len;
+    }
+
+    out[off++] = scid_len;
+    if (scid_len > 0) {
+        memcpy(out + off, vn_scid, scid_len);
+        off += scid_len;
+    }
+
+    for (uint32_t i = 0; i < version_count; i++) {
+        uint32_t v = versions[i];
+        out[off++] = (unsigned char)((v >> 24) & 0xff);
+        out[off++] = (unsigned char)((v >> 16) & 0xff);
+        out[off++] = (unsigned char)((v >> 8) & 0xff);
+        out[off++] = (unsigned char)(v & 0xff);
+    }
+
+    return off;
+}
+
+
+/*
+ * Drive xqc_packet_parse_version_negotiation directly. Skips the long
+ * header dispatch and just populates pi_pkt with the wire CIDs the
+ * caller wants the parser to see. Returns the parser's return value.
+ */
+static xqc_int_t
+invoke_vn_parser(xqc_connection_t *c,
+    const unsigned char *wire_dcid, uint8_t wire_dcid_len,
+    const unsigned char *wire_scid, uint8_t wire_scid_len,
+    const uint32_t *versions, uint32_t version_count)
+{
+    /* Build a wire-format buffer purely so the parser has a real
+     * version-list region to walk (its position is set just past the
+     * SCID, matching xqc_packet_parse_long_header's contract).
+     */
+    unsigned char buf[256];
+    size_t total = build_vn_packet(buf, sizeof(buf), 0x80,
+                                   wire_dcid, wire_dcid_len,
+                                   wire_scid, wire_scid_len,
+                                   versions, version_count);
+    if (total == 0) {
+        return -XQC_EILLPKT;
+    }
+
+    xqc_packet_in_t pkt;
+    memset(&pkt, 0, sizeof(pkt));
+    xqc_packet_in_init(&pkt, buf, total, NULL, 0, 0);
+
+    /* xqc_packet_parse_long_header would have populated these fields
+     * before dispatching to the VN parser; emulate that here so we can
+     * exercise the parser in isolation.
+     */
+    pkt.pi_pkt.pkt_dcid.cid_len = wire_dcid_len;
+    if (wire_dcid_len > 0) {
+        memcpy(pkt.pi_pkt.pkt_dcid.cid_buf, wire_dcid, wire_dcid_len);
+    }
+    pkt.pi_pkt.pkt_scid.cid_len = wire_scid_len;
+    if (wire_scid_len > 0) {
+        memcpy(pkt.pi_pkt.pkt_scid.cid_buf, wire_scid, wire_scid_len);
+    }
+
+    /* Position pos past the long header prefix + DCID/SCID, exactly
+     * where the dispatch in xqc_packet_parse_long_header would land.
+     */
+    pkt.pos = (unsigned char *)pkt.buf + 1 + 4 + 1 + wire_dcid_len + 1 + wire_scid_len;
+    pkt.last = (unsigned char *)pkt.buf + total;
+
+    return xqc_packet_parse_version_negotiation(c, &pkt);
+}
+
+
+/* =====================  TEST CASES  ===================== */
+
+/*
+ * T1: a valid Version Negotiation carrying only a foreign version MUST
+ *     drive the client into CLOSED with conn_err = TRA_VERSION_NEGOTIATION_ERROR,
+ *     and MUST NOT cause a packet to be written (no CONNECTION_CLOSE).
+ */
+void
+xqc_test_vn_abort_on_unsupported_version(void)
+{
+    vn_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+
+    if (!vn_test_start_client(&ctx)) {
+        CU_FAIL("client engine bootstrap failed");
+        vn_test_teardown(&ctx);
+        return;
+    }
+
+    /* Sanity: the connection should be sitting in CLIENT_INITIAL_SENT
+     * after xqc_connect (driven synchronously by xqc_engine_conn_logic).
+     */
+    CU_ASSERT(ctx.c->conn_state == XQC_CONN_STATE_CLIENT_INITIAL_SENT);
+    CU_ASSERT(ctx.c->conn_err == 0);
+
+    /* Snapshot the buffer state so we can prove no extra write occurs. */
+    size_t buf_len_before = ctx.buf_len;
+    int    writes_before  = ctx.write_count;
+    unsigned char buf_snapshot[2048];
+    memcpy(buf_snapshot, ctx.buf, buf_len_before);
+
+    uint32_t versions[] = { 0xfaceb002 };  /* RFC 9000 reserved test version, deliberately not V1 */
+
+    xqc_int_t ret = invoke_vn_parser(ctx.c,
+                                     ctx.c->initial_scid.cid_buf, ctx.c->initial_scid.cid_len,
+                                     ctx.c->original_dcid.cid_buf, ctx.c->original_dcid.cid_len,
+                                     versions, 1);
+
+    /* Parser MUST surface the abort to the caller. */
+    CU_ASSERT(ret == -XQC_EVERSION_NEGOTIATION);
+
+    /* Connection state MUST be CLOSED. */
+    CU_ASSERT(ctx.c->conn_state == XQC_CONN_STATE_CLOSED);
+
+    /* conn_err MUST carry the library-internal VN abort code. */
+    CU_ASSERT(ctx.c->conn_err == TRA_VERSION_NEGOTIATION_ERROR);
+
+    /* Error / closing flags MUST be set. */
+    CU_ASSERT(ctx.c->conn_flag & XQC_CONN_FLAG_ERROR);
+    CU_ASSERT(ctx.c->conn_flag & XQC_CONN_FLAG_CLOSING_NOTIFY);
+
+    /* And critically: NO new packet was emitted (CONNECTION_CLOSE forbidden
+     * in the VN response because keys are not yet established). */
+    CU_ASSERT(ctx.write_count == writes_before);
+    CU_ASSERT(ctx.buf_len == buf_len_before);
+    CU_ASSERT(memcmp(ctx.buf, buf_snapshot, buf_len_before) == 0);
+
+    vn_test_teardown(&ctx);
+}
+
+
+/*
+ * T2: a VN packet whose Supported Version list contains the client's
+ *     current version MUST be discarded silently (treated as forged),
+ *     leaving the connection untouched.
+ */
+void
+xqc_test_vn_downgrade_protection_when_version_matches(void)
+{
+    vn_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+
+    if (!vn_test_start_client(&ctx)) {
+        CU_FAIL("client engine bootstrap failed");
+        vn_test_teardown(&ctx);
+        return;
+    }
+
+    CU_ASSERT(ctx.c->conn_state == XQC_CONN_STATE_CLIENT_INITIAL_SENT);
+    CU_ASSERT(ctx.c->conn_err == 0);
+    size_t buf_len_before = ctx.buf_len;
+    int    writes_before  = ctx.write_count;
+
+    /* Build a VN list that includes the client's current (negotiated)
+     * version. xqc_proto_version_value[XQC_VERSION_V1] == 0x00000001. */
+    extern const uint32_t xqc_proto_version_value[];
+    uint32_t versions[] = { xqc_proto_version_value[XQC_VERSION_V1], 0xdeadbeef };
+
+    xqc_int_t ret = invoke_vn_parser(ctx.c,
+                                     ctx.c->initial_scid.cid_buf, ctx.c->initial_scid.cid_len,
+                                     ctx.c->original_dcid.cid_buf, ctx.c->original_dcid.cid_len,
+                                     versions, 2);
+
+    /* RFC §6.2: the packet is discarded; the parser returns OK to signal
+     * "consumed, nothing to do". */
+    CU_ASSERT(ret == XQC_OK);
+
+    /* State and error must be untouched. */
+    CU_ASSERT(ctx.c->conn_state == XQC_CONN_STATE_CLIENT_INITIAL_SENT);
+    CU_ASSERT(ctx.c->conn_err == 0);
+    CU_ASSERT((ctx.c->conn_flag & XQC_CONN_FLAG_ERROR) == 0);
+
+    /* No new send. */
+    CU_ASSERT(ctx.write_count == writes_before);
+    CU_ASSERT(ctx.buf_len == buf_len_before);
+
+    vn_test_teardown(&ctx);
+}
+
+
+/*
+ * T3: a VN packet whose DCID does NOT echo the client's SCID MUST be
+ *     rejected with -XQC_EILLPKT and MUST NOT alter the connection.
+ */
+void
+xqc_test_vn_reject_when_dcid_mismatch(void)
+{
+    vn_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+
+    if (!vn_test_start_client(&ctx)) {
+        CU_FAIL("client engine bootstrap failed");
+        vn_test_teardown(&ctx);
+        return;
+    }
+
+    CU_ASSERT(ctx.c->conn_state == XQC_CONN_STATE_CLIENT_INITIAL_SENT);
+    size_t buf_len_before = ctx.buf_len;
+    int    writes_before  = ctx.write_count;
+
+    /* Corrupt the DCID by flipping every bit -- guaranteed unequal. */
+    unsigned char bogus_dcid[XQC_MAX_CID_LEN];
+    uint8_t       bogus_dcid_len = ctx.c->initial_scid.cid_len;
+    for (uint8_t i = 0; i < bogus_dcid_len; i++) {
+        bogus_dcid[i] = (unsigned char)~ctx.c->initial_scid.cid_buf[i];
+    }
+
+    uint32_t versions[] = { 0xfaceb002 };
+    xqc_int_t ret = invoke_vn_parser(ctx.c,
+                                     bogus_dcid, bogus_dcid_len,
+                                     ctx.c->original_dcid.cid_buf, ctx.c->original_dcid.cid_len,
+                                     versions, 1);
+
+    /* Reverse-CID validation should refuse the packet. */
+    CU_ASSERT(ret == -XQC_EILLPKT);
+
+    /* Connection unchanged. */
+    CU_ASSERT(ctx.c->conn_state == XQC_CONN_STATE_CLIENT_INITIAL_SENT);
+    CU_ASSERT(ctx.c->conn_err == 0);
+    CU_ASSERT((ctx.c->conn_flag & XQC_CONN_FLAG_ERROR) == 0);
+    CU_ASSERT(ctx.write_count == writes_before);
+    CU_ASSERT(ctx.buf_len == buf_len_before);
+
+    vn_test_teardown(&ctx);
+}
+
+
+/*
+ * T4: a VN packet whose SCID does NOT echo the client's DCID MUST be
+ *     rejected with -XQC_EILLPKT and MUST NOT alter the connection.
+ */
+void
+xqc_test_vn_reject_when_scid_mismatch(void)
+{
+    vn_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+
+    if (!vn_test_start_client(&ctx)) {
+        CU_FAIL("client engine bootstrap failed");
+        vn_test_teardown(&ctx);
+        return;
+    }
+
+    size_t buf_len_before = ctx.buf_len;
+    int    writes_before  = ctx.write_count;
+
+    unsigned char bogus_scid[XQC_MAX_CID_LEN];
+    uint8_t       bogus_scid_len = ctx.c->original_dcid.cid_len;
+    for (uint8_t i = 0; i < bogus_scid_len; i++) {
+        bogus_scid[i] = (unsigned char)~ctx.c->original_dcid.cid_buf[i];
+    }
+
+    uint32_t versions[] = { 0xfaceb002 };
+    xqc_int_t ret = invoke_vn_parser(ctx.c,
+                                     ctx.c->initial_scid.cid_buf, ctx.c->initial_scid.cid_len,
+                                     bogus_scid, bogus_scid_len,
+                                     versions, 1);
+
+    CU_ASSERT(ret == -XQC_EILLPKT);
+    CU_ASSERT(ctx.c->conn_state == XQC_CONN_STATE_CLIENT_INITIAL_SENT);
+    CU_ASSERT(ctx.c->conn_err == 0);
+    CU_ASSERT(ctx.write_count == writes_before);
+    CU_ASSERT(ctx.buf_len == buf_len_before);
+
+    vn_test_teardown(&ctx);
+}
+
+
+/*
+ * T5: a VN packet received after the client has left CLIENT_INITIAL_SENT
+ *     MUST be dropped (-XQC_ESTATE). Guards against attacker re-triggering
+ *     a second VN abort once the connection has progressed.
+ */
+void
+xqc_test_vn_reject_when_state_not_initial_sent(void)
+{
+    vn_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+
+    if (!vn_test_start_client(&ctx)) {
+        CU_FAIL("client engine bootstrap failed");
+        vn_test_teardown(&ctx);
+        return;
+    }
+
+    /* Force the connection past CLIENT_INITIAL_SENT. */
+    ctx.c->conn_state = XQC_CONN_STATE_CLIENT_INITIAL_RECVD;
+    size_t buf_len_before = ctx.buf_len;
+    int    writes_before  = ctx.write_count;
+
+    uint32_t versions[] = { 0xfaceb002 };
+    xqc_int_t ret = invoke_vn_parser(ctx.c,
+                                     ctx.c->initial_scid.cid_buf, ctx.c->initial_scid.cid_len,
+                                     ctx.c->original_dcid.cid_buf, ctx.c->original_dcid.cid_len,
+                                     versions, 1);
+
+    CU_ASSERT(ret == -XQC_ESTATE);
+
+    /* State stays where we put it; no abort triggered. */
+    CU_ASSERT(ctx.c->conn_state == XQC_CONN_STATE_CLIENT_INITIAL_RECVD);
+    CU_ASSERT(ctx.c->conn_err == 0);
+    CU_ASSERT((ctx.c->conn_flag & XQC_CONN_FLAG_ERROR) == 0);
+    CU_ASSERT(ctx.write_count == writes_before);
+    CU_ASSERT(ctx.buf_len == buf_len_before);
+
+    vn_test_teardown(&ctx);
+}
+
+
+/*
+ * T6: a VN packet advertising MANY foreign versions still MUST trigger
+ *     the abort; the client must not invent a fallback negotiation.
+ *     Also smoke-tests that the parser's version-list buffering is sane
+ *     for non-trivial counts.
+ */
+void
+xqc_test_vn_abort_on_multi_unsupported_versions(void)
+{
+    vn_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+
+    if (!vn_test_start_client(&ctx)) {
+        CU_FAIL("client engine bootstrap failed");
+        vn_test_teardown(&ctx);
+        return;
+    }
+
+    CU_ASSERT(ctx.c->conn_state == XQC_CONN_STATE_CLIENT_INITIAL_SENT);
+    size_t buf_len_before = ctx.buf_len;
+    int    writes_before  = ctx.write_count;
+
+    uint32_t versions[] = {
+        0xfaceb002, 0xfaceb003, 0xff000020, 0xff00001c,
+        0x11223344, 0x55667788, 0x99aabbcc, 0xddeeff00
+    };
+    uint32_t vcount = sizeof(versions) / sizeof(versions[0]);
+
+    xqc_int_t ret = invoke_vn_parser(ctx.c,
+                                     ctx.c->initial_scid.cid_buf, ctx.c->initial_scid.cid_len,
+                                     ctx.c->original_dcid.cid_buf, ctx.c->original_dcid.cid_len,
+                                     versions, vcount);
+
+    CU_ASSERT(ret == -XQC_EVERSION_NEGOTIATION);
+    CU_ASSERT(ctx.c->conn_state == XQC_CONN_STATE_CLOSED);
+    CU_ASSERT(ctx.c->conn_err == TRA_VERSION_NEGOTIATION_ERROR);
+    CU_ASSERT(ctx.c->conn_flag & XQC_CONN_FLAG_ERROR);
+    CU_ASSERT(ctx.write_count == writes_before);
+    CU_ASSERT(ctx.buf_len == buf_len_before);
+
+    vn_test_teardown(&ctx);
+}

--- a/tests/unittest/xqc_vn_test.h
+++ b/tests/unittest/xqc_vn_test.h
@@ -1,0 +1,32 @@
+/**
+ * @copyright Copyright (c) 2022, Alibaba Group Holding Limited
+ */
+
+#ifndef XQC_VN_TEST_H
+#define XQC_VN_TEST_H
+
+/*
+ * Validation suite for the RFC 9000 Section 6.2 Version Negotiation
+ * abort behaviour. Each test exercises one branch of
+ * xqc_packet_parse_version_negotiation in isolation.
+ */
+
+/* Happy-path abort: valid VN, peer offers a foreign version. */
+void xqc_test_vn_abort_on_unsupported_version(void);
+
+/* Downgrade defence: VN echoes the client's current version. */
+void xqc_test_vn_downgrade_protection_when_version_matches(void);
+
+/* CID reverse validation: VN.DCID != client.SCID is rejected. */
+void xqc_test_vn_reject_when_dcid_mismatch(void);
+
+/* CID reverse validation: VN.SCID != client.DCID is rejected. */
+void xqc_test_vn_reject_when_scid_mismatch(void);
+
+/* State gate: a late VN after the initial flight is dropped. */
+void xqc_test_vn_reject_when_state_not_initial_sent(void);
+
+/* Abort even when the VN list contains multiple foreign versions. */
+void xqc_test_vn_abort_on_multi_unsupported_versions(void);
+
+#endif /* XQC_VN_TEST_H */


### PR DESCRIPTION
## Summary

- `xqc_packet_parse_version_negotiation` now obeys RFC 9000 §6.2 by
  abandoning the connection attempt instead of silently switching
  `c->version` and leaving a TODO behind. The abort is signalled via the
  existing `conn_close_notify` callback with errno
  `TRA_VERSION_NEGOTIATION_ERROR` (0x53, library-internal) so the upper
  layer can decide whether to reconnect with one of the server's
  advertised versions.
- No `CONNECTION_CLOSE` is emitted - the VN stage has no packet
  protection and the Initial keys are derived from the original
  version. The parser fast-paths the connection straight to `CLOSED`.
- Section 17.2.1's DCID reverse check is added (the SCID side was
  already there).
- The downgrade-protection check in the same function used to compare
  the wire-format version list against `c->version`, which stores an
  internal enum. That only matched by coincidence for V1; fixed by
  routing the enum through `xqc_proto_version_value[]` before comparing.

## Why

Before this change a client that hit a server requiring a different
version would loop on Initial retransmission until idle timeout: the
parser set `c->version` to a value the keys did not match and
`discard_vn_flag` swallowed every subsequent VN. Version negotiation was
effectively non-functional and the connection stayed in an undefined
state - both behaviours called out in the issue and in the legacy TODO
comment.

ngtcp2 and quiche both expose the abort to the caller
(`NGTCP2_ERR_RECV_VERSION_NEGOTIATION` in `ngtcp2/ngtcp2:lib/ngtcp2_err.c`,
`Error::UnknownVersion` in `cloudflare/quiche:quiche/src/error.rs`); this
PR takes the same shape, which keeps the application in control of
version-selection and downgrade-attack policy.

## Test plan

- [x] Six new CUnit cases in `tests/unittest/xqc_vn_test.c`:
  - VN with an unsupported version → abort + correct errno + no wire CC
  - VN listing the current wire version → discarded (downgrade
    protection)
  - VN with wrong DCID / wrong SCID → `-XQC_EILLPKT`, connection
    untouched
  - VN received after `CLIENT_INITIAL_RECVD` → `-XQC_ESTATE`, no double
    abort
  - VN with eight unsupported versions → still aborts (does not pick a
    version on the client's behalf)
- [x] `./tests/run_tests` → 50/50 PASS, 9,417,106 asserts pass,
      0.434 s
- [x] Builds clean with BoringSSL (libxquic + run_tests, no warnings)

Fixes: #624