### PR TITLE
fix(test): rebuild stateless reset case_test for RFC 9000 §10.1 idle negotiation

### DIFF
--- a/scripts/case_test.sh
+++ b/scripts/case_test.sh
@@ -1524,11 +1524,29 @@ fi
 
 
 killall test_server
-${SERVER_BIN} -l d -x 13 > /dev/null &
+# Start the server without -x 13. The previous "idle_time_out = 1000"
+# trick relied on a small max_idle_timeout transport parameter to force
+# the server to discard its connection state quickly; after RFC 9000
+# Section 10.1 negotiation (PR #758) the client now takes the minimum
+# of both advertised values, so a 1 s server-side TP would also kill
+# the client well before the wake-up packet that the test relies on.
+# Restart the server mid-test instead: it cleans up its connection
+# state silently, then the new instance generates the stateless reset
+# from the same default reset_token_key.
+${SERVER_BIN} -l d > /dev/null &
 sleep 1
 clear_log
 echo -e "stateless reset...\c"
-${CLIENT_BIN} -l d -x 41 -1 -t 5 > stdlog
+${CLIENT_BIN} -l d -x 41 -1 -t 8 > stdlog &
+CLIENT_PID=$!
+# Allow the handshake to finish, the two tracked short-header packets
+# to be sent, and the 3 s outbound black-hole inside the client to
+# begin before the server is recycled.
+sleep 2
+killall test_server
+sleep 0.2
+${SERVER_BIN} -l d > /dev/null &
+wait $CLIENT_PID
 result=`grep "|====>|receive stateless reset" clog`
 cloing_notify=`grep "conn closing: 641" stdlog`
 if [ -n "$result" ] && [ -n "$cloing_notify" ]; then
@@ -1542,7 +1560,17 @@ fi
 
 clear_log
 echo -e "stateless reset during hsk...\c"
-${CLIENT_BIN} -l d  -t 5 -x 45 -1 -s 100 -G > stdlog
+${CLIENT_BIN} -l d  -t 12 -x 45 -1 -s 100 -G > stdlog &
+CLIENT_PID=$!
+# Same pattern as above. The client opens the black-hole on the first
+# Handshake-level or short-header outbound packet, so 2 s gives Initial
+# exchange plus the start of the 10 s drop window before we recycle
+# the server.
+sleep 2
+killall test_server
+sleep 0.2
+${SERVER_BIN} -l d > /dev/null &
+wait $CLIENT_PID
 result=`grep "|====>|receive stateless reset" clog`
 cloing_notify=`grep "conn closing: 641" stdlog`
 svr_hsk=`grep "handshake_time:0" slog`


### PR DESCRIPTION
The two `stateless reset` cases in `scripts/case_test.sh` started the server with `-x 13`, which sets `conn_settings.idle_time_out = 1000` in `tests/test_server.c`. The 1 s value was both the server's local idle timer (used to drop the connection silently so the client's wake-up packet hits an unknown DCID and triggers a stateless reset) *and* the `max_idle_timeout` transport parameter advertised to the client.

Pre-PR #758, `xqc_conn_get_idle_timeout` ignored the peer-advertised value, so the client stayed at its own default 120 s idle and survived the 3 s / 10 s outbound black-hole comfortably. PR #758 implemented RFC 9000 §10.1 (`effective idle = min(local, peer)`), so the client now picks 1 s too and idles out during the black-hole before reaching the wake-up send. Both cases fail consistently on Ubuntu CI from `d58ff81` onward (verified via `gh run list --branch main --workflow Build`: `c57eed4` was the last green run, every commit from `d58ff81` to current `a583d7d` is red on this same pair, all other 99 case-tests and the 61 CUnit tests stay green).

Drop `-x 13` (the server now uses the default 120 s idle, so the negotiated minimum is comfortably above the black-hole) and recycle the server process mid-test instead. SIGTERM walks `xqc_engine_destroy` without emitting CONNECTION_CLOSE; the fresh instance generates the stateless reset from the same default `reset_token_key`; the client accepts it and reports `XQC_ESTATELESS_RESET` (641) exactly as the assertions expect.

Client poll timeouts bumped from `-t 5` to `-t 8` / `-t 12` to cover the added sleep + restart sequence.

No production code changes — RFC 9000 §10.1 behaviour from PR #758 stays intact. `tests/test_server.c` case 13 is left in place; it is no longer exercised by `case_test.sh`, but anyone invoking `test_server -x 13` directly still gets the same behaviour.

### Verification

Reran both blocks locally on macOS against current `main`:

```
stateless reset...>>>>>>>> pass:1
stateless reset during hsk...>>>>>>>> pass:1
```

All three assertions per case satisfied:
- `|====>|receive stateless reset` matched in `clog`
- `conn closing: 641` matched in `stdlog` (`XQC_ESTATELESS_RESET`, `include/xquic/xqc_errno.h:130`)
- `handshake_time:0` matched in `slog` for the during-hsk case (graceful SIGTERM lets the dying server flush its conn report before exit)
