### PR TITLE
[~] fix issue #693: fix duplicate condition in cert verify callback

### DIFF
--- a/src/tls/xqc_tls.c
+++ b/src/tls/xqc_tls.c
@@ -1018,6 +1018,25 @@ end:
 }
 
 
+xqc_bool_t
+xqc_cert_verify_err_tolerable(int err_code, uint8_t cert_verify_flag)
+{
+    if (err_code == X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY
+        || err_code == X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT)
+    {
+        return XQC_TRUE;
+    }
+
+    if ((cert_verify_flag & XQC_TLS_CERT_FLAG_ALLOW_SELF_SIGNED) != 0
+        && XQC_TLS_SELF_SIGNED_CERT(err_code))
+    {
+        return XQC_TRUE;
+    }
+
+    return XQC_FALSE;
+}
+
+
 int
 xqc_ssl_cert_verify_cb(int ok, X509_STORE_CTX *store_ctx)
 {
@@ -1041,10 +1060,8 @@ xqc_ssl_cert_verify_cb(int ok, X509_STORE_CTX *store_ctx)
     }
 
     int err_code = X509_STORE_CTX_get_error(store_ctx);
-    if (err_code != X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY
-        && err_code != X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY
-        && !((tls->cert_verify_flag & XQC_TLS_CERT_FLAG_ALLOW_SELF_SIGNED) != 0
-             && XQC_TLS_SELF_SIGNED_CERT(err_code)))
+    if (!xqc_cert_verify_err_tolerable(err_code,
+                                       tls->cert_verify_flag))
     {
         xqc_log(tls->log, XQC_LOG_ERROR, "|certificate verify failed with err_code:%d|", err_code);
         if (tls->cbs->error_cb) {

--- a/src/tls/xqc_tls.h
+++ b/src/tls/xqc_tls.h
@@ -222,5 +222,14 @@ xqc_int_t xqc_tls_update_tp(xqc_tls_t *tls, uint8_t *tp_buf, size_t tp_len);
  */
 void *xqc_tls_get_ssl(xqc_tls_t *tls);
 
+/**
+ * @brief check if a cert verification error is tolerable
+ *
+ * tolerable errors include missing issuer cert (local or chain)
+ * and self-signed cert when allowed by cert_verify_flag.
+ */
+xqc_bool_t xqc_cert_verify_err_tolerable(int err_code,
+    uint8_t cert_verify_flag);
+
 
 #endif

--- a/tests/unittest/xqc_tls_test.c
+++ b/tests/unittest/xqc_tls_test.c
@@ -882,6 +882,65 @@ void xqc_test_destroy_tls_ctx()
 }
 
 void
+xqc_test_cert_verify_err_tolerable()
+{
+    /*
+     * error 20: issuer cert not found in local store
+     * should be tolerated regardless of flags
+     */
+    CU_ASSERT(xqc_cert_verify_err_tolerable(
+        X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY, 0) == XQC_TRUE);
+
+    /*
+     * error 2: issuer cert of untrusted cert not found
+     * should also be tolerated (this was the bug in #693)
+     */
+    CU_ASSERT(xqc_cert_verify_err_tolerable(
+        X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT, 0) == XQC_TRUE);
+
+    /*
+     * error 18: self-signed leaf cert, allowed when flag is set
+     */
+    CU_ASSERT(xqc_cert_verify_err_tolerable(
+        X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT,
+        XQC_TLS_CERT_FLAG_ALLOW_SELF_SIGNED) == XQC_TRUE);
+
+    /*
+     * error 19: self-signed cert in chain, allowed when flag is set
+     */
+    CU_ASSERT(xqc_cert_verify_err_tolerable(
+        X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN,
+        XQC_TLS_CERT_FLAG_ALLOW_SELF_SIGNED) == XQC_TRUE);
+
+    /*
+     * error 18: self-signed leaf cert, rejected without flag
+     */
+    CU_ASSERT(xqc_cert_verify_err_tolerable(
+        X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT, 0) == XQC_FALSE);
+
+    /*
+     * error 19: self-signed in chain, rejected without flag
+     */
+    CU_ASSERT(xqc_cert_verify_err_tolerable(
+        X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN, 0) == XQC_FALSE);
+
+    /*
+     * error 10: expired cert, should always be rejected
+     */
+    CU_ASSERT(xqc_cert_verify_err_tolerable(
+        X509_V_ERR_CERT_HAS_EXPIRED, 0) == XQC_FALSE);
+    CU_ASSERT(xqc_cert_verify_err_tolerable(
+        X509_V_ERR_CERT_HAS_EXPIRED,
+        XQC_TLS_CERT_FLAG_ALLOW_SELF_SIGNED) == XQC_FALSE);
+
+    /*
+     * error 23: revoked cert, should always be rejected
+     */
+    CU_ASSERT(xqc_cert_verify_err_tolerable(
+        X509_V_ERR_CERT_REVOKED, 0) == XQC_FALSE);
+}
+
+void
 xqc_test_tls()
 {
     xqc_log_callbacks_t log_cb =  xqc_null_log_cb;
@@ -892,6 +951,7 @@ xqc_test_tls()
     xqc_test_tls_ctx_register_alpn();
     xqc_test_tls_reset_initial();
     
+    xqc_test_cert_verify_err_tolerable();
     xqc_test_tls_multiple_crypto_data();
     xqc_test_tls_generic();
     xqc_test_tls_process_truncated_crypto_handshake();


### PR DESCRIPTION
## Summary

Fix a copy-paste bug in `xqc_ssl_cert_verify_cb` where `X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY` (error 20) was checked twice, while `X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT` (error 2) was never checked.

These are two semantically different X509 verification errors:
- **Error 20** (`X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY`): issuer certificate could not be found in the local trust store
- **Error 2** (`X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT`): issuer of a looked-up certificate could not be found (chain broken at non-leaf)

The duplicate condition meant that when error 2 occurred, the application-layer `cert_verify_cb` was never invoked -- connections were rejected without giving the application a chance to handle the error (e.g., for certificate pinning scenarios).

## Changes

- `src/tls/xqc_tls.c`: Extract error tolerability logic into `xqc_cert_verify_err_tolerable()`, fix the duplicate condition
- `src/tls/xqc_tls.h`: Declare the new helper function
- `tests/unittest/xqc_tls_test.c`: Add unit tests covering all branches of the error filtering logic

## Test plan

- [x] Unit tests for `xqc_cert_verify_err_tolerable()` added:
  - Error 20 (UNABLE_TO_GET_ISSUER_CERT_LOCALLY) tolerated
  - Error 2 (UNABLE_TO_GET_ISSUER_CERT) tolerated -- was previously broken
  - Self-signed certs (error 18, 19) accepted with ALLOW_SELF_SIGNED flag
  - Self-signed certs rejected without the flag
  - Expired cert (error 10) always rejected
  - Revoked cert (error 23) always rejected
- [x] Existing `cert_verify` and `crypto_error_cert_verify` integration tests in `case_test.sh` cover end-to-end paths
- [ ] CI (build + run_tests + case_test.sh) passes

Fixes #693