### PR TITLE
[~]: Clamp flow control windows to the RFC 9000 limit

### DIFF
--- a/src/transport/xqc_conn.h
+++ b/src/transport/xqc_conn.h
@@ -39,6 +39,16 @@
 
 #define XQC_MAX_RECV_WINDOW (16 * 1024 * 1024)
 
+/* RFC 9000: variable-length integer max value, used as flow control upper bound */
+#define XQC_MAX_FLOW_CONTROL_WINDOW (((uint64_t)1 << 62) - 1)
+
+/* clamp a flow control value to the RFC 9000 variable-length integer maximum */
+static inline uint64_t
+xqc_clamp_to_max_flow_ctl(uint64_t value)
+{
+    return value > XQC_MAX_FLOW_CONTROL_WINDOW ? XQC_MAX_FLOW_CONTROL_WINDOW : value;
+}
+
 #define XQC_MP_SETTINGS_STR_LEN (30)
 
 static const uint32_t MAX_RSP_CONN_CLOSE_CNT = 3;

--- a/src/transport/xqc_frame.c
+++ b/src/transport/xqc_frame.c
@@ -1314,7 +1314,7 @@ xqc_process_data_blocked_frame(xqc_connection_t *conn, xqc_packet_in_t *packet_i
         return XQC_OK;
     }
 
-    new_limit = conn->conn_flow_ctl.fc_data_read + conn->conn_flow_ctl.fc_recv_windows_size;
+    new_limit = xqc_clamp_to_max_flow_ctl(conn->conn_flow_ctl.fc_data_read + conn->conn_flow_ctl.fc_recv_windows_size);
 
     if (new_limit > conn->conn_flow_ctl.fc_max_data_can_recv) {
         conn->conn_flow_ctl.fc_max_data_can_recv = new_limit;
@@ -1370,7 +1370,7 @@ xqc_process_stream_data_blocked_frame(xqc_connection_t *conn, xqc_packet_in_t *p
         return XQC_OK;
     }
 
-    new_limit = stream->stream_data_in.next_read_offset + stream->stream_flow_ctl.fc_stream_recv_window_size;
+    new_limit = xqc_clamp_to_max_flow_ctl(stream->stream_data_in.next_read_offset + stream->stream_flow_ctl.fc_stream_recv_window_size);
 
     if (new_limit > stream->stream_flow_ctl.fc_max_stream_data_can_recv) {
         stream->stream_flow_ctl.fc_max_stream_data_can_recv = new_limit;

--- a/src/transport/xqc_packet_out.c
+++ b/src/transport/xqc_packet_out.c
@@ -1215,6 +1215,7 @@ xqc_write_stream_frame_to_packet(xqc_connection_t *conn,
 
         if (stream->stream_flow_ctl.fc_stream_recv_window_size > available_window) {        
             stream->stream_flow_ctl.fc_max_stream_data_can_recv += (stream->stream_flow_ctl.fc_stream_recv_window_size - available_window);
+            stream->stream_flow_ctl.fc_max_stream_data_can_recv = xqc_clamp_to_max_flow_ctl(stream->stream_flow_ctl.fc_max_stream_data_can_recv);
             xqc_log(conn->log, XQC_LOG_DEBUG,
                     "|initial_fc_credit_update|stream:%ui|new_max_data:%ui|stream_max_recv_offset:%ui|next_read_offset:%ui|window_size:%ui|pkt_type:%d|",
                     stream->stream_id,

--- a/src/transport/xqc_stream.c
+++ b/src/transport/xqc_stream.c
@@ -416,6 +416,7 @@ xqc_stream_do_recv_flow_ctl(xqc_stream_t *stream)
 
         if (stream->stream_flow_ctl.fc_stream_recv_window_size > available_window) {        
             stream->stream_flow_ctl.fc_max_stream_data_can_recv += (stream->stream_flow_ctl.fc_stream_recv_window_size - available_window);
+            stream->stream_flow_ctl.fc_max_stream_data_can_recv = xqc_clamp_to_max_flow_ctl(stream->stream_flow_ctl.fc_max_stream_data_can_recv);
             xqc_log(conn->log, XQC_LOG_DEBUG,
                     "|xqc_write_max_stream_data_to_packet|new_max_data:%ui|stream_max_recv_offset:%ui|next_read_offset:%ui|window_size:%ui|",
                     stream->stream_flow_ctl.fc_max_stream_data_can_recv, stream->stream_max_recv_offset,
@@ -462,6 +463,7 @@ xqc_stream_do_recv_flow_ctl(xqc_stream_t *stream)
 
         if (conn->conn_flow_ctl.fc_recv_windows_size > available_window) {
             conn->conn_flow_ctl.fc_max_data_can_recv += (conn->conn_flow_ctl.fc_recv_windows_size - available_window);
+            conn->conn_flow_ctl.fc_max_data_can_recv = xqc_clamp_to_max_flow_ctl(conn->conn_flow_ctl.fc_max_data_can_recv);
             xqc_log(conn->log, XQC_LOG_DEBUG,
                     "|xqc_write_max_data_to_packet|new_max_data:%ui|fc_data_recved:%ui|fc_data_read:%ui|window_size:%ui|",
                     conn->conn_flow_ctl.fc_max_data_can_recv, conn->conn_flow_ctl.fc_data_recved,
@@ -1066,7 +1068,7 @@ xqc_stream_update_settings(xqc_stream_t *stream,
             xqc_log(conn->log, XQC_LOG_DEBUG, 
                     "|fc_win_update|old_fc_win:%ui|fc_win:%ui|", 
                     old_fc_win, stream->stream_flow_ctl.fc_stream_recv_window_size);
-            new_offset = stream->stream_data_in.next_read_offset + stream->stream_flow_ctl.fc_stream_recv_window_size;
+            new_offset = xqc_clamp_to_max_flow_ctl(stream->stream_data_in.next_read_offset + stream->stream_flow_ctl.fc_stream_recv_window_size);
 
             if(new_offset > stream->stream_flow_ctl.fc_max_stream_data_can_recv) {
                 stream->stream_flow_ctl.fc_max_stream_data_can_recv = new_offset;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -117,6 +117,7 @@ if(HAVE_CUNIT)
         ${UNIT_TEST_DIR}/xqc_send_ctl_test.c
         ${UNIT_TEST_DIR}/xqc_vn_test.c
         ${UNIT_TEST_DIR}/xqc_frame_type_bit_test.c
+        ${UNIT_TEST_DIR}/xqc_flow_ctl_test.c
     )
 
     if(XQC_ENABLE_FEC)

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -45,6 +45,7 @@
 #include "xqc_send_ctl_test.h"
 #include "xqc_vn_test.h"
 #include "xqc_frame_type_bit_test.h"
+#include "xqc_flow_ctl_test.h"
 
 static int xqc_init_suite(void) { return 0; }
 static int xqc_clean_suite(void) { return 0; }
@@ -92,6 +93,10 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite, "xqc_test_pq", xqc_test_pq)
         || !CU_add_test(pSuite, "xqc_test_common", xqc_test_common)
         || !CU_add_test(pSuite, "xqc_test_vint", xqc_test_vint)
+        || !CU_add_test(pSuite, "xqc_test_flow_ctl_clamp_boundary", xqc_test_flow_ctl_clamp_boundary)
+        || !CU_add_test(pSuite, "xqc_test_stream_flow_ctl_clamp", xqc_test_stream_flow_ctl_clamp)
+        || !CU_add_test(pSuite, "xqc_test_conn_flow_ctl_clamp", xqc_test_conn_flow_ctl_clamp)
+        || !CU_add_test(pSuite, "xqc_test_flow_ctl_normal_no_clamp", xqc_test_flow_ctl_normal_no_clamp)
         || !CU_add_test(pSuite, "xqc_test_recv_record", xqc_test_recv_record)
         || !CU_add_test(pSuite, "xqc_test_reno", xqc_test_reno)
         || !CU_add_test(pSuite, "xqc_test_reno_init_cwnd", xqc_test_reno_init_cwnd)

--- a/tests/unittest/xqc_flow_ctl_test.c
+++ b/tests/unittest/xqc_flow_ctl_test.c
@@ -1,0 +1,146 @@
+/**
+ * @copyright Copyright (c) 2022, Alibaba Group Holding Limited
+ */
+
+#include "xqc_flow_ctl_test.h"
+#include <CUnit/CUnit.h>
+#include <stdint.h>
+#include <string.h>
+#include "src/transport/xqc_conn.h"
+#include "src/transport/xqc_engine.h"
+#include "src/transport/xqc_stream.h"
+#include "xqc_common_test.h"
+
+/*
+ * Place the receive limit less than one window below the bound so a single
+ * growth step has to cross it.
+ */
+#define XQC_TEST_FC_NEAR_LIMIT (XQC_MAX_FLOW_CONTROL_WINDOW - 100)
+
+
+/**
+ * Test: xqc_clamp_to_max_flow_ctl bounds every input at the RFC 9000
+ * variable-length integer maximum and leaves smaller values untouched.
+ */
+void
+xqc_test_flow_ctl_clamp_boundary(void)
+{
+    CU_ASSERT_EQUAL(XQC_MAX_FLOW_CONTROL_WINDOW, ((uint64_t)1 << 62) - 1);
+
+    /* below the bound passes through unchanged */
+    CU_ASSERT_EQUAL(xqc_clamp_to_max_flow_ctl(0), 0);
+    CU_ASSERT_EQUAL(xqc_clamp_to_max_flow_ctl(XQC_MAX_RECV_WINDOW), XQC_MAX_RECV_WINDOW);
+    CU_ASSERT_EQUAL(xqc_clamp_to_max_flow_ctl(XQC_MAX_FLOW_CONTROL_WINDOW - 1),
+                    XQC_MAX_FLOW_CONTROL_WINDOW - 1);
+
+    /* exactly at the bound passes through unchanged */
+    CU_ASSERT_EQUAL(xqc_clamp_to_max_flow_ctl(XQC_MAX_FLOW_CONTROL_WINDOW),
+                    XQC_MAX_FLOW_CONTROL_WINDOW);
+
+    /* one above the bound, and far above it, are clamped */
+    CU_ASSERT_EQUAL(xqc_clamp_to_max_flow_ctl(XQC_MAX_FLOW_CONTROL_WINDOW + 1),
+                    XQC_MAX_FLOW_CONTROL_WINDOW);
+    CU_ASSERT_EQUAL(xqc_clamp_to_max_flow_ctl(UINT64_MAX), XQC_MAX_FLOW_CONTROL_WINDOW);
+}
+
+
+/**
+ * Test: the stream-level growth path in xqc_stream_do_recv_flow_ctl stops at
+ * the variable-length integer maximum instead of advertising a larger
+ * MAX_STREAM_DATA value.
+ */
+void
+xqc_test_stream_flow_ctl_clamp(void)
+{
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+
+    xqc_stream_t *stream = xqc_stream_create_with_direction(conn, XQC_STREAM_BIDI, NULL);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(stream);
+
+    /* keep the window-sizing branches deterministic */
+    stream->recv_rate_bytes_per_sec = 0;
+    stream->stream_flow_ctl.fc_last_window_update_time = 0;
+
+    /* the whole window has been consumed, so growth is due */
+    stream->stream_flow_ctl.fc_max_stream_data_can_recv = XQC_TEST_FC_NEAR_LIMIT;
+    stream->stream_data_in.next_read_offset = XQC_TEST_FC_NEAR_LIMIT;
+    stream->stream_flow_ctl.fc_stream_recv_window_size = XQC_MAX_RECV_WINDOW;
+
+    CU_ASSERT_EQUAL(xqc_stream_do_recv_flow_ctl(stream), XQC_OK);
+
+    CU_ASSERT_EQUAL(stream->stream_flow_ctl.fc_max_stream_data_can_recv,
+                    XQC_MAX_FLOW_CONTROL_WINDOW);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
+/**
+ * Test: the connection-level growth path in xqc_stream_do_recv_flow_ctl stops
+ * at the variable-length integer maximum instead of advertising a larger
+ * MAX_DATA value.
+ */
+void
+xqc_test_conn_flow_ctl_clamp(void)
+{
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+
+    xqc_stream_t *stream = xqc_stream_create_with_direction(conn, XQC_STREAM_BIDI, NULL);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(stream);
+
+    /* leave the stream window fully free so only the connection level grows */
+    stream->recv_rate_bytes_per_sec = 0;
+    stream->stream_flow_ctl.fc_stream_recv_window_size = XQC_MAX_RECV_WINDOW;
+    stream->stream_flow_ctl.fc_max_stream_data_can_recv = XQC_MAX_RECV_WINDOW;
+    stream->stream_data_in.next_read_offset = 0;
+
+    conn->conn_settings.recv_rate_bytes_per_sec = 0;
+    conn->conn_flow_ctl.fc_last_window_update_time = 0;
+    conn->conn_flow_ctl.fc_max_data_can_recv = XQC_TEST_FC_NEAR_LIMIT;
+    conn->conn_flow_ctl.fc_data_read = XQC_TEST_FC_NEAR_LIMIT;
+    conn->conn_flow_ctl.fc_recv_windows_size = XQC_MAX_RECV_WINDOW;
+
+    CU_ASSERT_EQUAL(xqc_stream_do_recv_flow_ctl(stream), XQC_OK);
+
+    /* the stream level stayed put, so the assertion below observes the
+       connection-level clamp on its own */
+    CU_ASSERT_EQUAL(stream->stream_flow_ctl.fc_max_stream_data_can_recv, XQC_MAX_RECV_WINDOW);
+    CU_ASSERT_EQUAL(conn->conn_flow_ctl.fc_max_data_can_recv, XQC_MAX_FLOW_CONTROL_WINDOW);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
+/**
+ * Control test: a limit far below the bound still grows by the full window, so
+ * the assertions above observe the clamp rather than a saturated no-op.
+ */
+void
+xqc_test_flow_ctl_normal_no_clamp(void)
+{
+    uint64_t expected;
+
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+
+    xqc_stream_t *stream = xqc_stream_create_with_direction(conn, XQC_STREAM_BIDI, NULL);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(stream);
+
+    stream->recv_rate_bytes_per_sec = 0;
+    stream->stream_flow_ctl.fc_last_window_update_time = 0;
+
+    stream->stream_flow_ctl.fc_max_stream_data_can_recv = 1024 * 1024;
+    stream->stream_data_in.next_read_offset = 1024 * 1024;
+    stream->stream_flow_ctl.fc_stream_recv_window_size = XQC_MAX_RECV_WINDOW;
+
+    expected = stream->stream_flow_ctl.fc_max_stream_data_can_recv + XQC_MAX_RECV_WINDOW;
+
+    CU_ASSERT_EQUAL(xqc_stream_do_recv_flow_ctl(stream), XQC_OK);
+
+    CU_ASSERT_EQUAL(stream->stream_flow_ctl.fc_max_stream_data_can_recv, expected);
+    CU_ASSERT(stream->stream_flow_ctl.fc_max_stream_data_can_recv < XQC_MAX_FLOW_CONTROL_WINDOW);
+
+    xqc_engine_destroy(conn->engine);
+}

--- a/tests/unittest/xqc_flow_ctl_test.h
+++ b/tests/unittest/xqc_flow_ctl_test.h
@@ -1,0 +1,13 @@
+/**
+ * @copyright Copyright (c) 2022, Alibaba Group Holding Limited
+ */
+
+#ifndef _XQC_TEST_FLOW_CTL_H_INCLUDED_
+#define _XQC_TEST_FLOW_CTL_H_INCLUDED_
+
+void xqc_test_flow_ctl_clamp_boundary(void);
+void xqc_test_stream_flow_ctl_clamp(void);
+void xqc_test_conn_flow_ctl_clamp(void);
+void xqc_test_flow_ctl_normal_no_clamp(void);
+
+#endif /* _XQC_TEST_FLOW_CTL_H_INCLUDED_ */


### PR DESCRIPTION
### Mechanism

The receive-side flow control limits grow by adding a window size to a read
offset or byte counter, and no growth path bounded the result. RFC 9000
section 4.2 forbids advertising a Maximum Data value above the variable-length
integer maximum, so every growth path of the connection and stream receive
limits is now clamped at 2^62-1. Values below the limit pass through unchanged.

- RFC or draft: `RFC 9000 section 4.2`

Fixes: #675

### Validation Cases

- `Not applicable — the clamp only engages as receive offsets and byte counters approach 2^62-1, which no real client-to-server transfer can reach.`

### CONTRIBUTING.md

- Overall: `Passed`
- Local regression: `Complete`
- CI: `Complete`
