### PR TITLE
fix issue 748: reject incoming HTTP/3 headers with uppercase field names

### DIFF
--- a/harness/spec/validation.md
+++ b/harness/spec/validation.md
@@ -100,7 +100,7 @@ its case is retired so later changes cannot reuse it.
 | `[705, 799]` | QUIC Transport core | None |
 | `[800, 899]` | Recovery and congestion control | None |
 | `[900, 999]` | QUIC-TLS | None |
-| `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1012` |
+| `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1014` |
 | `[1100, 1149]` | QPACK | None |
 | `[1150, 1199]` | HTTP priority | None |
 | `[1200, 1299]` | QUIC DATAGRAM | None |

--- a/include/xquic/xqc_errno.h
+++ b/include/xquic/xqc_errno.h
@@ -287,6 +287,7 @@ typedef enum {
     XQC_H3_MISSING_SETTINGS             = 834,  /**< first frame on control stream is not SETTINGS, RFC 9114 §6.2.1 */
     XQC_H3_REQUEST_FRAME_UNEXPECTED     = 835,  /**< control-only frame received on request stream (RFC 9114 §7.2) */
     XQC_H3_INVALID_MAX_PUSH_ID          = 836,  /**< RFC 9114 §7.2.7 */
+    XQC_H3_EMALFORMED_HEADER            = 837,  /**< malformed HTTP/3 header field (RFC 9114 4.1.2 / 4.2) */
 
     XQC_H3_ERR_MAX,
 } xqc_h3_error_t;

--- a/scripts/case_test.sh
+++ b/scripts/case_test.sh
@@ -440,6 +440,7 @@ else
 fi
 
 
+
 clear_log
 echo -e "forbidden_header_e2e ...\c"
 ${CLIENT_BIN} -s 5120 -l d -t 1 -E -x 55 >> clog
@@ -5570,5 +5571,45 @@ fi
 
 killall test_server 2> /dev/null
 rm -f h3_field_section_server.log
+
+
+## RFC 9114 Sections 4.2 and 4.1.2 field-name validation
+
+clear_log
+rm -f test_session xqc_token tp_localhost
+${SERVER_BIN} -l d -e -x 1013 > /dev/null &
+sleep 1
+echo -e "HTTP/3 lowercase response field name is accepted ...\c"
+${CLIENT_BIN} -G -l d -t 1 -x 1013 >> clog
+lowercase_ok=`grep "lowercase_header_received:1" clog`
+stream_ok=`grep "lowercase_header_request_succeeded:1" clog`
+if [ -n "$lowercase_ok" ] && [ -n "$stream_ok" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "h3_lowercase_response_field_name_accepted" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "h3_lowercase_response_field_name_accepted" "fail"
+fi
+
+killall test_server 2> /dev/null
+clear_log
+rm -f test_session xqc_token tp_localhost
+${SERVER_BIN} -l d -e -x 1014 > /dev/null &
+sleep 1
+echo -e "HTTP/3 uppercase response field name resets only stream ...\c"
+${CLIENT_BIN} -G -l d -n 2 -t 2 -x 1014 >> clog
+stream_error_ok=`grep "uppercase_header_stream_error:1" clog`
+connection_reuse_ok=`grep "post_error_request_succeeded:1" clog`
+transport_error=`grep "conn_err:1" clog`
+if [ -n "$stream_error_ok" ] && [ -n "$connection_reuse_ok" ] \
+    && [ -z "$transport_error" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "h3_uppercase_response_field_name_rejected" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "h3_uppercase_response_field_name_rejected" "fail"
+fi
+
+killall test_server 2> /dev/null
 
 cd -

--- a/src/http3/qpack/xqc_qpack.c
+++ b/src/http3/qpack/xqc_qpack.c
@@ -474,6 +474,24 @@ xqc_qpack_enc_headers(xqc_qpack_t *qpk, uint64_t stream_id,
 }
 
 
+xqc_bool_t
+xqc_qpack_field_name_has_uppercase(const unsigned char *name, size_t name_len)
+{
+    /*
+     * RFC 9114 4.2 / 4.1.2: any uppercase ASCII character in an HTTP/3
+     * field name makes the message malformed. Pseudo-header names start
+     * with ':' (0x3A) which is below 'A', so the same scan covers them.
+     */
+    for (size_t i = 0; i < name_len; i++) {
+        unsigned char c = name[i];
+        if (c >= 'A' && c <= 'Z') {
+            return XQC_TRUE;
+        }
+    }
+    return XQC_FALSE;
+}
+
+
 ssize_t
 xqc_qpack_dec_headers(xqc_qpack_t *qpk, xqc_rep_ctx_t *req_ctx, unsigned char *data,
     size_t data_len, xqc_http_headers_t *headers, xqc_bool_t fin, xqc_bool_t *blocked)

--- a/src/http3/qpack/xqc_qpack.h
+++ b/src/http3/qpack/xqc_qpack.h
@@ -171,4 +171,11 @@ xqc_int_t xqc_qpack_enc_headers(xqc_qpack_t *qpk, uint64_t stream_id,
 void xqc_qpack_set_compat_dup(xqc_qpack_t *qpk, xqc_bool_t compat);
 #endif
 
+/**
+ * @brief test whether a decoded HTTP/3 field name contains any uppercase
+ *        ASCII character (RFC 9114 4.2 forbids them on the wire).
+ * @return XQC_TRUE if at least one byte in [A-Z] is found, XQC_FALSE otherwise.
+ */
+xqc_bool_t xqc_qpack_field_name_has_uppercase(const unsigned char *name, size_t name_len);
+
 #endif

--- a/src/http3/xqc_h3_request.c
+++ b/src/http3/xqc_h3_request.c
@@ -7,6 +7,7 @@
 #include "src/transport/xqc_engine.h"
 #include "src/http3/xqc_h3_conn.h"
 #include "src/http3/xqc_h3_ctx.h"
+#include "src/http3/qpack/xqc_qpack.h"
 #include "src/common/xqc_time.h"
 
 
@@ -867,6 +868,27 @@ xqc_h3_request_on_recv_header(xqc_h3_request_t *h3r)
                         (char *)hdr->name.iov_base);
                 return -XQC_H3_INVALID_HEADER;
             }
+        }
+    }
+
+    /*
+     * RFC 9114 4.2: a request or response containing uppercase characters
+     * in field names MUST be treated as malformed. 4.1.2 routes malformed
+     * messages through H3_MESSAGE_ERROR. The QPACK layer is purposefully
+     * byte-transparent (it round-trips arbitrary bytes for codec testing),
+     * so this HTTP-semantic check lives at the H3 boundary instead.
+     */
+    for (size_t i = 0; i < headers->count; i++) {
+        xqc_http_header_t *hdr = &headers->headers[i];
+        if (xqc_qpack_field_name_has_uppercase(hdr->name.iov_base,
+                                               hdr->name.iov_len))
+        {
+            xqc_log(h3r->h3_stream->log, XQC_LOG_ERROR,
+                    "|uppercase character in field name|conn:%p|"
+                    "stream_id:%ui|field_index:%uz|name_len:%uz|",
+                    h3r->h3_stream->h3c->conn, h3r->h3_stream->stream_id,
+                    i, hdr->name.iov_len);
+            return -XQC_H3_EMALFORMED_HEADER;
         }
     }
 

--- a/src/http3/xqc_h3_stream.c
+++ b/src/http3/xqc_h3_stream.c
@@ -1605,8 +1605,8 @@ xqc_h3_stream_process_in(xqc_h3_stream_t *h3s, unsigned char *data, size_t data_
             if (h3s->type == XQC_H3_STREAM_TYPE_BYTESTEAM) {
                 errcode = -XQC_H3_EPROC_BYTESTREAM;
             }
-            
-            if (processed == -XQC_H3_INVALID_HEADER
+            if ((processed == -XQC_H3_INVALID_HEADER
+                 || processed == -XQC_H3_EMALFORMED_HEADER)
                 && h3c->conn->conn_err == 0)
             {
                 /*
@@ -1831,7 +1831,9 @@ xqc_h3_stream_process_data(xqc_stream_t *stream, xqc_h3_stream_t *h3s, xqc_bool_
         ret = xqc_h3_stream_process_in(h3s, buff, read, *fin);
         if (ret != XQC_OK) {
             xqc_log(h3c->log, XQC_LOG_ERROR, "|xqc_h3_stream_process_in error|%d|", ret);
-            XQC_H3_CONN_ERR(h3s->h3c, H3_INTERNAL_ERROR, ret);
+            if (h3s->stream_err == 0) {
+                XQC_H3_CONN_ERR(h3s->h3c, H3_INTERNAL_ERROR, ret);
+            }
             return ret;
         }
 
@@ -1887,6 +1889,12 @@ xqc_h3_stream_process_blocked_stream(xqc_h3_stream_t *h3s)
         ssize_t processed = xqc_h3_stream_process_request(h3s, buf->data + buf->consumed_len,
                                                           buf->data_len - buf->consumed_len, buf->fin_flag);
         if (processed < 0) {
+            if (processed == -XQC_H3_EMALFORMED_HEADER) {
+                xqc_stream_close_with_error(h3s->stream,
+                                            H3_MESSAGE_ERROR);
+                h3s->ref_cnt--;
+                return XQC_OK;
+            }
             h3s->ref_cnt--;
             return processed;
         }

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -15,6 +15,7 @@
 #include <inttypes.h>
 #include <xquic/xquic.h>
 #include <xquic/xquic_typedef.h>
+#include <xquic/xqc_errno.h>
 #include <xquic/xqc_http3.h>
 #include "src/http3/xqc_h3_conn.h"
 #include "src/http3/xqc_h3_request.h"
@@ -77,6 +78,8 @@ printf_null(const char *format, ...)
 #define XQC_TEST_CASE_H3_SINGLE_VINT_OVERLONG 1008
 #define XQC_TEST_CASE_H3_FIELD_SECTION_VALID 1011
 #define XQC_TEST_CASE_H3_FIELD_SECTION_OVER_LIMIT 1012
+#define XQC_TEST_CASE_H3_LOWERCASE_RESPONSE 1013
+#define XQC_TEST_CASE_H3_UPPERCASE_RESPONSE 1014
 
 typedef struct user_conn_s user_conn_t;
 
@@ -3119,6 +3122,18 @@ xqc_client_request_read_notify(xqc_h3_request_t *h3_request, xqc_request_notify_
 
         for (int i = 0; i < headers->count; i++) {
             printf("%s = %s\n", (char *)headers->headers[i].name.iov_base, (char *)headers->headers[i].value.iov_base);
+
+            if ((g_test_case == XQC_TEST_CASE_H3_LOWERCASE_RESPONSE
+                 || g_test_case == XQC_TEST_CASE_H3_UPPERCASE_RESPONSE)
+                && headers->headers[i].name.iov_len == 16
+                && memcmp(headers->headers[i].name.iov_base,
+                          "x-uppercase-test", 16) == 0
+                && headers->headers[i].value.iov_len == 9
+                && memcmp(headers->headers[i].value.iov_base,
+                          "lowercase", 9) == 0)
+            {
+                printf("lowercase_header_received:1\n");
+            }
         }
 
         user_stream->header_recvd = 1;
@@ -3265,8 +3280,26 @@ xqc_client_request_close_notify(xqc_h3_request_t *h3_request, void *user_data)
     printf("retx:%u, sent:%u, max_pto:%u\n", stats.retrans_cnt,
            stats.sent_pkt_cnt, stats.max_pto_backoff);
 
+    if (g_test_case == XQC_TEST_CASE_H3_LOWERCASE_RESPONSE
+        && stats.stream_err == 0
+        && user_stream->header_recvd)
+    {
+        printf("lowercase_header_request_succeeded:1\n");
+    }
+
+    if (g_test_case == XQC_TEST_CASE_H3_UPPERCASE_RESPONSE) {
+        if (stats.stream_err == H3_MESSAGE_ERROR) {
+            printf("uppercase_header_stream_error:1\n");
+
+        } else if (stats.stream_err == 0 && user_stream->header_recvd) {
+            printf("post_error_request_succeeded:1\n");
+        }
+    }
+
     if (g_echo_check
         && !(g_test_case == XQC_TEST_CASE_H3_FIELD_SECTION_OVER_LIMIT
+             && stats.stream_err == H3_MESSAGE_ERROR)
+        && !(g_test_case == XQC_TEST_CASE_H3_UPPERCASE_RESPONSE
              && stats.stream_err == H3_MESSAGE_ERROR))
     {
         int pass = 0;

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -19,6 +19,7 @@
 
 #include "platform.h"
 #include "src/http3/xqc_h3_conn.h"
+#include "src/http3/xqc_h3_request.h"
 #include "src/transport/xqc_conn.h"
 #include "src/transport/xqc_packet_out.h"
 
@@ -61,6 +62,8 @@ printf_null(const char *format, ...)
 #define XQC_TEST_CASE_H3_SINGLE_VINT_OVERLONG 1008
 #define XQC_TEST_CASE_H3_FIELD_SECTION_VALID 1011
 #define XQC_TEST_CASE_H3_FIELD_SECTION_OVER_LIMIT 1012
+#define XQC_TEST_CASE_H3_LOWERCASE_RESPONSE 1013
+#define XQC_TEST_CASE_H3_UPPERCASE_RESPONSE 1014
 
 extern long xqc_random(void);
 extern xqc_usec_t xqc_now();
@@ -1268,8 +1271,10 @@ xqc_client_h3_send_pure_fin(int fd, short what, void *arg)
 int
 xqc_server_request_send(xqc_h3_request_t *h3_request, user_stream_t *user_stream)
 {
+    static int uppercase_response_sent;
     ssize_t ret = 0;
     int header_cnt = 6;
+    int send_uppercase;
     xqc_http_header_t header[MAX_HEADER] = {
         {
             .name   = {.iov_base = ":method", .iov_len = 7},
@@ -1302,6 +1307,45 @@ xqc_server_request_send(xqc_h3_request_t *h3_request, user_stream_t *user_stream
             .flags  = 0,
         },
     };
+
+    send_uppercase = g_test_case == XQC_TEST_CASE_H3_UPPERCASE_RESPONSE
+                     && !uppercase_response_sent;
+    if (g_test_case == XQC_TEST_CASE_H3_LOWERCASE_RESPONSE
+        || (g_test_case == XQC_TEST_CASE_H3_UPPERCASE_RESPONSE
+            && !send_uppercase))
+    {
+        xqc_http_header_t lowercase_name_hdr = {
+            .name = {
+                .iov_base = "x-uppercase-test",
+                .iov_len = 16,
+            },
+            .value = {
+                .iov_base = "lowercase",
+                .iov_len = 9,
+            },
+            .flags = 0,
+        };
+        header[header_cnt++] = lowercase_name_hdr;
+
+    } else if (send_uppercase) {
+        /*
+         * RFC 9114 Section 4.2: uppercase field names make the response
+         * malformed. Bypass only the public sender's normalization inside
+         * this test peer so the client receives the invalid wire input.
+         */
+        xqc_http_header_t uppercase_name_hdr = {
+            .name = {
+                .iov_base = "X-Uppercase-Test",
+                .iov_len = 16,
+            },
+            .value = {
+                .iov_base = "rejected",
+                .iov_len = 8,
+            },
+            .flags = 0,
+        };
+        header[header_cnt++] = uppercase_name_hdr;
+    }
 
     if (g_test_case == 9) {
         memset(test_long_value, 'a', XQC_TEST_LONG_HEADER_LEN - 1);
@@ -1338,7 +1382,16 @@ xqc_server_request_send(xqc_h3_request_t *h3_request, user_stream_t *user_stream
     }
 
     if (user_stream->header_sent == 0) {
-        ret = xqc_h3_request_send_headers(h3_request, &headers, header_only && send_fin);
+        if (send_uppercase) {
+            uppercase_response_sent = 1;
+            ret = xqc_h3_stream_send_headers(h3_request->h3_stream, &headers,
+                                             header_only && send_fin);
+
+        } else {
+            ret = xqc_h3_request_send_headers(h3_request, &headers,
+                                              header_only && send_fin);
+        }
+
         if (ret < 0) {
             printf("xqc_h3_request_send_headers error %zd\n", ret);
             return ret;

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -181,6 +181,12 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite, "xqc_test_h3_forbidden_headers_rejected", xqc_test_h3_forbidden_headers_rejected)
         || !CU_add_test(pSuite, "xqc_test_h3_allowed_headers_pass", xqc_test_h3_allowed_headers_pass)
         || !CU_add_test(pSuite, "xqc_test_h3_blocked_stream_limit_uses_local", xqc_test_h3_blocked_stream_limit_uses_local)
+        /* issue #748: RFC 9114 §4.2 uppercase field name rejection */
+        || !CU_add_test(pSuite, "xqc_test_h3_field_name_uppercase_rejection", xqc_test_h3_field_name_uppercase_rejection)
+        || !CU_add_test(pSuite, "xqc_test_h3_lowercase_field_name_stream_accepted",
+                        xqc_test_h3_lowercase_field_name_stream_accepted)
+        || !CU_add_test(pSuite, "xqc_test_h3_uppercase_field_name_stream_rejected",
+                        xqc_test_h3_uppercase_field_name_stream_rejected)
         || !CU_add_test(pSuite, "xqc_test_stable", xqc_test_stable)
         || !CU_add_test(pSuite, "xqc_test_dtable", xqc_test_dtable)
         || !CU_add_test(pSuite, "test_2d_hash_table", test_2d_hash_table)

--- a/tests/unittest/xqc_h3_test.c
+++ b/tests/unittest/xqc_h3_test.c
@@ -941,8 +941,18 @@ xqc_test_h3_recv_header_field_section_size()
     xqc_init_list_head(&h3r->body_buf);
 
     xqc_http_headers_t *hdr = &h3r->h3_header[0];
-    hdr->headers  = NULL;
-    hdr->capacity = 0;
+    xqc_http_header_t fake_hdrs[2] = {
+        {
+            .name = {.iov_base = (void *)"x", .iov_len = 1},
+            .value = {.iov_base = (void *)"v", .iov_len = 1},
+        },
+        {
+            .name = {.iov_base = (void *)"y", .iov_len = 1},
+            .value = {.iov_base = (void *)"v", .iov_len = 1},
+        },
+    };
+    hdr->headers  = fake_hdrs;
+    hdr->capacity = 2;
 
     /* regression for issue 751: total_len < limit but
        total_len + count*32 > limit. Pre-fix this would have been accepted. */
@@ -977,6 +987,7 @@ xqc_test_h3_recv_header_field_section_size()
     ret = xqc_h3_request_on_recv_header(h3r);
     CU_ASSERT_EQUAL(ret, XQC_OK);
 
+    hdr->headers = NULL;
     for (size_t i = 0; i < XQC_H3_REQUEST_MAX_HEADERS_CNT; i++) {
         xqc_h3_headers_free(&h3r->h3_header[i]);
     }
@@ -2136,4 +2147,228 @@ xqc_test_h3_settings_frame_size_limit()
     ret = xqc_h3_frm_parse(normal_settings, sizeof(normal_settings), &pctx);
     /* normal-sized SETTINGS frame should parse successfully */
     CU_ASSERT(ret >= 0);
+}
+
+
+/*
+ * Issue #748 regression test.
+ *
+ * RFC 9114 4.2 says any request or response containing uppercase
+ * characters in field names MUST be treated as malformed, and 4.1.2
+ * routes malformed messages to a stream error of type H3_MESSAGE_ERROR.
+ * The xquic encoder already silently lowercases on send, but the
+ * receiver had no check at all -- xqc_qpack_dec_headers handed any
+ * decoded header straight to the application without validating the
+ * name was lowercase. This test exercises the new helper that powers
+ * the receive-side guard.
+ *
+ * The helper is a pure byte scan, so the test drives it directly
+ * with stack-allocated names rather than going through QPACK encoding.
+ * Pseudo-header names (which start with ':') go through the same
+ * scan: ':' is 0x3A which sits below 'A' = 0x41, so a pseudo-header
+ * name like ":Method" is caught on the 'M', exactly the same path
+ * as a regular field.
+ */
+void
+xqc_test_h3_field_name_uppercase_rejection()
+{
+    /* all-lowercase regular field name -> accepted */
+    const unsigned char ua_lc[] = "user-agent";
+    CU_ASSERT(xqc_qpack_field_name_has_uppercase(ua_lc, sizeof(ua_lc) - 1)
+              == XQC_FALSE);
+
+    /* mixed case regular field name -> rejected */
+    const unsigned char ua_mc[] = "User-Agent";
+    CU_ASSERT(xqc_qpack_field_name_has_uppercase(ua_mc, sizeof(ua_mc) - 1)
+              == XQC_TRUE);
+
+    /* single uppercase byte -> rejected */
+    const unsigned char single_u[] = "X";
+    CU_ASSERT(xqc_qpack_field_name_has_uppercase(single_u, sizeof(single_u) - 1)
+              == XQC_TRUE);
+
+    /* all-uppercase -> rejected */
+    const unsigned char all_u[] = "ACCEPT";
+    CU_ASSERT(xqc_qpack_field_name_has_uppercase(all_u, sizeof(all_u) - 1)
+              == XQC_TRUE);
+
+    /* empty name -> accepted (the helper is name-only; empty-name
+     * malformed handling lives elsewhere) */
+    CU_ASSERT(xqc_qpack_field_name_has_uppercase((const unsigned char *)"", 0)
+              == XQC_FALSE);
+
+    /* lowercase pseudo-header -> accepted */
+    const unsigned char pseudo_lc[] = ":method";
+    CU_ASSERT(xqc_qpack_field_name_has_uppercase(pseudo_lc, sizeof(pseudo_lc) - 1)
+              == XQC_FALSE);
+
+    /* uppercase in pseudo-header -> rejected (RFC 9114 4.3 routes
+     * this through "undefined pseudo-header" but the byte scan
+     * catches it first) */
+    const unsigned char pseudo_uc[] = ":Method";
+    CU_ASSERT(xqc_qpack_field_name_has_uppercase(pseudo_uc, sizeof(pseudo_uc) - 1)
+              == XQC_TRUE);
+
+    /* boundary characters around A-Z -> not flagged */
+    const unsigned char at_sign[] = "@";  /* 0x40, just below 'A' */
+    CU_ASSERT(xqc_qpack_field_name_has_uppercase(at_sign, sizeof(at_sign) - 1)
+              == XQC_FALSE);
+    const unsigned char open_bracket[] = "[";  /* 0x5B, just above 'Z' */
+    CU_ASSERT(xqc_qpack_field_name_has_uppercase(open_bracket,
+                                                 sizeof(open_bracket) - 1)
+              == XQC_FALSE);
+
+    /* high-bit byte (0xff) -> not flagged. Such a byte is invalid in
+     * an HTTP/3 field name per RFC 9110 token rules, but that is a
+     * separate validation -- the helper is scoped to A-Z. */
+    const unsigned char high_bit[] = { 0xff, 0x00 };
+    CU_ASSERT(xqc_qpack_field_name_has_uppercase(high_bit, 1) == XQC_FALSE);
+
+    /* uppercase deep inside an otherwise lowercase name -> rejected.
+     * Catches the off-by-one of an early-exit-only-on-first-byte loop. */
+    const unsigned char trailing_uc[] = "x-forwarded-For";
+    CU_ASSERT(xqc_qpack_field_name_has_uppercase(trailing_uc,
+                                                 sizeof(trailing_uc) - 1)
+              == XQC_TRUE);
+
+    /*
+     * Drive xqc_h3_request_on_recv_header with fake header data containing
+     * an uppercase field name.  This exercises the full error propagation
+     * path (helper -> H3_MESSAGE_ERROR -> -XQC_H3_EMALFORMED_HEADER)
+     * without touching the sender path or requiring a real wire exchange.
+     */
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_FATAL(conn != NULL);
+
+    if (conn->alpn) {
+        xqc_free(conn->alpn);
+    }
+    conn->alpn_len = strlen(XQC_ALPN_H3);
+    conn->alpn = xqc_calloc(1, conn->alpn_len + 1);
+    xqc_memcpy(conn->alpn, XQC_ALPN_H3, conn->alpn_len);
+
+    xqc_h3_conn_t *h3c = xqc_h3_conn_create(conn, NULL);
+    CU_ASSERT_FATAL(h3c != NULL);
+
+    conn->conn_flow_ctl.fc_max_streams_uni_can_send = 16;
+
+    xqc_stream_t *stream = xqc_create_stream_with_conn(conn,
+                                                       XQC_UNDEFINE_STREAM_ID,
+                                                       XQC_CLI_UNI, NULL, NULL);
+    CU_ASSERT_FATAL(stream != NULL);
+
+    xqc_h3_stream_t *h3s = xqc_h3_stream_create(h3c, stream,
+                                                XQC_H3_STREAM_TYPE_CONTROL,
+                                                NULL);
+    CU_ASSERT_FATAL(h3s != NULL);
+
+    xqc_h3_request_t *h3r = xqc_calloc(1, sizeof(xqc_h3_request_t));
+    CU_ASSERT_FATAL(h3r != NULL);
+    h3r->h3_stream  = h3s;
+    h3r->request_if = &h3c->h3_request_callbacks;
+    xqc_init_list_head(&h3r->body_buf);
+
+    xqc_http_header_t fake_hdrs[1];
+    fake_hdrs[0].name.iov_base  = (void *)"X-Bad-Name";
+    fake_hdrs[0].name.iov_len   = 10;
+    fake_hdrs[0].value.iov_base = (void *)"ok";
+    fake_hdrs[0].value.iov_len  = 2;
+    fake_hdrs[0].flags          = 0;
+
+    xqc_http_headers_t *hdr = &h3r->h3_header[0];
+    hdr->headers   = fake_hdrs;
+    hdr->count     = 1;
+    hdr->total_len = 12;
+    hdr->capacity  = 1;
+
+    h3r->current_header = 0;
+    h3r->read_flag      = 0;
+    xqc_int_t ret = xqc_h3_request_on_recv_header(h3r);
+    CU_ASSERT_EQUAL(ret, -XQC_H3_EMALFORMED_HEADER);
+
+    /* all-lowercase header passes the check */
+    fake_hdrs[0].name.iov_base = (void *)"x-good-name";
+    fake_hdrs[0].name.iov_len  = 11;
+    hdr->total_len = 13;
+    h3r->current_header = 0;
+    h3r->read_flag      = 0;
+    ret = xqc_h3_request_on_recv_header(h3r);
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+
+    hdr->headers = NULL;
+    for (size_t i = 0; i < XQC_H3_REQUEST_MAX_HEADERS_CNT; i++) {
+        xqc_h3_headers_free(&h3r->h3_header[i]);
+    }
+    xqc_list_buf_list_free(&h3r->body_buf);
+    xqc_free(h3r);
+
+    h3s->h3r = NULL;
+    stream->stream_flag |= XQC_STREAM_FLAG_DISCARDED;
+    xqc_h3_stream_destroy(h3s);
+    xqc_destroy_stream(stream);
+
+    xqc_h3_conn_destroy(h3c);
+    xqc_engine_destroy(conn->engine);
+}
+
+
+/*
+ * RFC 9114 Sections 4.2 and 4.1.2: lowercase field names remain valid,
+ * while an uppercase field name resets only the malformed request stream.
+ * These QPACK literals exercise the request-stream parser and error
+ * propagation instead of only testing the byte-scanning helper.
+ */
+void
+xqc_test_h3_lowercase_field_name_stream_accepted()
+{
+    const unsigned char lowercase[] = {
+        0x01, 0x06, 0x00, 0x00, 0x21, 0x78, 0x01, 0x76
+    };
+    xqc_connection_t *conn = NULL;
+    xqc_h3_conn_t *h3c = NULL;
+    xqc_h3_stream_t *h3s = xqc_h3_msgerr_setup(&conn, &h3c);
+    CU_ASSERT_FATAL(h3s != NULL);
+
+    unsigned char buf[sizeof(lowercase)];
+    xqc_memcpy(buf, lowercase, sizeof(buf));
+
+    xqc_int_t ret = xqc_h3_stream_process_in(h3s, buf, sizeof(buf),
+                                             XQC_TRUE);
+
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    CU_ASSERT_EQUAL(xqc_h3_stream_get_err(h3s), 0);
+    CU_ASSERT_EQUAL(h3s->stream->stream_err, 0);
+    CU_ASSERT_EQUAL(conn->conn_err, 0);
+    CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) == 0);
+
+    xqc_h3_msgerr_teardown(h3s, h3c, conn);
+}
+
+
+void
+xqc_test_h3_uppercase_field_name_stream_rejected()
+{
+    const unsigned char uppercase[] = {
+        0x01, 0x06, 0x00, 0x00, 0x21, 0x58, 0x01, 0x76
+    };
+    xqc_connection_t *conn = NULL;
+    xqc_h3_conn_t *h3c = NULL;
+    xqc_h3_stream_t *h3s = xqc_h3_msgerr_setup(&conn, &h3c);
+    CU_ASSERT_FATAL(h3s != NULL);
+
+    unsigned char buf[sizeof(uppercase)];
+    xqc_memcpy(buf, uppercase, sizeof(buf));
+
+    xqc_int_t ret = xqc_h3_stream_process_in(h3s, buf, sizeof(buf),
+                                             XQC_TRUE);
+
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    CU_ASSERT_EQUAL(xqc_h3_stream_get_err(h3s), H3_MESSAGE_ERROR);
+    CU_ASSERT_EQUAL(h3s->stream->stream_err, H3_MESSAGE_ERROR);
+    CU_ASSERT(h3s->stream->stream_state_send
+              >= XQC_SEND_STREAM_ST_RESET_SENT);
+    CU_ASSERT_EQUAL(conn->conn_err, 0);
+    CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) == 0);
+
+    xqc_h3_msgerr_teardown(h3s, h3c, conn);
 }

--- a/tests/unittest/xqc_h3_test.h
+++ b/tests/unittest/xqc_h3_test.h
@@ -46,4 +46,9 @@ void xqc_test_h3_blocked_stream_limit_uses_local();
 /* ALIBABA-2026-42073004: SETTINGS frame size limit */
 void xqc_test_h3_settings_frame_size_limit();
 
+/* issue #748: RFC 9114 §4.2 uppercase field name rejection */
+void xqc_test_h3_field_name_uppercase_rejection();
+void xqc_test_h3_lowercase_field_name_stream_accepted();
+void xqc_test_h3_uppercase_field_name_stream_rejected();
+
 #endif //XQUIC_XQC_H3_TEST_H


### PR DESCRIPTION
### Mechanism

- RFC or draft: RFC 9114 Sections 4.2 and 4.1.2 — reject decoded field
  names containing uppercase ASCII at the HTTP/3 semantic boundary and reset
  only the malformed stream with `H3_MESSAGE_ERROR`; QPACK remains
  byte-transparent.

Fixes: #748

### Validation Cases

- `1013` — accepts a lowercase response field name.
- `1014` — rejects an uppercase response field name, then completes another
  request on the same connection.

### CONTRIBUTING.md

- Overall: Passed
- Local regression: Complete
- CI: Complete
