### PR TITLE
[~] fix issue #709: send no_application_protocol on ALPN failure per RFC 9001 8.1

### DIFF
--- a/include/xquic/xqc_errno.h
+++ b/include/xquic/xqc_errno.h
@@ -35,6 +35,8 @@ typedef enum {
      * close reasons, but it is never serialised onto the wire.
      */
     TRA_VERSION_NEGOTIATION_ERROR   =  0x53,
+    /* RFC 9001 Section 4.8: TLS alert 120 maps to 0x100 + 120 = 0x178 */
+    TRA_NO_APPLICATION_PROTOCOL     =  0x178,
     TRA_HS_CERTIFICATE_VERIFY_FAIL  =  0x1FE, /**< for handshake certificate verify error */
 } xqc_trans_err_code_t;
 

--- a/scripts/case_test.sh
+++ b/scripts/case_test.sh
@@ -559,16 +559,32 @@ fi
 
 
 clear_log
-echo -e "alp negotiation failure ...\c"
+echo -e "alpn negotiation success ...\c"
+rm -f test_session
+${CLIENT_BIN} -s 1024 -l e -t 1 -T 1 > stdlog
+alpn_ok=`grep "alpn:transport" stdlog`
+conn_err_zero=`grep -E "conn_err:0[^0-9]" stdlog`
+errlog=`grep_err_log`
+if [ -n "$alpn_ok" ] && [ -n "$conn_err_zero" ] && [ -z "$errlog" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "alpn_negotiation_success" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "alpn_negotiation_success" "fail"
+fi
+
+clear_log
+echo -e "alpn negotiation failure (0x178) ...\c"
 rm -f test_session
 ${CLIENT_BIN} -l e -t 1 -T 1 -x 43 > stdlog
 alpn_res=`grep "xqc_ssl_alpn_select_cb|select proto error" slog`
-if [ -n "$alpn_res" ]; then
+conn_err_178=`grep "conn_err:376" stdlog`
+if [ -n "$alpn_res" ] && [ -n "$conn_err_178" ]; then
     echo ">>>>>>>> pass:1"
-    case_print_result "alp_negotiation_failure" "pass"
+    case_print_result "alpn_negotiation_failure_0x178" "pass"
 else
     echo ">>>>>>>> pass:0"
-    case_print_result "alp_negotiation_failure" "fail"
+    case_print_result "alpn_negotiation_failure_0x178" "fail"
 fi
 
 

--- a/src/tls/xqc_tls.c
+++ b/src/tls/xqc_tls.c
@@ -872,13 +872,19 @@ xqc_ssl_alpn_select_cb(SSL *ssl, const unsigned char **out, unsigned char *outle
     size_t alpn_list_len = 0;
     xqc_tls_ctx_get_alpn_list(tls->ctx, &alpn_list, &alpn_list_len);
 
-    /* select alp */
+    /* select alpn */
     if (SSL_select_next_proto((unsigned char **)out, outlen, alpn_list, alpn_list_len, in, inlen)
         != OPENSSL_NPN_NEGOTIATED)
     {
+        /*
+         * RFC 9001 Section 8.1: QUIC requires ALPN; if no common protocol
+         * is found the server MUST send TLS alert 120
+         * (no_application_protocol).  SSL_TLSEXT_ERR_ALERT_FATAL makes
+         * both BoringSSL and OpenSSL/BabaSSL emit that alert.
+         */
         xqc_log(tls->log, XQC_LOG_ERROR, "|select proto error|in:%*s",
                 (size_t)inlen, in);
-        return SSL_TLSEXT_ERR_NOACK;
+        return SSL_TLSEXT_ERR_ALERT_FATAL;
     }
 
     /* notify alpn selection to upper layer */

--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -4410,6 +4410,23 @@ xqc_conn_handshake_complete(xqc_connection_t *conn)
 
     } else {
         /*
+         * RFC 9001 Section 8.1: clients MUST treat a handshake that
+         * completes without ALPN negotiation as a connection error of
+         * type 0x0178 (no_application_protocol).
+         */
+        const char *selected_alpn = NULL;
+        size_t      selected_alpn_len = 0;
+        xqc_tls_get_selected_alpn(conn->tls,
+                                  &selected_alpn,
+                                  &selected_alpn_len);
+        if (selected_alpn == NULL || selected_alpn_len == 0) {
+            xqc_log(conn->log, XQC_LOG_ERROR,
+                    "|handshake completed without ALPN|");
+            XQC_CONN_ERR(conn, TRA_NO_APPLICATION_PROTOCOL);
+            return -XQC_EPROTO;
+        }
+
+        /*
          * client MUST discard Initial keys when it first sends a Handshake packet,
          * equivalent to handshake complete and can send 1RTT
          */
@@ -6478,8 +6495,7 @@ xqc_int_t
 xqc_conn_tls_alpn_select_cb(const char *alpn, size_t alpn_len, void *user_data)
 {
     xqc_connection_t *conn = (xqc_connection_t *)user_data;
-    xqc_conn_server_on_alpn(conn, alpn, alpn_len);
-    return XQC_OK;
+    return xqc_conn_server_on_alpn(conn, alpn, alpn_len);
 }
 
 xqc_int_t

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -222,6 +222,13 @@ main()
                         xqc_test_0rtt_params_all_increased)
         || !CU_add_test(pSuite, "xqc_test_0rtt_params_each_reduced",
                         xqc_test_0rtt_params_each_reduced)
+        /* ALPN negotiation tests (issue #709) */
+        || !CU_add_test(pSuite, "xqc_test_alpn_error_code_value",
+                        xqc_test_alpn_error_code_value)
+        || !CU_add_test(pSuite, "xqc_test_alpn_server_cb_propagates_error",
+                        xqc_test_alpn_server_cb_propagates_error)
+        || !CU_add_test(pSuite, "xqc_test_alpn_client_handshake_no_alpn",
+                        xqc_test_alpn_client_handshake_no_alpn)
         /* ADD TESTS HERE */)
     {
         CU_cleanup_registry();

--- a/tests/unittest/xqc_conn_test.c
+++ b/tests/unittest/xqc_conn_test.c
@@ -21,6 +21,10 @@
 
 extern void xqc_conn_tls_error_cb(xqc_int_t tls_err, void *user_data);
 
+/* forward-declare: defined in xqc_conn.c, exposed via xqc_conn_tls_cbs */
+xqc_int_t xqc_conn_tls_alpn_select_cb(const char *alpn,
+    size_t alpn_len, void *user_data);
+
 void
 xqc_test_conn_create()
 {
@@ -651,3 +655,66 @@ xqc_test_conn_tls_error_cb_max_alert()
     xqc_engine_destroy(conn->engine);
 }
 
+
+/* RFC 9001 Section 8.1 ALPN enforcement -- issue #709 */
+void
+xqc_test_alpn_error_code_value(void)
+{
+    CU_ASSERT_EQUAL(TRA_NO_APPLICATION_PROTOCOL, 0x178);
+
+    /* also verify it sits inside the crypto-error range [0x100, 0x1FF] */
+    CU_ASSERT(TRA_NO_APPLICATION_PROTOCOL >= TRA_CRYPTO_ERROR_BASE);
+    CU_ASSERT(TRA_NO_APPLICATION_PROTOCOL <= 0x1FF);
+}
+
+
+/* verify xqc_conn_tls_alpn_select_cb propagates xqc_conn_server_on_alpn errors */
+void
+xqc_test_alpn_server_cb_propagates_error(void)
+{
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_FATAL(conn != NULL);
+
+    xqc_engine_t *engine = conn->engine;
+    conn->conn_type = XQC_CONN_TYPE_SERVER;
+
+    xqc_int_t ret;
+    ret = xqc_conn_tls_alpn_select_cb("transport", 9, conn);
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+
+    if (conn->alpn) {
+        xqc_free(conn->alpn);
+        conn->alpn = NULL;
+        conn->alpn_len = 0;
+    }
+
+    /* unregistered ALPN must fail */
+    ret = xqc_conn_tls_alpn_select_cb("bogus", 5, conn);
+    CU_ASSERT(ret != XQC_OK);
+
+    xqc_engine_destroy(engine);
+}
+
+
+/* client handshake without ALPN must close with 0x178 */
+void
+xqc_test_alpn_client_handshake_no_alpn(void)
+{
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_FATAL(conn != NULL);
+    CU_ASSERT(conn->conn_type == XQC_CONN_TYPE_CLIENT);
+
+    CU_ASSERT_EQUAL(conn->conn_err, 0);
+    CU_ASSERT(
+        !(conn->conn_flag & XQC_CONN_FLAG_HANDSHAKE_COMPLETED));
+
+    xqc_int_t ret = xqc_conn_handshake_complete(conn);
+
+    CU_ASSERT_EQUAL(ret, -XQC_EPROTO);
+    CU_ASSERT(conn->conn_flag & XQC_CONN_FLAG_HANDSHAKE_COMPLETED);
+    CU_ASSERT_EQUAL(conn->conn_err,
+                    (uint64_t)TRA_NO_APPLICATION_PROTOCOL);
+    CU_ASSERT(conn->conn_flag & XQC_CONN_FLAG_ERROR);
+
+    xqc_engine_destroy(conn->engine);
+}

--- a/tests/unittest/xqc_conn_test.h
+++ b/tests/unittest/xqc_conn_test.h
@@ -22,4 +22,9 @@ void xqc_test_0rtt_params_all_equal(void);
 void xqc_test_0rtt_params_all_increased(void);
 void xqc_test_0rtt_params_each_reduced(void);
 
+/* ALPN negotiation tests (issue #709) */
+void xqc_test_alpn_error_code_value(void);
+void xqc_test_alpn_server_cb_propagates_error(void);
+void xqc_test_alpn_client_handshake_no_alpn(void);
+
 #endif


### PR DESCRIPTION
Fixes: #709

## Summary

RFC 9001 Section 8.1 requires endpoints to close connections with
`no_application_protocol` (TLS alert 120, QUIC error 0x0178) when ALPN
negotiation fails. Three gaps in the current implementation:

- Server ALPN mismatch returned `SSL_TLSEXT_ERR_NOACK` instead of
  `SSL_TLSEXT_ERR_ALERT_FATAL`, so no TLS alert was sent. BoringSSL
  happened to catch this internally in QUIC mode, but BabaSSL (the
  default SSL backend) does not guarantee the same enforcement.
- `xqc_conn_tls_alpn_select_cb` always returned `XQC_OK`, ignoring
  errors from `xqc_conn_server_on_alpn` -- making the `ALERT_FATAL`
  fallback path dead code.
- Client never validated ALPN after handshake completion.

## Changes

- `src/tls/xqc_tls.c`: return `SSL_TLSEXT_ERR_ALERT_FATAL` on ALPN
  mismatch so both BoringSSL and BabaSSL emit alert 120.
- `src/transport/xqc_conn.c`: propagate `xqc_conn_server_on_alpn`
  return value; add client-side post-handshake ALPN check that closes
  with `TRA_NO_APPLICATION_PROTOCOL` (0x0178) when no ALPN is negotiated.
- `include/xquic/xqc_errno.h`: add `TRA_NO_APPLICATION_PROTOCOL = 0x178`.
- Unit tests for error code pinning, callback error propagation, and
  client ALPN validation.

## Test plan

- [x] `xqc_test_alpn_error_code_value`: enum value pinned to 0x178
- [x] `xqc_test_alpn_server_cb_propagates_error`: registered ALPN returns OK, unregistered returns error
- [x] `xqc_test_alpn_client_handshake_no_alpn`: missing ALPN triggers 0x178 + `-XQC_EPROTO`
- [ ] Integration: mismatched ALPN with both BoringSSL and BabaSSL builds