### PR TITLE
[~] fix simulate_ecn not propagated in xqc_server_set_conn_settings

### DIFF
--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -378,6 +378,8 @@ xqc_server_set_conn_settings(xqc_engine_t *engine, const xqc_conn_settings_t *se
     if (settings->max_streams_uni > 0) {
         engine->default_conn_settings.max_streams_uni = settings->max_streams_uni;
     }
+
+    engine->default_conn_settings.simulate_ecn = settings->simulate_ecn;
 }
 
 static const char * const xqc_conn_flag_to_str[XQC_CONN_FLAG_SHIFT_NUM] = {


### PR DESCRIPTION
## Summary

- `xqc_server_set_conn_settings()` copies fields individually but was missing `simulate_ecn`, so server-side connections never received the flag
- This caused CI case tests 454/455 (`ack_ecn_parse`) to fail: the server never sent ACK_ECN (0x03) frames, only plain ACK (0x02)
- Fix: add `engine->default_conn_settings.simulate_ecn = settings->simulate_ecn;` after the `max_streams_uni` copy

## Root cause

`xqc_server_set_conn_settings()` is a field-by-field copy function (unlike the client side which uses struct assignment). When `simulate_ecn` was added to `xqc_conn_settings_t`, the copy list was not updated. The server's `conn_settings.simulate_ecn` remained 0 even though `test_server.c` sets it to 1.

## Test plan

- [ ] CI case tests 454/455 (`ack_ecn_parse`) should pass (currently `pass:0`)
- [ ] No regression in other case tests or unit tests