### PR TITLE
docs: document supported TLS 1.3 cipher suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ XQUIC supports the following TLS 1.3 cipher suites for QUIC packet protection (a
 | TLS_AES_128_CCM_SHA256 | AEAD_AES_128_CCM | — | Not Supported |
 | TLS_AES_128_CCM_8_SHA256 | — | — | Not Supported |
 
-> **Note:** `TLS_AES_128_CCM_SHA256` and `TLS_AES_128_CCM_8_SHA256` are not supported. CCM-based cipher suites are optional per [RFC 9001](https://www.rfc-editor.org/rfc/rfc9001) and have significantly lower confidentiality and integrity limits (2^21.5) compared to GCM (2^23 / 2^52) and ChaCha20-Poly1305. `TLS_AES_128_CCM_8_SHA256` is further excluded from QUIC usage by RFC 9001 as no header protection scheme is defined for it. Most QUIC implementations (including ngtcp2) also do not support CCM.
+> **Note:** `TLS_AES_128_CCM_SHA256` and `TLS_AES_128_CCM_8_SHA256` are not supported. CCM-based cipher suites are optional per [RFC 9001](https://www.rfc-editor.org/rfc/rfc9001) and have significantly lower confidentiality and integrity limits (2^21.5) compared to GCM (2^23 / 2^52) and ChaCha20-Poly1305. `TLS_AES_128_CCM_8_SHA256` is further excluded from QUIC usage by RFC 9001 as no header protection scheme is defined for it.
 
 #### Not Yet Standardized Features
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,20 @@ XQUIC Library released by Alibaba is …
 * All big features conforming with [RFC 9000](https://www.rfc-editor.org/rfc/rfc9000), [RFC9001](https://www.rfc-editor.org/rfc/rfc9001), [RFC9002](https://www.rfc-editor.org/rfc/rfc9002), [RFC9114](https://www.rfc-editor.org/rfc/rfc9114) and [RFC9204](https://www.rfc-editor.org/rfc/rfc9204), including the interface between QUIC and TLS, 0-RTT connection establishment, HTTP/3 and QPACK.
 * ALPN Extension conforming with [RFC7301](https://www.rfc-editor.org/rfc/rfc7301)
 
+#### Supported TLS 1.3 Cipher Suites
+
+XQUIC supports the following TLS 1.3 cipher suites for QUIC packet protection (as defined in [RFC 9001 Section 5](https://www.rfc-editor.org/rfc/rfc9001#section-5)):
+
+| Cipher Suite | AEAD | Header Protection | Status |
+|---|---|---|---|
+| TLS_AES_128_GCM_SHA256 | AEAD_AES_128_GCM | AES-ECB (128-bit) | Supported |
+| TLS_AES_256_GCM_SHA384 | AEAD_AES_256_GCM | AES-ECB (256-bit) | Supported |
+| TLS_CHACHA20_POLY1305_SHA256 | AEAD_CHACHA20_POLY1305 | ChaCha20 | Supported |
+| TLS_AES_128_CCM_SHA256 | AEAD_AES_128_CCM | — | Not Supported |
+| TLS_AES_128_CCM_8_SHA256 | — | — | Not Supported |
+
+> **Note:** `TLS_AES_128_CCM_SHA256` and `TLS_AES_128_CCM_8_SHA256` are not supported. CCM-based cipher suites are optional per [RFC 9001](https://www.rfc-editor.org/rfc/rfc9001) and have significantly lower confidentiality and integrity limits (2^21.5) compared to GCM (2^23 / 2^52) and ChaCha20-Poly1305. `TLS_AES_128_CCM_8_SHA256` is further excluded from QUIC usage by RFC 9001 as no header protection scheme is defined for it. Most QUIC implementations (including ngtcp2) also do not support CCM.
+
 #### Not Yet Standardized Features
 
 * [Multipath QUIC](https://tools.ietf.org/html/draft-ietf-quic-multipath-04)

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -1,4 +1,32 @@
 # Features
+
+## Supported TLS 1.3 Cipher Suites
+
+XQUIC supports the following TLS 1.3 cipher suites for QUIC packet protection, as specified in [RFC 9001 Section 5](https://www.rfc-editor.org/rfc/rfc9001#section-5):
+
+| Cipher Suite | AEAD | Header Protection | Status |
+|---|---|---|---|
+| TLS_AES_128_GCM_SHA256 | AEAD_AES_128_GCM | AES-ECB (128-bit) | Supported |
+| TLS_AES_256_GCM_SHA384 | AEAD_AES_256_GCM | AES-ECB (256-bit) | Supported |
+| TLS_CHACHA20_POLY1305_SHA256 | AEAD_CHACHA20_POLY1305 | ChaCha20 | Supported |
+| TLS_AES_128_CCM_SHA256 | AEAD_AES_128_CCM | — | Not Supported |
+| TLS_AES_128_CCM_8_SHA256 | — | — | Not Supported |
+
+The default cipher list is defined by the `XQC_TLS_CIPHERS` macro in `include/xquic/xquic.h`:
+
+```
+TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
+```
+
+### Why CCM is not supported
+
+CCM-based cipher suites (`TLS_AES_128_CCM_SHA256` and `TLS_AES_128_CCM_8_SHA256`) are not supported for the following reasons:
+
+1. **Optional per RFC 9001**: CCM support is not mandatory for QUIC implementations.
+2. **Low security limits**: AEAD_AES_128_CCM has significantly lower confidentiality and integrity limits (2^21.5 ≈ 2,992,530 packets) compared to GCM (confidentiality: 2^23, integrity: 2^52) and ChaCha20-Poly1305 (confidentiality: 2^62, integrity: 2^36). This requires more frequent key updates.
+3. **No header protection for CCM_8**: RFC 9001 does not define a header protection scheme for `TLS_AES_128_CCM_8_SHA256`, making it unsuitable for QUIC.
+4. **Industry consensus**: Most QUIC implementations (including ngtcp2, quiche) also do not support CCM.
+
 ## qlog
 Based on qlog ([draft-ietf-quic-qlog-main-schema](https://datatracker.ietf.org/doc/draft-ietf-quic-qlog-main-schema/), [draft-ietf-quic-qlog-quic-events](https://datatracker.ietf.org/doc/draft-ietf-quic-qlog-quic-events/) and [draft-ietf-quic-qlog-h3-events](https://datatracker.ietf.org/doc/draft-ietf-quic-qlog-h3-events/))，xquic implements quic event logging.
 

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -25,7 +25,6 @@ CCM-based cipher suites (`TLS_AES_128_CCM_SHA256` and `TLS_AES_128_CCM_8_SHA256`
 1. **Optional per RFC 9001**: CCM support is not mandatory for QUIC implementations.
 2. **Low security limits**: AEAD_AES_128_CCM has significantly lower confidentiality and integrity limits (2^21.5 ≈ 2,992,530 packets) compared to GCM (confidentiality: 2^23, integrity: 2^52) and ChaCha20-Poly1305 (confidentiality: 2^62, integrity: 2^36). This requires more frequent key updates.
 3. **No header protection for CCM_8**: RFC 9001 does not define a header protection scheme for `TLS_AES_128_CCM_8_SHA256`, making it unsuitable for QUIC.
-4. **Industry consensus**: Most QUIC implementations (including ngtcp2, quiche) also do not support CCM.
 
 ## qlog
 Based on qlog ([draft-ietf-quic-qlog-main-schema](https://datatracker.ietf.org/doc/draft-ietf-quic-qlog-main-schema/), [draft-ietf-quic-qlog-quic-events](https://datatracker.ietf.org/doc/draft-ietf-quic-qlog-quic-events/) and [draft-ietf-quic-qlog-h3-events](https://datatracker.ietf.org/doc/draft-ietf-quic-qlog-h3-events/))，xquic implements quic event logging.

--- a/docs/docs-zh/Features-zh.md
+++ b/docs/docs-zh/Features-zh.md
@@ -25,7 +25,6 @@ XQUIC 不支持基于 CCM 的加密套件（`TLS_AES_128_CCM_SHA256` 和 `TLS_AE
 1. **RFC 9001 中为可选项**：QUIC 实现不强制要求支持 CCM。
 2. **安全限值极低**：AEAD_AES_128_CCM 的机密性和完整性限值仅为 2^21.5（约 2,992,530 个数据包），远低于 GCM（机密性：2^23，完整性：2^52）和 ChaCha20-Poly1305（机密性：2^62，完整性：2^36）。这意味着需要更频繁地进行密钥更新。
 3. **CCM_8 无头部保护方案**：RFC 9001 未为 `TLS_AES_128_CCM_8_SHA256` 定义头部保护方案，因此无法在 QUIC 中使用。
-4. **行业共识**：大多数 QUIC 实现（包括 ngtcp2、quiche）也不支持 CCM。
 
 ## qlog
 基于 qlog ([draft-ietf-quic-qlog-main-schema](https://datatracker.ietf.org/doc/draft-ietf-quic-qlog-main-schema/)、[draft-ietf-quic-qlog-quic-events](https://datatracker.ietf.org/doc/draft-ietf-quic-qlog-quic-events/) 和 [draft-ietf-quic-qlog-h3-events](https://datatracker.ietf.org/doc/draft-ietf-quic-qlog-h3-events/))，xquic 实现了 quic 事件记录。

--- a/docs/docs-zh/Features-zh.md
+++ b/docs/docs-zh/Features-zh.md
@@ -1,4 +1,32 @@
 # Features
+
+## 支持的 TLS 1.3 加密套件
+
+XQUIC 支持以下 TLS 1.3 加密套件用于 QUIC 数据包保护，具体参见 [RFC 9001 第 5 节](https://www.rfc-editor.org/rfc/rfc9001#section-5)：
+
+| 加密套件 | AEAD 算法 | 头部保护 | 状态 |
+|---|---|---|---|
+| TLS_AES_128_GCM_SHA256 | AEAD_AES_128_GCM | AES-ECB (128-bit) | 支持 |
+| TLS_AES_256_GCM_SHA384 | AEAD_AES_256_GCM | AES-ECB (256-bit) | 支持 |
+| TLS_CHACHA20_POLY1305_SHA256 | AEAD_CHACHA20_POLY1305 | ChaCha20 | 支持 |
+| TLS_AES_128_CCM_SHA256 | AEAD_AES_128_CCM | — | 不支持 |
+| TLS_AES_128_CCM_8_SHA256 | — | — | 不支持 |
+
+默认加密套件列表由 `include/xquic/xquic.h` 中的 `XQC_TLS_CIPHERS` 宏定义：
+
+```
+TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
+```
+
+### 为什么不支持 CCM
+
+XQUIC 不支持基于 CCM 的加密套件（`TLS_AES_128_CCM_SHA256` 和 `TLS_AES_128_CCM_8_SHA256`），原因如下：
+
+1. **RFC 9001 中为可选项**：QUIC 实现不强制要求支持 CCM。
+2. **安全限值极低**：AEAD_AES_128_CCM 的机密性和完整性限值仅为 2^21.5（约 2,992,530 个数据包），远低于 GCM（机密性：2^23，完整性：2^52）和 ChaCha20-Poly1305（机密性：2^62，完整性：2^36）。这意味着需要更频繁地进行密钥更新。
+3. **CCM_8 无头部保护方案**：RFC 9001 未为 `TLS_AES_128_CCM_8_SHA256` 定义头部保护方案，因此无法在 QUIC 中使用。
+4. **行业共识**：大多数 QUIC 实现（包括 ngtcp2、quiche）也不支持 CCM。
+
 ## qlog
 基于 qlog ([draft-ietf-quic-qlog-main-schema](https://datatracker.ietf.org/doc/draft-ietf-quic-qlog-main-schema/)、[draft-ietf-quic-qlog-quic-events](https://datatracker.ietf.org/doc/draft-ietf-quic-qlog-quic-events/) 和 [draft-ietf-quic-qlog-h3-events](https://datatracker.ietf.org/doc/draft-ietf-quic-qlog-h3-events/))，xquic 实现了 quic 事件记录。
 ### 编译参数 DXQC_ENABLE_EVENT_LOG 开启 qlog


### PR DESCRIPTION
## Summary

- Add a "Supported TLS 1.3 Cipher Suites" section to `README.md`, `docs/Features.md` and `docs/docs-zh/Features-zh.md`
- Document which cipher suites XQUIC supports (AES-128-GCM, AES-256-GCM, ChaCha20-Poly1305) and which it does not (AES-128-CCM, AES-128-CCM-8)
- Explain why CCM-based suites are unsupported: optional per RFC 9001, low security limits (2^21.5), and no header protection defined for CCM_8

Closes #720

## Context

As noted in `src/tls/xqc_crypto.c`, the `xqc_crypto_create()` function explicitly handles only three cipher suites and rejects CCM variants in the default branch. The default cipher list macro `XQC_TLS_CIPHERS` in `include/xquic/xquic.h` also confirms only these three are configured.

This is consistent with RFC 9001 (CCM is optional) and aligns with other major QUIC implementations (ngtcp2, quiche).

## Test plan

- [x] Documentation-only change, no code modifications
- [ ] Verify markdown renders correctly on GitHub