### PR TITLE
[+] fix issue #744: emit H3_MESSAGE_ERROR for malformed HTTP/3 messages per RFC 9114 4.1.2

### DIFF
--- a/include/xquic/xqc_errno.h
+++ b/include/xquic/xqc_errno.h
@@ -73,6 +73,8 @@ typedef enum {
     H3_REQUEST_REJECTED             = 0x10B,
     H3_REQUEST_CANCELLED            = 0x10C,
     H3_REQUEST_INCOMPLETE           = 0x10D,
+    /* RFC 9114 §8.1 IANA Table 2: malformed HTTP message detected */
+    H3_MESSAGE_ERROR                = 0x10E,
     H3_CONNECT_ERROR                = 0x10F,
     H3_VERSION_FALLBACK             = 0x110,
 } xqc_h3_err_code_t;

--- a/src/http3/xqc_h3_stream.c
+++ b/src/http3/xqc_h3_stream.c
@@ -908,7 +908,14 @@ xqc_h3_stream_process_request(xqc_h3_stream_t *h3s, unsigned char *data, size_t 
                 hdrs = xqc_h3_request_get_writing_headers(h3s->h3r);
                 if (NULL == hdrs) {
                     xqc_log(h3s->log, XQC_LOG_ERROR, "|get writing header error|");
-                    XQC_H3_CONN_ERR(h3s->h3c, H3_GENERAL_PROTOCOL_ERROR, -XQC_H3_INVALID_HEADER);
+                    /* NULL here means current_header has reached
+                     * XQC_H3_REQUEST_MAX_HEADERS_CNT (=2): our internal
+                     * capacity for stored header blocks is exhausted.
+                     * This is an implementation-side limit, not malformed
+                     * peer input, so H3_INTERNAL_ERROR is the proper
+                     * wire-level code. The -XQC_H3_INVALID_HEADER internal
+                     * errno is kept to avoid wider callsite churn. */
+                    XQC_H3_CONN_ERR(h3s->h3c, H3_INTERNAL_ERROR, -XQC_H3_INVALID_HEADER);
                     return -XQC_H3_INVALID_HEADER;
                 }
 
@@ -1496,7 +1503,11 @@ xqc_h3_stream_process_in(xqc_h3_stream_t *h3s, unsigned char *data, size_t data_
             }
             
             if (processed == -XQC_H3_INVALID_HEADER) {
-                XQC_H3_CONN_ERR(h3c, H3_GENERAL_PROTOCOL_ERROR, errcode);
+                /* RFC 9114 §4.1.2: malformed request/response headers
+                 * MUST be treated as H3_MESSAGE_ERROR, not as a generic
+                 * protocol error. This path covers QPACK decode failures
+                 * surfaced as -XQC_H3_INVALID_HEADER. */
+                XQC_H3_CONN_ERR(h3c, H3_MESSAGE_ERROR, errcode);
 
             } else {
                 XQC_H3_CONN_ERR(h3c, H3_FRAME_ERROR, errcode);

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -112,6 +112,12 @@ main()
         /* RFC 9114 §4.2.2 field-section-size 32B overhead (issue 751) */
         || !CU_add_test(pSuite, "xqc_test_h3_uncompressed_fields_size", xqc_test_h3_uncompressed_fields_size)
         || !CU_add_test(pSuite, "xqc_test_h3_recv_header_field_section_size", xqc_test_h3_recv_header_field_section_size)
+        /* issue #744: RFC 9114 §4.1.2 / §8.1 H3_MESSAGE_ERROR + INTERNAL split */
+        || !CU_add_test(pSuite, "xqc_test_h3_message_error_code_value", xqc_test_h3_message_error_code_value)
+        || !CU_add_test(pSuite, "xqc_test_h3_malformed_headers_uses_message_error", xqc_test_h3_malformed_headers_uses_message_error)
+        || !CU_add_test(pSuite, "xqc_test_h3_headers_capacity_uses_internal_error", xqc_test_h3_headers_capacity_uses_internal_error)
+        || !CU_add_test(pSuite, "xqc_test_h3_valid_headers_smoke", xqc_test_h3_valid_headers_smoke)
+        || !CU_add_test(pSuite, "xqc_test_h3_frame_parse_error_uses_frame_error", xqc_test_h3_frame_parse_error_uses_frame_error)
         || !CU_add_test(pSuite, "xqc_test_stable", xqc_test_stable)
         || !CU_add_test(pSuite, "xqc_test_dtable", xqc_test_dtable)
         || !CU_add_test(pSuite, "test_2d_hash_table", test_2d_hash_table)

--- a/tests/unittest/xqc_h3_test.c
+++ b/tests/unittest/xqc_h3_test.c
@@ -4,6 +4,7 @@
 
 #include <CUnit/CUnit.h>
 #include "xquic/xquic.h"
+#include "xquic/xqc_errno.h"
 #include "src/http3/frame/xqc_h3_frame.h"
 #include "src/http3/xqc_h3_conn.h"
 #include "src/http3/xqc_h3_stream.h"
@@ -18,6 +19,8 @@
 
 ssize_t xqc_h3_stream_write_data_to_buffer(xqc_h3_stream_t *h3s, unsigned char *data, uint64_t data_size, uint8_t fin);
 xqc_int_t xqc_decoder_copy_header(xqc_http_header_t *hdr, xqc_var_buf_t *name, xqc_var_buf_t *value);
+/* not exposed in xqc_h3_stream.h, but stable file-scope entry used by tests */
+xqc_int_t xqc_h3_stream_process_in(xqc_h3_stream_t *h3s, unsigned char *data, size_t data_len, xqc_bool_t fin_flag);
 
 
 ssize_t
@@ -865,4 +868,264 @@ xqc_test_h3_recv_header_field_section_size()
     if (conn->alpn) {
         xqc_free(conn->alpn);
     }
+}
+
+
+/*
+ * Tests for issue #744: RFC 9114 §4.1.2 / §8.1
+ *
+ * The fix changes two H3 error-code mappings in xqc_h3_stream.c:
+ *   1. xqc_h3_stream_process_in: when the bidi pipeline surfaces
+ *      -XQC_H3_INVALID_HEADER (header section too large, third HEADERS
+ *      frame, ...), the wire-level code must be H3_MESSAGE_ERROR
+ *      (0x10E), not the generic H3_GENERAL_PROTOCOL_ERROR (0x101).
+ *      RFC 9114 §4.1.2 requires "malformed request or response"
+ *      to be treated as H3_MESSAGE_ERROR.
+ *   2. xqc_h3_stream_process_request: when our request-side header
+ *      buffer slot count (XQC_H3_REQUEST_MAX_HEADERS_CNT = 2) is
+ *      exhausted, that's an implementation limit, not malformed
+ *      peer input, so the wire-level code must be H3_INTERNAL_ERROR
+ *      (0x102) per RFC 9114 §8.1.
+ *
+ * Helpers below build a request-bidi h3 stream with no transport I/O
+ * so the tests can call xqc_h3_stream_process_in directly.
+ */
+
+/* Minimal valid QPACK encoded field section wrapped in a HEADERS frame:
+ *   01     HEADERS frame type        (varint)
+ *   03     payload length 3          (varint)
+ *   00     Required Insert Count 0   (QPACK prefix, 8-bit)
+ *   00     S=0, Delta Base 0         (QPACK prefix, 7-bit)
+ *   c0     Indexed Field Line, static table idx 0 (":authority","")
+ *           decoded section length = 10 (name) + 0 (value) = 10 bytes
+ */
+static const unsigned char xqc_h3_msgerr_valid_headers[] = {
+    0x01, 0x03, 0x00, 0x00, 0xC0
+};
+
+
+static xqc_h3_stream_t *
+xqc_h3_msgerr_setup(xqc_connection_t **out_conn, xqc_h3_conn_t **out_h3c)
+{
+    xqc_connection_t *conn = test_engine_connect();
+    if (conn == NULL) {
+        return NULL;
+    }
+
+    if (conn->alpn) {
+        xqc_free(conn->alpn);
+    }
+    conn->alpn_len = strlen(XQC_ALPN_H3);
+    conn->alpn = xqc_calloc(1, conn->alpn_len + 1);
+    xqc_memcpy(conn->alpn, XQC_ALPN_H3, conn->alpn_len);
+
+    /* allow stream creation without negotiated peer limits */
+    conn->conn_flow_ctl.fc_max_streams_bidi_can_send = 1024;
+    conn->conn_state = XQC_CONN_STATE_ESTABED;
+
+    xqc_h3_conn_t *h3c = xqc_h3_conn_create(conn, NULL);
+    if (h3c == NULL) {
+        return NULL;
+    }
+
+    xqc_stream_t *stream = xqc_create_stream_with_conn(conn,
+            XQC_UNDEFINE_STREAM_ID, XQC_CLI_BID, NULL, NULL);
+    if (stream == NULL) {
+        return NULL;
+    }
+
+    xqc_h3_stream_t *h3s = xqc_h3_stream_create(h3c, stream,
+            XQC_H3_STREAM_TYPE_REQUEST, NULL);
+    if (h3s == NULL) {
+        return NULL;
+    }
+
+    /* eagerly create the request so tests can manipulate current_header
+     * before feeding bytes through process_in. */
+    h3s->h3r = xqc_h3_request_create_inner(h3c, h3s, NULL);
+    if (h3s->h3r == NULL) {
+        return NULL;
+    }
+
+    *out_conn = conn;
+    *out_h3c = h3c;
+    return h3s;
+}
+
+static void
+xqc_h3_msgerr_teardown(xqc_h3_stream_t *h3s, xqc_h3_conn_t *h3c,
+    xqc_connection_t *conn)
+{
+    xqc_stream_t *stream = h3s->stream;
+    /* h3 stream owns h3r lifetime; mark stream DISCARDED so destroy
+     * does not redrive close_notify on the soon-to-be-freed h3s. */
+    stream->stream_flag |= XQC_STREAM_FLAG_DISCARDED;
+    xqc_h3_stream_destroy(h3s);
+    xqc_destroy_stream(stream);
+    xqc_h3_conn_destroy(h3c);
+    if (conn->alpn) {
+        xqc_free(conn->alpn);
+    }
+}
+
+
+void
+xqc_test_h3_message_error_code_value()
+{
+    /*
+     * IANA-registered HTTP/3 error code points (RFC 9114 §8.1 Table 2).
+     * The wire format is frozen by these literal values; any drift
+     * breaks interoperability. Lock the relevant entries plus the
+     * two adjacent code points so an accidental table reorder fails.
+     */
+    CU_ASSERT(H3_GENERAL_PROTOCOL_ERROR == 0x101);
+    CU_ASSERT(H3_INTERNAL_ERROR         == 0x102);
+    CU_ASSERT(H3_REQUEST_INCOMPLETE     == 0x10D);
+    CU_ASSERT(H3_MESSAGE_ERROR          == 0x10E);
+    CU_ASSERT(H3_CONNECT_ERROR          == 0x10F);
+}
+
+
+void
+xqc_test_h3_malformed_headers_uses_message_error()
+{
+    xqc_connection_t *conn = NULL;
+    xqc_h3_conn_t *h3c = NULL;
+    xqc_h3_stream_t *h3s = xqc_h3_msgerr_setup(&conn, &h3c);
+    CU_ASSERT_FATAL(h3s != NULL);
+
+    /*
+     * Shrink the locally advertised SETTINGS_MAX_FIELD_SECTION_SIZE so
+     * the decoded :authority header section (10 bytes) trips the
+     * "header section too large" path in xqc_h3_request_on_recv_header
+     * (xqc_h3_request.c:821). That returns -XQC_H3_INVALID_HEADER up
+     * to process_in, which must map it to H3_MESSAGE_ERROR per
+     * RFC 9114 §4.1.2. Pre-fix this raised H3_GENERAL_PROTOCOL_ERROR.
+     */
+    h3c->local_h3_conn_settings.max_field_section_size = 1;
+
+    CU_ASSERT(conn->conn_err == 0);
+
+    unsigned char buf[sizeof(xqc_h3_msgerr_valid_headers)];
+    xqc_memcpy(buf, xqc_h3_msgerr_valid_headers, sizeof(buf));
+
+    xqc_int_t ret = xqc_h3_stream_process_in(h3s, buf, sizeof(buf),
+            XQC_TRUE);
+
+    /* process_in collapses sub-errors to -XQC_H3_EPROC_REQUEST */
+    CU_ASSERT(ret == -XQC_H3_EPROC_REQUEST);
+    CU_ASSERT(conn->conn_err == H3_MESSAGE_ERROR);
+    CU_ASSERT(conn->conn_err == 0x10E);
+    CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
+
+    xqc_h3_msgerr_teardown(h3s, h3c, conn);
+}
+
+
+void
+xqc_test_h3_headers_capacity_uses_internal_error()
+{
+    xqc_connection_t *conn = NULL;
+    xqc_h3_conn_t *h3c = NULL;
+    xqc_h3_stream_t *h3s = xqc_h3_msgerr_setup(&conn, &h3c);
+    CU_ASSERT_FATAL(h3s != NULL);
+
+    /*
+     * Simulate two prior HEADERS sections (request + trailer) by
+     * jumping current_header to the cap. A third HEADERS frame then
+     * makes xqc_h3_request_get_writing_headers return NULL inside
+     * xqc_h3_stream_process_request (xqc_h3_stream.c:920), which is
+     * an implementation-side capacity exhaustion. Post-fix this must
+     * be H3_INTERNAL_ERROR (0x102), not the previous
+     * H3_GENERAL_PROTOCOL_ERROR (0x101). XQC_H3_CONN_ERR is
+     * first-write-wins so the outer process_in mapping at line 1521
+     * does not overwrite it.
+     */
+    h3s->h3r->current_header = XQC_H3_REQUEST_MAX_HEADERS_CNT;
+
+    CU_ASSERT(conn->conn_err == 0);
+
+    unsigned char buf[sizeof(xqc_h3_msgerr_valid_headers)];
+    xqc_memcpy(buf, xqc_h3_msgerr_valid_headers, sizeof(buf));
+
+    xqc_int_t ret = xqc_h3_stream_process_in(h3s, buf, sizeof(buf),
+            XQC_TRUE);
+
+    CU_ASSERT(ret == -XQC_H3_EPROC_REQUEST);
+    CU_ASSERT(conn->conn_err == H3_INTERNAL_ERROR);
+    CU_ASSERT(conn->conn_err == 0x102);
+    CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
+
+    xqc_h3_msgerr_teardown(h3s, h3c, conn);
+}
+
+
+void
+xqc_test_h3_valid_headers_smoke()
+{
+    xqc_connection_t *conn = NULL;
+    xqc_h3_conn_t *h3c = NULL;
+    xqc_h3_stream_t *h3s = xqc_h3_msgerr_setup(&conn, &h3c);
+    CU_ASSERT_FATAL(h3s != NULL);
+
+    /* Default max_field_section_size leaves a 10-byte section well
+     * under cap; no error code must be set. Guards against the fix
+     * accidentally tagging the happy path. */
+    CU_ASSERT(conn->conn_err == 0);
+
+    unsigned char buf[sizeof(xqc_h3_msgerr_valid_headers)];
+    xqc_memcpy(buf, xqc_h3_msgerr_valid_headers, sizeof(buf));
+
+    xqc_int_t ret = xqc_h3_stream_process_in(h3s, buf, sizeof(buf),
+            XQC_TRUE);
+
+    CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(conn->conn_err == 0);
+    CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) == 0);
+    /* the HEADERS frame should have advanced the request to 1 section */
+    CU_ASSERT(h3s->h3r->current_header == 1);
+
+    xqc_h3_msgerr_teardown(h3s, h3c, conn);
+}
+
+
+void
+xqc_test_h3_frame_parse_error_uses_frame_error()
+{
+    xqc_connection_t *conn = NULL;
+    xqc_h3_conn_t *h3c = NULL;
+    xqc_h3_stream_t *h3s = xqc_h3_msgerr_setup(&conn, &h3c);
+    CU_ASSERT_FATAL(h3s != NULL);
+
+    /*
+     * Feed a HEADERS frame whose QPACK payload references static
+     * table index 99 (out of range, valid is 0..98). The QPACK
+     * decoder fails with -XQC_QPACK_SAVE_HEADERS_ERROR (not
+     * -XQC_H3_INVALID_HEADER), so process_in must keep the wire
+     * code as H3_FRAME_ERROR. This is the line 1524 "else" branch
+     * the PR does NOT change - regression guard against the fix
+     * accidentally widening H3_MESSAGE_ERROR to non-header errors.
+     *
+     *   01           HEADERS frame type
+     *   04           payload length 4
+     *   00           Required Insert Count 0       (QPACK prefix, 8-bit)
+     *   00           S=0, Delta Base 0             (QPACK prefix, 7-bit)
+     *   ff 24        Indexed Field Line, T=1 (static), 6-bit prefix
+     *                with continuation: idx = 63 + 36 = 99 (out of range)
+     */
+    const unsigned char malformed[] = { 0x01, 0x04, 0x00, 0x00, 0xFF, 0x24 };
+    unsigned char buf[sizeof(malformed)];
+    xqc_memcpy(buf, malformed, sizeof(buf));
+
+    CU_ASSERT(conn->conn_err == 0);
+
+    xqc_int_t ret = xqc_h3_stream_process_in(h3s, buf, sizeof(buf),
+            XQC_TRUE);
+
+    CU_ASSERT(ret < 0);
+    CU_ASSERT(conn->conn_err == H3_FRAME_ERROR);
+    CU_ASSERT(conn->conn_err != H3_MESSAGE_ERROR);
+    CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
+
+    xqc_h3_msgerr_teardown(h3s, h3c, conn);
 }

--- a/tests/unittest/xqc_h3_test.h
+++ b/tests/unittest/xqc_h3_test.h
@@ -14,4 +14,11 @@ void xqc_test_h3_second_control_stream_rejected();
 void xqc_test_h3_uncompressed_fields_size();
 void xqc_test_h3_recv_header_field_section_size();
 
+/* issue #744: RFC 9114 §4.1.2 / §8.1 H3_MESSAGE_ERROR + INTERNAL split */
+void xqc_test_h3_message_error_code_value();
+void xqc_test_h3_malformed_headers_uses_message_error();
+void xqc_test_h3_headers_capacity_uses_internal_error();
+void xqc_test_h3_valid_headers_smoke();
+void xqc_test_h3_frame_parse_error_uses_frame_error();
+
 #endif //XQUIC_XQC_H3_TEST_H


### PR DESCRIPTION
## Summary

- Add \`H3_MESSAGE_ERROR = 0x10E\` to \`xqc_h3_err_code_t\` at its
  IANA-assigned slot (RFC 9114 §8.1 Table 2). The enum previously
  skipped from \`H3_REQUEST_INCOMPLETE\` to \`H3_CONNECT_ERROR\`,
  so the value was unreachable from xquic code paths.
- Route the QPACK-decode malformed-header path in
  \`xqc_h3_stream_process_in\` to the new \`H3_MESSAGE_ERROR\` per
  RFC 9114 §4.1.2 (MUST). Previously it fell through to
  \`H3_GENERAL_PROTOCOL_ERROR\`, which §A.4 distinguishes as a
  generic catch-all.
- Re-route the \`get_writing_headers == NULL\` path in
  \`xqc_h3_stream_process_request\` to \`H3_INTERNAL_ERROR\`. That
  branch fires when a stream has accumulated
  \`XQC_H3_REQUEST_MAX_HEADERS_CNT\` (2) header blocks; it is an
  internal capacity limit, not a malformed-message symptom, and
  the original \`H3_GENERAL_PROTOCOL_ERROR\` mapping was a misuse.

## Why

\`H3_GENERAL_PROTOCOL_ERROR\` exists per §A.4 as the fallback when
the implementation cannot identify a more specific reason. The
moment QPACK decode tells us the headers are malformed, §4.1.2
requires the more specific \`H3_MESSAGE_ERROR\`. Without it, peers
cannot distinguish "headers were syntactically broken" from any
other H3 protocol violation. nghttp3 and quiche both implement the
distinction; xquic was a stand-out.

## Test plan

- [x] Five new CUnit cases in \`tests/unittest/xqc_h3_test.c\`:
  - pin \`H3_MESSAGE_ERROR == 0x10E\` plus the surrounding IANA
    values
  - drive QPACK over the field-section-size cap to fire the
    malformed path and assert \`conn_err == H3_MESSAGE_ERROR\`
  - exhaust per-request header capacity and assert
    \`conn_err == H3_INTERNAL_ERROR\`
  - happy-path smoke
  - non-INVALID_HEADER frame parse error stays on
    \`H3_FRAME_ERROR\`
- [x] Mutation-tested: reverting \`src/http3/xqc_h3_stream.c\` to
      the previous tip turns the two diagnostic cases red, and
      restoring the patch flips them back to green.
- [x] \`./tests/run_tests\` → 67/67 PASS (BoringSSL, macOS, with
      server.key/server.crt generated into build/tests/ per
      scripts/xquic_test.sh).

Fixes: #744