### PR TITLE
clarify AES-CTR HP mask equivalence to RFC 9001 AES-ECB

### DIFF
--- a/src/tls/babassl/xqc_crypto_impl.c
+++ b/src/tls/babassl/xqc_crypto_impl.c
@@ -202,6 +202,7 @@ xqc_hp_ctx_free(void *hp_ctx)
     }
 }
 
+/* AES-CTR(key, iv=sample, zeros) == AES-ECB(key, sample) per RFC 9001 S5.4.3 */
 xqc_int_t
 xqc_ossl_hp_mask(const xqc_hdr_protect_cipher_t *hp_cipher, void *hp_ctx,
     uint8_t *dest, size_t destcap, size_t *destlen,

--- a/src/tls/boringssl/xqc_crypto_impl.c
+++ b/src/tls/boringssl/xqc_crypto_impl.c
@@ -112,6 +112,7 @@ xqc_hp_ctx_free(void *hp_ctx)
     }
 }
 
+/* AES-CTR(key, iv=sample, zeros) == AES-ECB(key, sample) per RFC 9001 S5.4.3 */
 xqc_int_t
 xqc_bssl_hp_mask(const xqc_hdr_protect_cipher_t *hp_cipher, void *hp_ctx,
     uint8_t *dest, size_t destcap, size_t *destlen,


### PR DESCRIPTION
## Summary

- Add comments to `xqc_bssl_hp_mask` (BoringSSL) and `xqc_ossl_hp_mask` (BabaSSL/OpenSSL) clarifying that the AES-CTR implementation is mathematically equivalent to the AES-ECB description in RFC 9001 Section 5.4.3.
- `AES-CTR(key, iv=sample, "\x00"*5)` produces `AES(key, sample)[0:5]`, which is identical to `AES-ECB(key, sample)[0:5]`.
- No behavioral change; comment-only.

Closes #696

## Test plan

- [ ] Verify build succeeds with both BoringSSL and BabaSSL backends
- [ ] No functional change — existing test suite covers correctness