### PR TITLE
[!] fix version_negotiation case test failures from PR #771

### DIFF
--- a/scripts/case_test.sh
+++ b/scripts/case_test.sh
@@ -1412,15 +1412,19 @@ else
 fi
 
 killall test_server 2> /dev/null
-${SERVER_BIN} -l d -e -b > /dev/null &
+# Case 33: server only advertises draft-29 so the V1 client hits the
+# abort path instead of the downgrade-protection discard.
+${SERVER_BIN} -l d -e -x 33 > /dev/null &
 sleep 1
 
 clear_log
 echo -e "version negotiation ...\c"
 ${CLIENT_BIN} -l d -E -x 33 >> clog 2>&1
 
-# Wire-level: VN packet was received and recognised by the receiver.
-result=`grep -e "|====>|.*VERSION_NEGOTIATION" clog`
+# Wire-level: VN packet was received and parsed by the client.
+# (The event-log callback is skipped because the abort error is non-tolerant,
+# so we match the unconditional debug log from xqc_packet_parse_version_negotiation.)
+result=`grep "packet parse|version negotiation" clog`
 if [ -n "$result" ]; then
     echo ">>>>>>>> pass:1"
     case_print_result "version_negotiation" "pass"

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -909,12 +909,6 @@ xqc_client_write_socket(const unsigned char *buf, size_t size,
     send_buf_size = size;
     memcpy(send_buf, buf, send_buf_size);
 
-    /* trigger version negotiation */
-    if (g_test_case == 33) {
-        /* makes version 0xff000001 */
-        send_buf[1] = 0xff;
-    }
-
     /* make initial packet loss to test 0rtt buffer */
     if (g_test_case == 39) {
         g_test_case = -1;
@@ -1132,12 +1126,6 @@ xqc_client_write_socket_ex(uint64_t path_id,
     }
     send_buf_size = size;
     memcpy(send_buf, buf, send_buf_size);
-
-    /* trigger version negotiation */
-    if (g_test_case == 33) {
-        /* makes version 0xff000001 */
-        send_buf[1] = 0xff;
-    }
 
     /* make initial packet loss to test 0rtt buffer */
     if (g_test_case == 39) {

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -2643,6 +2643,18 @@ int main(int argc, char *argv[]) {
     }
 #endif
 
+    /*
+     * VN abort test (case 33): offer only draft-29 so that the V1
+     * client hits the abort path instead of the downgrade-protection
+     * discard.  Server's VN will list 0xFF00001D only; V1 is absent,
+     * so the client's current_wire_version check passes and the
+     * connection is correctly abandoned per RFC 9000 §6.2.
+     */
+    if (g_test_case == 33) {
+        config.support_version_count = 1;
+        config.support_version_list[0] = 0xFF00001D; /* draft-29 */
+    }
+
     /* test server cid negotiate */
     if (g_test_case == 1 || g_test_case == 5 || g_test_case == 6 || g_sid_len != 0) {
 


### PR DESCRIPTION
## Summary

- PR #771 introduced RFC 9000 §6.2 abort-on-VN semantics but broke case 33's three sub-tests (`version_negotiation`, `version_negotiation_abort_path`, `version_negotiation_close_errno`) on CI
- **Root cause**: client-side wire version corruption (`0xFF000001`) was incompatible with the new abort path — the server's VN listed V1, triggering downgrade-protection discard instead of the abort path
- **Fix**: move version mismatch to the server side — when `-x 33`, server only advertises draft-29 (`0xFF00001D`), so V1 is absent from VN and the client correctly hits the abort path per RFC 9000 §6.2
- **Bonus fix**: first sub-test grep pattern changed from event-log `|====>|.*VERSION_NEGOTIATION` (never emitted because `xqc_conn_on_pkt_processed` is skipped for non-tolerant errors) to the unconditional debug log `packet parse|version negotiation`

## Changes

| File | Change |
|------|--------|
| `tests/test_server.c` | Added case 33: restrict server to draft-29 only |
| `tests/test_client.c` | Removed case 33 wire version corruption from both `write_socket` functions |
| `scripts/case_test.sh` | Server startup uses `-x 33`; first sub-test grep pattern fixed |

## Test plan

- [x] All 3 VN sub-tests pass locally (`version_negotiation`, `version_negotiation_abort_path`, `version_negotiation_close_errno`)
- [ ] CI passes on Ubuntu

🤖 Generated with [Claude Code](https://claude.com/claude-code)