### PR TITLE
[~] fix issue #695: use fixed length for initial salt instead of strlen

### DIFF
--- a/scripts/case_test.sh
+++ b/scripts/case_test.sh
@@ -5098,4 +5098,26 @@ else
     case_print_result "ack_ecn_parse_server_only" "fail"
 fi
 
+killall test_server 2> /dev/null
+> svr_stdlog
+stdbuf -oL ${SERVER_BIN} -l d -e -x 48 > svr_stdlog &
+sleep 1
+
+rm -f test_session tp_localhost xqc_token
+
+clear_log
+echo -e "initial salt v1 key derivation ...\c"
+${CLIENT_BIN} -s 1024 -l d -t 1 -E -x 48 > stdlog
+result=`grep ">>>>>>>> pass" stdlog`
+salt_cli=`grep "\[initial-salt-test\] handshake ok, conn_err:0" stdlog`
+salt_svr=`grep -a "\[initial-salt-test\] server handshake ok, conn_err:0" svr_stdlog`
+errlog=`grep "derive initial secret error" clog slog`
+if [ "$result" == ">>>>>>>> pass:1" ] && [ -n "$salt_cli" ] && [ -n "$salt_svr" ] && [ -z "$errlog" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "initial_salt_v1_key_derivation" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "initial_salt_v1_key_derivation" "fail"
+fi
+
 cd -

--- a/src/tls/xqc_tls.c
+++ b/src/tls/xqc_tls.c
@@ -439,7 +439,7 @@ xqc_tls_derive_and_install_initial_keys(xqc_tls_t *tls, const xqc_cid_t *odcid)
     ret = xqc_crypto_derive_initial_secret(cli_initial_secret, INITIAL_SECRET_MAX_LEN,
                                            svr_initial_secret, INITIAL_SECRET_MAX_LEN,
                                            odcid, xqc_crypto_initial_salt[tls->version],
-                                           strlen(xqc_crypto_initial_salt[tls->version]));
+                                           XQC_INITIAL_SALT_LEN);
     if (XQC_OK != ret) {
         xqc_log(tls->log, XQC_LOG_ERROR, "|derive initial secret error|ret:%d", ret);
         return ret;

--- a/src/tls/xqc_tls_common.h
+++ b/src/tls/xqc_tls_common.h
@@ -32,22 +32,33 @@
 
 #define INITIAL_SECRET_MAX_LEN  32
 
-static const char * const (xqc_crypto_initial_salt)[] = {
-    /* placeholder */
-    [XQC_IDRAFT_INIT_VER] = 
-        "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
+/* length of QUIC initial salt (all versions use 20 bytes) */
+#define XQC_INITIAL_SALT_LEN    20
 
-    /* QUIC v1 */
-    [XQC_VERSION_V1] = 
-        "\x38\x76\x2c\xf7\xf5\x59\x34\xb3\x4d\x17\x9a\xe6\xa4\xc8\x0c\xad\xcc\xbb\x7f\x0a",
+static const uint8_t xqc_crypto_initial_salt[][XQC_INITIAL_SALT_LEN] = {
+    /* placeholder */
+    [XQC_IDRAFT_INIT_VER] = {
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+    },
+
+    /* QUIC v1 (RFC 9001, Section 5.2) */
+    [XQC_VERSION_V1] = {
+        0x38, 0x76, 0x2c, 0xf7, 0xf5, 0x59, 0x34, 0xb3, 0x4d, 0x17,
+        0x9a, 0xe6, 0xa4, 0xc8, 0x0c, 0xad, 0xcc, 0xbb, 0x7f, 0x0a
+    },
 
     /* draft-29 ~ draft-32 */
-    [XQC_IDRAFT_VER_29] = 
-        "\xaf\xbf\xec\x28\x99\x93\xd2\x4c\x9e\x97\x86\xf1\x9c\x61\x11\xe0\x43\x90\xa8\x99",
+    [XQC_IDRAFT_VER_29] = {
+        0xaf, 0xbf, 0xec, 0x28, 0x99, 0x93, 0xd2, 0x4c, 0x9e, 0x97,
+        0x86, 0xf1, 0x9c, 0x61, 0x11, 0xe0, 0x43, 0x90, 0xa8, 0x99
+    },
 
     /* version negotiation */
-    [XQC_IDRAFT_VER_NEGOTIATION] = 
-        "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
+    [XQC_IDRAFT_VER_NEGOTIATION] = {
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+    },
 };
 
 static const char * const (xqc_crypto_retry_key)[] = {

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -1908,6 +1908,10 @@ xqc_client_h3_conn_handshake_finished(xqc_h3_conn_t *h3_conn, void *user_data)
         }
     }
 
+    if (g_test_case == 48) {
+        printf("[initial-salt-test] handshake ok, conn_err:%d\n", stats.conn_err);
+    }
+
     if (g_test_case == 200 || g_test_case == 201) {
         printf("[h3-dgram-200]|1RTT|updated_mss:%zu|\n", user_conn->dgram_mss);
     }

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -989,6 +989,11 @@ xqc_server_h3_conn_handshake_finished(xqc_h3_conn_t *h3_conn, void *conn_user_da
     printf("h3_datagram_mss:%zd\n", xqc_h3_ext_datagram_get_mss(h3_conn));
 
 
+    if (g_test_case == 48) {
+        printf("[initial-salt-test] server handshake ok, conn_err:%d\n",
+               stats.conn_err);
+    }
+
     /* pretend to create a server-inited http3 stream */
     if (g_test_case == 17) {
         xqc_stream_t * stream = xqc_stream_create_with_direction(

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -197,6 +197,10 @@ main()
         || !CU_add_test(pSuite, "xqc_test_rfc9001_derive_initial_secrets", xqc_test_rfc9001_derive_initial_secrets)
         || !CU_add_test(pSuite, "xqc_test_rfc9001_client_initial_keys", xqc_test_rfc9001_client_initial_keys)
         || !CU_add_test(pSuite, "xqc_test_rfc9001_server_initial_keys", xqc_test_rfc9001_server_initial_keys)
+        /* issue #695: initial salt strlen fix */
+        || !CU_add_test(pSuite, "xqc_test_initial_salt_length", xqc_test_initial_salt_length)
+        || !CU_add_test(pSuite, "xqc_test_initial_salt_v1_value", xqc_test_initial_salt_v1_value)
+        || !CU_add_test(pSuite, "xqc_test_initial_salt_null_byte_regression", xqc_test_initial_salt_null_byte_regression)
         /* ADD TESTS HERE */)
     {
         CU_cleanup_registry();

--- a/tests/unittest/xqc_crypto_test.c
+++ b/tests/unittest/xqc_crypto_test.c
@@ -2,6 +2,7 @@
  * @copyright Copyright (c) 2022, Alibaba Group Holding Limited
  */
 
+#include <string.h>
 #include <CUnit/CUnit.h>
 #include "xqc_common_test.h"
 #include "src/transport/xqc_conn.h"
@@ -34,7 +35,7 @@ xqc_test_derive_initial_secret()
     ret = xqc_crypto_derive_initial_secret(client_initial_secret, INITIAL_SECRET_MAX_LEN,
                                            server_initial_secret, INITIAL_SECRET_MAX_LEN,
                                            odcid, xqc_crypto_initial_salt[XQC_VERSION_V1],
-                                           strlen(xqc_crypto_initial_salt[XQC_VERSION_V1]));
+                                           XQC_INITIAL_SALT_LEN);
     CU_ASSERT(ret == XQC_OK);
 
     xqc_engine_destroy(conn->engine);
@@ -399,6 +400,56 @@ xqc_test_rfc9001_server_initial_keys()
     xqc_engine_destroy(engine);
 }
 
+
+void
+xqc_test_initial_salt_length()
+{
+    /* XQC_INITIAL_SALT_LEN must be 20 (all QUIC versions) */
+    CU_ASSERT_EQUAL(XQC_INITIAL_SALT_LEN, 20);
+
+    /* sizeof each row must match the constant */
+    CU_ASSERT_EQUAL(sizeof(xqc_crypto_initial_salt[XQC_VERSION_V1]),
+                    XQC_INITIAL_SALT_LEN);
+    CU_ASSERT_EQUAL(sizeof(xqc_crypto_initial_salt[XQC_IDRAFT_VER_29]),
+                    XQC_INITIAL_SALT_LEN);
+}
+
+void
+xqc_test_initial_salt_v1_value()
+{
+    /* RFC 9001 Section 5.2: 0x38762cf7f55934b34d179ae6a4c80cadccbb7f0a */
+    static const uint8_t rfc9001_v1_salt[20] = {
+        0x38, 0x76, 0x2c, 0xf7, 0xf5, 0x59, 0x34, 0xb3,
+        0x4d, 0x17, 0x9a, 0xe6, 0xa4, 0xc8, 0x0c, 0xad,
+        0xcc, 0xbb, 0x7f, 0x0a
+    };
+
+    CU_ASSERT_EQUAL(memcmp(xqc_crypto_initial_salt[XQC_VERSION_V1],
+                           rfc9001_v1_salt, 20), 0);
+}
+
+void
+xqc_test_initial_salt_null_byte_regression()
+{
+    /* salt with embedded 0x00: sizeof must still return 20 */
+    static const uint8_t salt_with_null[XQC_INITIAL_SALT_LEN] = {
+        0xAA, 0xBB, 0xCC, 0xDD,
+        0x00,  /* embedded null */
+        0x11, 0x22, 0x33, 0x44, 0x55,
+        0x66, 0x77, 0x88, 0x99, 0xAA,
+        0xBB, 0xCC, 0xDD, 0xEE, 0xFF
+    };
+
+    /* sizeof on a fixed-size uint8_t array is immune to 0x00 */
+    CU_ASSERT_EQUAL(sizeof(salt_with_null), XQC_INITIAL_SALT_LEN);
+
+    /* strlen would return 4 here -- that is the bug we are guarding */
+    CU_ASSERT(strlen((const char *)salt_with_null) < XQC_INITIAL_SALT_LEN);
+
+    /* the real salt table must also be immune */
+    CU_ASSERT_EQUAL(sizeof(xqc_crypto_initial_salt[XQC_IDRAFT_INIT_VER]),
+                    XQC_INITIAL_SALT_LEN);
+}
 
 void
 xqc_test_crypto()

--- a/tests/unittest/xqc_crypto_test.h
+++ b/tests/unittest/xqc_crypto_test.h
@@ -7,6 +7,9 @@
 
 void xqc_test_crypto();
 void xqc_test_hp_sample_boundary();
+void xqc_test_initial_salt_length();
+void xqc_test_initial_salt_v1_value();
+void xqc_test_initial_salt_null_byte_regression();
 
 /* RFC 9001 Appendix A test vector verification */
 void xqc_test_rfc9001_initial_secret();


### PR DESCRIPTION
Fixes: #695

## Summary

The initial salt table (`xqc_crypto_initial_salt`) was declared as C
string literals (`const char *`) and `strlen()` was used to measure
the salt length before passing it to `xqc_crypto_derive_initial_secret`.

Since the salt is binary data, `strlen()` stops at the first `0x00`
byte.  The current QUIC v1 and draft-29 salts happen to contain no null
bytes so this works by accident, but:

- The placeholder and version-negotiation salts (all zeros) yield
  `strlen() == 0`
- The QUIC v2 salt (RFC 9369 Section 3.3.1) has `0x00` at byte offset 5,
  so `strlen()` would return 5 instead of 20 -- silently producing wrong
  initial secrets and breaking the handshake with any v2 peer

## Changes

- `src/tls/xqc_tls_common.h`: changed salt array from `const char *`
  string literals to `const uint8_t[][20]` with hex byte initializers;
  added `XQC_INITIAL_SALT_LEN` constant (20).
- `src/tls/xqc_tls.c`: replaced `strlen()` with `XQC_INITIAL_SALT_LEN`.
- `tests/unittest/xqc_crypto_test.c`: same `strlen()` fix, plus three
  new tests.

This matches how ngtcp2 handles initial salts (`uint8_t[]` +
`sizeof()`).

## Test plan

- [x] `xqc_test_initial_salt_length`: constant value + sizeof each row
- [x] `xqc_test_initial_salt_v1_value`: byte-for-byte match against RFC 9001 S5.2
- [x] `xqc_test_initial_salt_null_byte_regression`: embedded 0x00 regression guard
- [x] Existing `xqc_test_derive_initial_secret` still passes with the new constant

## Follow-up

`xqc_crypto_retry_key` and `xqc_crypto_retry_nonce` in the same header
have the same `const char *` + `strlen()` pattern.  Their current values
don't contain 0x00 so there's no active bug, but they should be
converted in a separate PR.