### PR TITLE
[+] add RFC 9001 Appendix A test vector verification

### DIFF
--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -161,6 +161,11 @@ main()
         || !CU_add_test(pSuite, "xqc_test_vn_reject_when_scid_mismatch", xqc_test_vn_reject_when_scid_mismatch)
         || !CU_add_test(pSuite, "xqc_test_vn_reject_when_state_not_initial_sent", xqc_test_vn_reject_when_state_not_initial_sent)
         || !CU_add_test(pSuite, "xqc_test_vn_abort_on_multi_unsupported_versions", xqc_test_vn_abort_on_multi_unsupported_versions)
+        /* RFC 9001 Appendix A test vector verification (#719) */
+        || !CU_add_test(pSuite, "xqc_test_rfc9001_initial_secret", xqc_test_rfc9001_initial_secret)
+        || !CU_add_test(pSuite, "xqc_test_rfc9001_derive_initial_secrets", xqc_test_rfc9001_derive_initial_secrets)
+        || !CU_add_test(pSuite, "xqc_test_rfc9001_client_initial_keys", xqc_test_rfc9001_client_initial_keys)
+        || !CU_add_test(pSuite, "xqc_test_rfc9001_server_initial_keys", xqc_test_rfc9001_server_initial_keys)
         /* ADD TESTS HERE */)
     {
         CU_cleanup_registry();

--- a/tests/unittest/xqc_crypto_test.c
+++ b/tests/unittest/xqc_crypto_test.c
@@ -8,6 +8,7 @@
 #include "src/tls/xqc_tls_defs.h"
 #include "src/tls/xqc_tls.h"
 #include "src/tls/xqc_crypto.h"
+#include "src/tls/xqc_hkdf.h"
 
 #define XQC_TEST_CLIENT_SECRET "\x75\xf5\xba\x26\xff\x42\x51\x13\x20\x76\x4e\xd7" \
 "\x36\x5c\x20\x8d\x5d\x9c\x8a\xd1\x01\xe5\x0f\xc1\xc3\xc5\xaa\xfb\xd6\x3b\x56\x4a"
@@ -171,6 +172,231 @@ xqc_test_hp_sample_boundary()
 
     /* Case 8: encrypt, exact boundary (21 bytes) -> should pass check */
     xqc_test_hp_sample_boundary_one(XQC_TRUE, 21, XQC_OK);
+}
+
+
+/*
+ * ==========================================================================
+ * RFC 9001 Appendix A test vectors.
+ *
+ * Input:
+ *   DCID  = 0x8394c8f03e515708
+ *   Salt  = QUIC v1 initial salt (0x38762cf7f55934b34d179ae6a4c80cadccbb7f0a)
+ *
+ * Reference: RFC 9001, Appendix A.1 "Keys"
+ * ==========================================================================
+ */
+
+/* Destination Connection ID from RFC 9001 Appendix A */
+static const uint8_t rfc9001_dcid[] = {
+    0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08
+};
+
+/* initial_secret = HKDF-Extract(initial_salt, client_dst_connection_id) */
+static const uint8_t rfc9001_initial_secret[32] = {
+    0x7d, 0xb5, 0xdf, 0x06, 0xe7, 0xa6, 0x9e, 0x43,
+    0x24, 0x96, 0xad, 0xed, 0xb0, 0x08, 0x51, 0x92,
+    0x35, 0x95, 0x22, 0x15, 0x96, 0xae, 0x2a, 0xe9,
+    0xfb, 0x81, 0x15, 0xc1, 0xe9, 0xed, 0x0a, 0x44
+};
+
+/* client_initial_secret */
+static const uint8_t rfc9001_client_initial_secret[32] = {
+    0xc0, 0x0c, 0xf1, 0x51, 0xca, 0x5b, 0xe0, 0x75,
+    0xed, 0x0e, 0xbf, 0xb5, 0xc8, 0x03, 0x23, 0xc4,
+    0x2d, 0x6b, 0x7d, 0xb6, 0x78, 0x81, 0x28, 0x9a,
+    0xf4, 0x00, 0x8f, 0x1f, 0x6c, 0x35, 0x7a, 0xea
+};
+
+/* server_initial_secret */
+static const uint8_t rfc9001_server_initial_secret[32] = {
+    0x3c, 0x19, 0x98, 0x28, 0xfd, 0x13, 0x9e, 0xfd,
+    0x21, 0x6c, 0x15, 0x5a, 0xd8, 0x44, 0xcc, 0x81,
+    0xfb, 0x82, 0xfa, 0x8d, 0x74, 0x46, 0xfa, 0x7d,
+    0x78, 0xbe, 0x80, 0x3a, 0xcd, 0xda, 0x95, 0x1b
+};
+
+/* client AEAD key (AES-128-GCM, 16 bytes) */
+static const uint8_t rfc9001_client_key[16] = {
+    0x1f, 0x36, 0x96, 0x13, 0xdd, 0x76, 0xd5, 0x46,
+    0x77, 0x30, 0xef, 0xcb, 0xe3, 0xb1, 0xa2, 0x2d
+};
+
+/* client AEAD IV (12 bytes) */
+static const uint8_t rfc9001_client_iv[12] = {
+    0xfa, 0x04, 0x4b, 0x2f, 0x42, 0xa3, 0xfd, 0x3b,
+    0x46, 0xfb, 0x25, 0x5c
+};
+
+/* client header protection key (AES-128-CTR, 16 bytes) */
+static const uint8_t rfc9001_client_hp[16] = {
+    0x9f, 0x50, 0x44, 0x9e, 0x04, 0xa0, 0xe8, 0x10,
+    0x28, 0x3a, 0x1e, 0x99, 0x33, 0xad, 0xed, 0xd2
+};
+
+/* server AEAD key (AES-128-GCM, 16 bytes) */
+static const uint8_t rfc9001_server_key[16] = {
+    0xcf, 0x3a, 0x53, 0x31, 0x65, 0x3c, 0x36, 0x4c,
+    0x88, 0xf0, 0xf3, 0x79, 0xb6, 0x06, 0x7e, 0x37
+};
+
+/* server AEAD IV (12 bytes) */
+static const uint8_t rfc9001_server_iv[12] = {
+    0x0a, 0xc1, 0x49, 0x3c, 0xa1, 0x90, 0x58, 0x53,
+    0xb0, 0xbb, 0xa0, 0x3e
+};
+
+/* server header protection key (AES-128-CTR, 16 bytes) */
+static const uint8_t rfc9001_server_hp[16] = {
+    0xc2, 0x06, 0xb8, 0xd9, 0xb9, 0xf0, 0xf3, 0x76,
+    0x44, 0x43, 0x0b, 0x49, 0x0e, 0xea, 0xa3, 0x14
+};
+
+
+/*
+ * Test A: verify HKDF-Extract produces the correct initial_secret.
+ *
+ * RFC 9001 S5.2:
+ *   initial_secret = HKDF-Extract(initial_salt, client_dst_connection_id)
+ */
+void
+xqc_test_rfc9001_initial_secret()
+{
+    uint8_t initial_secret[INITIAL_SECRET_MAX_LEN] = {0};
+    xqc_digest_t md;
+    xqc_digest_init_to_sha256(&md);
+
+    const uint8_t *salt = (const uint8_t *)xqc_crypto_initial_salt[XQC_VERSION_V1];
+    size_t saltlen = 20;  /* QUIC v1 initial salt is exactly 20 bytes */
+
+    xqc_int_t ret = xqc_hkdf_extract(initial_secret, INITIAL_SECRET_MAX_LEN,
+                                      rfc9001_dcid, sizeof(rfc9001_dcid),
+                                      salt, saltlen, &md);
+    CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(memcmp(initial_secret, rfc9001_initial_secret,
+                     sizeof(rfc9001_initial_secret)) == 0);
+}
+
+
+/*
+ * Test B: verify client_initial_secret and server_initial_secret
+ * produced by xqc_crypto_derive_initial_secret().
+ *
+ * RFC 9001 Appendix A.1:
+ *   client_initial_secret = HKDF-Expand-Label(initial_secret, "client in", "", 32)
+ *   server_initial_secret = HKDF-Expand-Label(initial_secret, "server in", "", 32)
+ */
+void
+xqc_test_rfc9001_derive_initial_secrets()
+{
+    uint8_t cli_secret[INITIAL_SECRET_MAX_LEN] = {0};
+    uint8_t svr_secret[INITIAL_SECRET_MAX_LEN] = {0};
+
+    xqc_cid_t dcid;
+    memset(&dcid, 0, sizeof(dcid));
+    memcpy(dcid.cid_buf, rfc9001_dcid, sizeof(rfc9001_dcid));
+    dcid.cid_len = sizeof(rfc9001_dcid);
+
+    const uint8_t *salt = (const uint8_t *)xqc_crypto_initial_salt[XQC_VERSION_V1];
+    size_t saltlen = 20;
+
+    xqc_int_t ret = xqc_crypto_derive_initial_secret(
+        cli_secret, INITIAL_SECRET_MAX_LEN,
+        svr_secret, INITIAL_SECRET_MAX_LEN,
+        &dcid, salt, saltlen);
+    CU_ASSERT(ret == XQC_OK);
+
+    CU_ASSERT(memcmp(cli_secret, rfc9001_client_initial_secret,
+                     sizeof(rfc9001_client_initial_secret)) == 0);
+    CU_ASSERT(memcmp(svr_secret, rfc9001_server_initial_secret,
+                     sizeof(rfc9001_server_initial_secret)) == 0);
+}
+
+
+/*
+ * Test C: verify client-side packet protection key, IV, and HP key.
+ *
+ * RFC 9001 Appendix A.1:
+ *   key  = HKDF-Expand-Label(client_initial_secret, "quic key", "", 16)
+ *   iv   = HKDF-Expand-Label(client_initial_secret, "quic iv",  "", 12)
+ *   hp   = HKDF-Expand-Label(client_initial_secret, "quic hp",  "", 16)
+ */
+void
+xqc_test_rfc9001_client_initial_keys()
+{
+    xqc_engine_t *engine = test_create_engine();
+    CU_ASSERT_FATAL(engine != NULL);
+
+    xqc_crypto_t *crypto = xqc_crypto_create(XQC_TLS13_AES_128_GCM_SHA256,
+                                              engine->log);
+    CU_ASSERT_FATAL(crypto != NULL);
+
+    xqc_int_t ret = xqc_crypto_derive_keys(crypto,
+                                            rfc9001_client_initial_secret,
+                                            INITIAL_SECRET_MAX_LEN,
+                                            XQC_KEY_TYPE_RX_READ);
+    CU_ASSERT(ret == XQC_OK);
+
+    /* key_phase is 0 after xqc_crypto_create */
+    xqc_crypto_km_t *ckm = &crypto->keys.rx_ckm[0];
+
+    CU_ASSERT(ckm->key.len == sizeof(rfc9001_client_key));
+    CU_ASSERT(memcmp(ckm->key.base, rfc9001_client_key,
+                     sizeof(rfc9001_client_key)) == 0);
+
+    CU_ASSERT(ckm->iv.len == sizeof(rfc9001_client_iv));
+    CU_ASSERT(memcmp(ckm->iv.base, rfc9001_client_iv,
+                     sizeof(rfc9001_client_iv)) == 0);
+
+    CU_ASSERT(crypto->keys.rx_hp.len == sizeof(rfc9001_client_hp));
+    CU_ASSERT(memcmp(crypto->keys.rx_hp.base, rfc9001_client_hp,
+                     sizeof(rfc9001_client_hp)) == 0);
+
+    xqc_crypto_destroy(crypto);
+    xqc_engine_destroy(engine);
+}
+
+
+/*
+ * Test D: verify server-side packet protection key, IV, and HP key.
+ *
+ * RFC 9001 Appendix A.1:
+ *   key  = HKDF-Expand-Label(server_initial_secret, "quic key", "", 16)
+ *   iv   = HKDF-Expand-Label(server_initial_secret, "quic iv",  "", 12)
+ *   hp   = HKDF-Expand-Label(server_initial_secret, "quic hp",  "", 16)
+ */
+void
+xqc_test_rfc9001_server_initial_keys()
+{
+    xqc_engine_t *engine = test_create_engine();
+    CU_ASSERT_FATAL(engine != NULL);
+
+    xqc_crypto_t *crypto = xqc_crypto_create(XQC_TLS13_AES_128_GCM_SHA256,
+                                              engine->log);
+    CU_ASSERT_FATAL(crypto != NULL);
+
+    xqc_int_t ret = xqc_crypto_derive_keys(crypto,
+                                            rfc9001_server_initial_secret,
+                                            INITIAL_SECRET_MAX_LEN,
+                                            XQC_KEY_TYPE_RX_READ);
+    CU_ASSERT(ret == XQC_OK);
+
+    xqc_crypto_km_t *ckm = &crypto->keys.rx_ckm[0];
+
+    CU_ASSERT(ckm->key.len == sizeof(rfc9001_server_key));
+    CU_ASSERT(memcmp(ckm->key.base, rfc9001_server_key,
+                     sizeof(rfc9001_server_key)) == 0);
+
+    CU_ASSERT(ckm->iv.len == sizeof(rfc9001_server_iv));
+    CU_ASSERT(memcmp(ckm->iv.base, rfc9001_server_iv,
+                     sizeof(rfc9001_server_iv)) == 0);
+
+    CU_ASSERT(crypto->keys.rx_hp.len == sizeof(rfc9001_server_hp));
+    CU_ASSERT(memcmp(crypto->keys.rx_hp.base, rfc9001_server_hp,
+                     sizeof(rfc9001_server_hp)) == 0);
+
+    xqc_crypto_destroy(crypto);
+    xqc_engine_destroy(engine);
 }
 
 

--- a/tests/unittest/xqc_crypto_test.h
+++ b/tests/unittest/xqc_crypto_test.h
@@ -8,4 +8,10 @@
 void xqc_test_crypto();
 void xqc_test_hp_sample_boundary();
 
+/* RFC 9001 Appendix A test vector verification */
+void xqc_test_rfc9001_initial_secret();
+void xqc_test_rfc9001_derive_initial_secrets();
+void xqc_test_rfc9001_client_initial_keys();
+void xqc_test_rfc9001_server_initial_keys();
+
 #endif


### PR DESCRIPTION
## Summary

`xqc_crypto_test.c` previously verified only return codes from key derivation functions without checking the derived bytes. This means a regression in the derivation logic (label typo, length miscalculation, etc.) would go undetected by the test suite.

This patch adds four test cases that derive Initial keys using the RFC 9001 Appendix A input (DCID `0x8394c8f03e515708`, QUIC v1 salt) and `memcmp` every output against the RFC's known-good values:

- `initial_secret` via `xqc_hkdf_extract()`
- `client_initial_secret` + `server_initial_secret` via `xqc_crypto_derive_initial_secret()`
- Client AEAD key (16 B) / IV (12 B) / HP key (16 B) via `xqc_crypto_derive_keys()`
- Server AEAD key / IV / HP key

All four pass, confirming xquic's V1 key derivation matches the RFC byte-for-byte.

## Test plan

- [x] `xqc_test_rfc9001_initial_secret` — HKDF-Extract output matches RFC A.1
- [x] `xqc_test_rfc9001_derive_initial_secrets` — client/server initial secrets match RFC A.1
- [x] `xqc_test_rfc9001_client_initial_keys` — client key/IV/HP match RFC A.1
- [x] `xqc_test_rfc9001_server_initial_keys` — server key/IV/HP match RFC A.1
- [x] Full unit-test suite: 91 tests pass, 0 regressions

Fixes: #719