### PR TITLE
fix: propagate simulate_ecn in xqc_server_set_conn_settings

### DIFF
--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -378,6 +378,8 @@ xqc_server_set_conn_settings(xqc_engine_t *engine, const xqc_conn_settings_t *se
     if (settings->max_streams_uni > 0) {
         engine->default_conn_settings.max_streams_uni = settings->max_streams_uni;
     }
+
+    engine->default_conn_settings.simulate_ecn = settings->simulate_ecn;
 }
 
 static const char * const xqc_conn_flag_to_str[XQC_CONN_FLAG_SHIFT_NUM] = {


### PR DESCRIPTION
## Summary

Fixes 2 failing CI case tests:
- `ack_ecn_parse: both endpoints send ACK_ECN, verify parsing on both sides` → pass:0
- `ack_ecn_parse: only server sends ACK_ECN, verify client parsing` → pass:0

### Root Cause

`xqc_server_set_conn_settings()` in `src/transport/xqc_conn.c` copies `xqc_conn_settings_t` fields one-by-one into `engine->default_conn_settings` but omits `simulate_ecn` (the last field in the struct, added at `include/xquic/xquic.h:1541`).

**Client path** (unaffected): `xqc_conn_create()` does `xc->conn_settings = *settings;` (full struct copy), so `simulate_ecn` is preserved.

**Server path** (broken): `xqc_server_set_conn_settings()` never copies `simulate_ecn`, so it stays 0. The server always sends plain ACK (type 0x02), never ACK_ECN (type 0x03). The test greps for `"ACK_ECN frame ECN counts consumed"` and finds nothing.

### Changes

- `src/transport/xqc_conn.c`: Add `engine->default_conn_settings.simulate_ecn = settings->simulate_ecn;` to `xqc_server_set_conn_settings()`

### Note

Audit found 5 other fields also missing from `xqc_server_set_conn_settings()`: `least_available_cid_count`, `conn_option_str`, `fec_callback`, `control_pto_value`, `disable_pn_skipping`. These are not causing CI failures currently but represent latent bugs. A follow-up PR to address them (or refactor to struct copy with selective overrides) is recommended.

## Test plan

- [ ] CI `ack_ecn_parse: both endpoints send ACK_ECN` passes
- [ ] CI `ack_ecn_parse: only server sends ACK_ECN` passes
- [ ] No regression in other case tests