### PR TITLE
[+] #679 remove TRA_HS_CERTIFICATE_VERIFY_FAIL (0x1FE) from reserved CRYPTO_ERROR range

### DIFF
--- a/include/xquic/xqc_errno.h
+++ b/include/xquic/xqc_errno.h
@@ -37,7 +37,6 @@ typedef enum {
     TRA_VERSION_NEGOTIATION_ERROR   =  0x53,
     /* RFC 9001 Section 4.8: TLS alert 120 maps to 0x100 + 120 = 0x178 */
     TRA_NO_APPLICATION_PROTOCOL     =  0x178,
-    TRA_HS_CERTIFICATE_VERIFY_FAIL  =  0x1FE, /**< for handshake certificate verify error */
 } xqc_trans_err_code_t;
 
 


### PR DESCRIPTION
Remove dead enum value that occupied RFC 9000 §20.1 reserved CRYPTO_ERROR range. Closes #679