### PR TITLE
fix: resolve case 700 test ID collision between #534 and #680

### DIFF
--- a/scripts/case_test.sh
+++ b/scripts/case_test.sh
@@ -5139,7 +5139,7 @@ clear_log
 echo -e "crypto_error: cert verify triggers dynamic CRYPTO_ERROR (0x112=274) ...\c"
 ${SERVER_BIN} -l d -e > /dev/null &
 sleep 1
-${CLIENT_BIN} -l d -t 1 -E -x 700 > stdlog
+${CLIENT_BIN} -l d -t 1 -E -x 703 > stdlog
 result=`grep "conn_err:274" stdlog | wc -l`
 if [ "$result" -gt 0 ]; then
     echo ">>>>>>>> pass:1"
@@ -5155,7 +5155,7 @@ clear_log
 echo -e "crypto_error: removed 0x1FF enum not used (conn_err:511 absent) ...\c"
 ${SERVER_BIN} -l d -e > /dev/null &
 sleep 1
-${CLIENT_BIN} -l d -t 1 -E -x 700 > stdlog
+${CLIENT_BIN} -l d -t 1 -E -x 703 > stdlog
 result=`grep "conn_err:511" stdlog | wc -l`
 if [ "$result" -eq 0 ]; then
     echo ">>>>>>>> pass:1"

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -4760,7 +4760,7 @@ int main(int argc, char *argv[]) {
         conn_settings.datagram_redundant_probe = 30000;
     }
 
-    if (g_test_case == 700) {
+    if (g_test_case == 703) {
         g_verify_cert = 1;
         g_verify_cert_allow_self_sign = 0;
     }


### PR DESCRIPTION
## Summary

- PR #790 (issue #534, FEC frame_type_bit) and PR #786 (issue #680, crypto_error) both used test case ID 700
- When crypto_error test runs with `-x 700`, it inadvertently triggers FEC code paths (`fec_code_rate = 1.0`), causing spurious CI failures
- Reassign crypto_error test to case ID 703 (701/702 reserved by PR #792)

## Test plan

- [ ] CI passes: `crypto_error_cert_verify` and `crypto_error_not_fixed_enum` cases produce correct results with `-x 703`
- [ ] FEC tests (`frame_type_bit_repair_sent`, `frame_type_bit_repair_received`) still pass with `-x 700`
