### PR TITLE
Fix buffer overflow, QPACK DDoS, SSL cert ordering, and CWE-770 crypto frame flood vulnerabilities

### DIFF
--- a/include/xquic/xquic.h
+++ b/include/xquic/xquic.h
@@ -1539,6 +1539,20 @@ typedef struct xqc_conn_settings_s {
      * (type 0x03) with dummy ECN counts instead of plain ACK (0x02).
      */
     uint8_t                     simulate_ecn;
+
+    /**
+     * Maximum blocked buffer size per stream (bytes) for QPACK decode blocking.
+     * This limits memory usage when QPACK decoding is blocked waiting for
+     * dynamic table updates. Default: 0 (use internal default: 1MB)
+     */
+    size_t                      max_blocked_buf_per_stream;
+
+    /**
+     * Maximum total blocked buffer size per connection (bytes) for QPACK decode blocking.
+     * This limits total memory usage across all blocked streams on a connection.
+     * Default: 0 (use internal default: 8MB)
+     */
+    size_t                      max_blocked_buf_per_conn;
 } xqc_conn_settings_t;
 
 

--- a/src/common/xqc_log_event_callback.c
+++ b/src/common/xqc_log_event_callback.c
@@ -65,8 +65,10 @@ xqc_log_CON_CONNECTION_CLOSED_callback(xqc_log_t *log, const char *func, xqc_con
             xqc_calc_delay(path->path_send_ctl->ctl_recent_cwnd_limitation_time[(idx + 1) % 3], conn->conn_create_time) / 1000,
             xqc_calc_delay(path->path_send_ctl->ctl_recent_cwnd_limitation_time[(idx + 2) % 3], conn->conn_create_time) / 1000
             );
-            if (p != last) {
+            if (p < last) {
                 *p = '\0';
+            } else {
+                *(last - 1) = '\0';
             }
         }
         xqc_qlog_implement(log, CON_CONNECTION_CLOSED, func,
@@ -145,8 +147,10 @@ xqc_log_TRA_VERSION_INFORMATION_callback(xqc_log_t *log, const char *func, uint3
         p = xqc_sprintf(p, last, " %d", remote_version[i]);
     }
 
-    if (p != last) {
+    if (p < last) {
         *p = '\0';
+    } else {
+        *(last - 1) = '\0';
     }
 
     xqc_qlog_implement(log, TRA_VERSION_INFORMATION, func,
@@ -325,8 +329,10 @@ xqc_log_TRA_FRAMES_PROCESSED_callback(xqc_log_t *log, const char *func, ...)
         }
 
         p = xqc_sprintf(p, last, "}");
-        if (p != last) {
+        if (p < last) {
             *p = '\0';
+        } else {
+            *(last - 1) = '\0';
         }
 
         xqc_qlog_implement(log, TRA_FRAMES_PROCESSED, func,

--- a/src/http3/xqc_h3_conn.c
+++ b/src/http3/xqc_h3_conn.c
@@ -497,6 +497,12 @@ xqc_h3_conn_create(xqc_connection_t *conn, void *user_data)
 #endif
     }
 
+    /* read effective blocked buffer limits (already computed in xqc_server_set_conn_settings) */
+    h3c->max_blocked_buf_per_stream = conn->conn_settings.max_blocked_buf_per_stream;
+    h3c->max_blocked_buf_per_conn = conn->conn_settings.max_blocked_buf_per_conn;
+    xqc_log(h3c->log, XQC_LOG_DEBUG, "|blocked_buf_limits|per_stream:%uz|per_conn:%uz|",
+            h3c->max_blocked_buf_per_stream, h3c->max_blocked_buf_per_conn);
+
     /* create qpack */
     h3c->qpack = xqc_qpack_create(h3c->local_h3_conn_settings.qpack_enc_max_table_capacity,
                                   h3c->local_h3_conn_settings.qpack_dec_max_table_capacity,

--- a/src/http3/xqc_h3_conn.h
+++ b/src/http3/xqc_h3_conn.h
@@ -96,6 +96,13 @@ typedef struct xqc_h3_conn_s {
     /* h3 settings */
     xqc_h3_conn_settings_t       local_h3_conn_settings; /* set by user for sending to the peer */
     xqc_h3_conn_settings_t       peer_h3_conn_settings;  /* receive from peer */
+
+    /* blocked buffer limits (effective values computed at init time) */
+    size_t                       max_blocked_buf_per_stream;       /* effective limit per stream */
+    size_t                       max_blocked_buf_per_conn;         /* effective limit per connection */
+
+    /* blocked buffer monitoring */
+    size_t                       total_blocked_buf_size;           /* current total blocked buffer size */
 } xqc_h3_conn_t;
 
 

--- a/src/http3/xqc_h3_request.c
+++ b/src/http3/xqc_h3_request.c
@@ -850,21 +850,23 @@ xqc_h3_request_on_recv_header(xqc_h3_request_t *h3r)
      * Any message containing connection-specific header fields
      * MUST be treated as malformed (H3_MESSAGE_ERROR).
      */
-    for (size_t fi = 0; fi < headers->count; fi++) {
-        xqc_http_header_t *hdr = &headers->headers[fi];
-        if (xqc_h3_hdr_is_forbidden(hdr->name.iov_base,
-                                     hdr->name.iov_len,
-                                     hdr->value.iov_base,
-                                     hdr->value.iov_len))
-        {
-            xqc_log(h3r->h3_stream->log, XQC_LOG_ERROR,
-                    "|forbidden header in h3|conn:%p|stream_id:%ui|"
-                    "name:%*s|",
-                    h3r->h3_stream->h3c->conn,
-                    h3r->h3_stream->stream_id,
-                    (int)hdr->name.iov_len,
-                    (char *)hdr->name.iov_base);
-            return -XQC_H3_INVALID_HEADER;
+    if (headers->headers != NULL) {
+        for (size_t fi = 0; fi < headers->count; fi++) {
+            xqc_http_header_t *hdr = &headers->headers[fi];
+            if (xqc_h3_hdr_is_forbidden(hdr->name.iov_base,
+                                         hdr->name.iov_len,
+                                         hdr->value.iov_base,
+                                         hdr->value.iov_len))
+            {
+                xqc_log(h3r->h3_stream->log, XQC_LOG_ERROR,
+                        "|forbidden header in h3|conn:%p|stream_id:%ui|"
+                        "name:%*s|",
+                        h3r->h3_stream->h3c->conn,
+                        h3r->h3_stream->stream_id,
+                        (int)hdr->name.iov_len,
+                        (char *)hdr->name.iov_base);
+                return -XQC_H3_INVALID_HEADER;
+            }
         }
     }
 

--- a/src/http3/xqc_h3_stream.c
+++ b/src/http3/xqc_h3_stream.c
@@ -34,6 +34,7 @@ xqc_h3_stream_create(xqc_h3_conn_t *h3c, xqc_stream_t *stream, xqc_h3_stream_typ
     h3s->blocked_stream = NULL;
     xqc_init_list_head(&h3s->send_buf);
     xqc_init_list_head(&h3s->blocked_buf);
+    h3s->blocked_buf_size = 0;
     h3s->ctx = xqc_qpack_create_req_ctx(stream->stream_id);
     h3s->log = h3c->log;
     h3s->recv_rate_limit = stream->recv_rate_bytes_per_sec;
@@ -98,6 +99,12 @@ xqc_h3_stream_destroy(xqc_h3_stream_t *h3s)
     xqc_h3_frm_reset_pctx(&h3s->pctx.frame_pctx);
     xqc_qpack_destroy_req_ctx(h3s->ctx);
     xqc_list_buf_list_free(&h3s->send_buf);
+
+    /* update connection-level blocked buffer counter before freeing */
+    if (h3s->blocked_buf_size > 0 && h3s->h3c != NULL) {
+        h3s->h3c->total_blocked_buf_size -= h3s->blocked_buf_size;
+        h3s->blocked_buf_size = 0;
+    }
     xqc_list_buf_list_free(&h3s->blocked_buf);
 
     xqc_log(h3s->log, XQC_LOG_DEBUG, "|stream_id:%ui|h3_stream_type:%d|",
@@ -1561,6 +1568,28 @@ xqc_h3_stream_process_in(xqc_h3_stream_t *h3s, unsigned char *data, size_t data_
                 return XQC_ERROR;
             }
 
+            /* check blocked buffer size limit */
+            size_t remaining_size = data_len - processed;
+            if (h3c->max_blocked_buf_per_stream
+                && (h3s->blocked_buf_size + remaining_size > h3c->max_blocked_buf_per_stream))
+            {
+                xqc_log(h3c->log, XQC_LOG_ERROR,
+                        "|blocked buffer size limit exceeded|stream_id:%ui|current:%uz|adding:%uz|limit:%uz|",
+                        h3s->stream_id, h3s->blocked_buf_size, remaining_size, h3c->max_blocked_buf_per_stream);
+                XQC_H3_CONN_ERR(h3c, H3_EXCESSIVE_LOAD, -XQC_H3_EPROC_REQUEST);
+                return -XQC_H3_EPROC_REQUEST;
+            }
+
+            if (h3c->max_blocked_buf_per_conn
+                && (h3c->total_blocked_buf_size + remaining_size > h3c->max_blocked_buf_per_conn))
+            {
+                xqc_log(h3c->log, XQC_LOG_ERROR,
+                        "|connection blocked buffer size limit exceeded|total:%uz|adding:%uz|limit:%uz|",
+                        h3c->total_blocked_buf_size, remaining_size, h3c->max_blocked_buf_per_conn);
+                XQC_H3_CONN_ERR(h3c, H3_EXCESSIVE_LOAD, -XQC_H3_EPROC_REQUEST);
+                return -XQC_H3_EPROC_REQUEST;
+            }
+
             /* if blocked, store data in blocked buffer */
             xqc_var_buf_t *buf = xqc_var_buf_create(XQC_DATA_BUF_SIZE_4K);
             if (buf == NULL) {
@@ -1578,6 +1607,10 @@ xqc_h3_stream_process_in(xqc_h3_stream_t *h3s, unsigned char *data, size_t data_
                 xqc_var_buf_free(buf);
                 return ret;
             }
+
+            /* update blocked buffer size counters  */
+            h3s->blocked_buf_size += remaining_size;
+            h3c->total_blocked_buf_size += remaining_size;
         }
     }
 
@@ -1634,6 +1667,27 @@ xqc_h3_stream_process_blocked_data(xqc_stream_t *stream, xqc_h3_stream_t *h3s, x
 
     do
     {
+        /* check blocked buffer size limit before receiving more data */
+        if (h3s->h3c->max_blocked_buf_per_stream
+            && (h3s->blocked_buf_size >= h3s->h3c->max_blocked_buf_per_stream))
+        {
+            xqc_log(h3s->log, XQC_LOG_ERROR,
+                    "|blocked buffer size limit reached|stream_id:%ui|size:%uz|limit:%uz|",
+                    h3s->stream_id, h3s->blocked_buf_size, h3s->h3c->max_blocked_buf_per_stream);
+            XQC_H3_CONN_ERR(h3s->h3c, H3_EXCESSIVE_LOAD, -XQC_H3_EPROC_REQUEST);
+            return -XQC_H3_EPROC_REQUEST;
+        }
+
+        if (h3s->h3c->max_blocked_buf_per_conn
+            && (h3s->h3c->total_blocked_buf_size >= h3s->h3c->max_blocked_buf_per_conn))
+        {
+            xqc_log(h3s->log, XQC_LOG_ERROR,
+                    "|connection blocked buffer size limit reached|total:%uz|limit:%uz|",
+                    h3s->h3c->total_blocked_buf_size, h3s->h3c->max_blocked_buf_per_conn);
+            XQC_H3_CONN_ERR(h3s->h3c, H3_EXCESSIVE_LOAD, -XQC_H3_EPROC_REQUEST);
+            return -XQC_H3_EPROC_REQUEST;
+        }
+
         buf = xqc_h3_stream_get_buf(h3s, &h3s->blocked_buf, XQC_DATA_BUF_SIZE_4K);
         if (buf == NULL) {
             return -XQC_EMALLOC;
@@ -1654,6 +1708,10 @@ xqc_h3_stream_process_blocked_data(xqc_stream_t *stream, xqc_h3_stream_t *h3s, x
 
         buf->data_len += rcvd;
         buf->fin_flag = *fin;
+
+        /* update blocked buffer size counters  */
+        h3s->blocked_buf_size += rcvd;
+        h3s->h3c->total_blocked_buf_size += rcvd;
 
         if (*fin) {
             h3s->flags |= XQC_HTTP3_STREAM_FLAG_READ_EOF;
@@ -1767,6 +1825,10 @@ xqc_h3_stream_process_blocked_stream(xqc_h3_stream_t *h3s)
             return processed;
         }
         buf->consumed_len += processed;
+
+        /* update blocked buffer size counters: subtract consumed bytes */
+        h3s->blocked_buf_size -= processed;
+        h3s->h3c->total_blocked_buf_size -= processed;
 
         if (buf->consumed_len == buf->data_len) {
             xqc_list_buf_free(list_buf);

--- a/src/http3/xqc_h3_stream.h
+++ b/src/http3/xqc_h3_stream.h
@@ -11,6 +11,12 @@
 #include "src/http3/frame/xqc_h3_frame.h"
 #include "src/transport/xqc_stream.h"
 
+/* Default maximum size of blocked buffer per stream (1 MB) */
+#define XQC_H3_STREAM_MAX_BLOCKED_BUF_SIZE_DEFAULT (1 * 1024 * 1024)
+
+/* Default maximum total size of blocked buffers per connection (8 MB) */
+#define XQC_H3_CONN_MAX_BLOCKED_BUF_SIZE_DEFAULT (8 * 1024 * 1024)
+
 typedef struct xqc_h3_conn_s    xqc_h3_conn_t;
 typedef struct xqc_h3_stream_s  xqc_h3_stream_t;
 
@@ -136,6 +142,8 @@ typedef struct xqc_h3_stream_s {
     /* blocked data buffer, used to store request
        stream data when stream is blocked */
     xqc_list_head_t                 blocked_buf;
+    /* current size of blocked buffer */
+    size_t                          blocked_buf_size;
     xqc_h3_blocked_stream_t        *blocked_stream;
 
     /* context of representation */

--- a/src/tls/xqc_tls.c
+++ b/src/tls/xqc_tls.c
@@ -1122,17 +1122,35 @@ xqc_ssl_cert_cb(SSL *ssl, void *arg)
             goto end;
         }
 
-        ssl_ret = SSL_set1_chain(ssl, chain);
-        if (ssl_ret != XQC_SSL_SUCCESS) {
-            xqc_log(tls->log, XQC_LOG_ERROR,
-                    "|set chain error|sni:%s|ret:%d", hostname, ssl_ret);
-            return XQC_SSL_FAIL;
-        }
-
+        /*
+         * IMPORTANT: SSL_use_certificate MUST be called BEFORE SSL_set1_chain.
+         *
+         * SSL_use_certificate() internally calls ssl_set_cert(), which switches
+         * ssl->cert->key to the pkey slot matching the new certificate type
+         * (e.g., RSA → ECC).  SSL_set1_chain() operates on ssl->cert->key->chain,
+         * i.e., the *current* slot.
+         *
+         * If SSL_set1_chain is called first (old order), the chain is written to
+         * the OLD slot (inherited from xquic SSL_CTX).  Then SSL_use_certificate
+         * switches to the NEW slot, whose chain is NULL.  During handshake,
+         * BabaSSL reads ssl->cert->key->chain from the NEW slot → NULL → client
+         * receives only the leaf certificate → TLS alert unknown_ca (0x130).
+         *
+         * The correct order matches BabaSSL's own SSL_CTX_use_certificate_chain_file:
+         *   1. SSL_CTX_use_certificate  (switch slot)
+         *   2. SSL_CTX_add0_chain_cert  (add chain to current slot)
+         */
         ssl_ret = SSL_use_certificate(ssl, crt);
         if (ssl_ret != XQC_SSL_SUCCESS) {
             xqc_log(tls->log, XQC_LOG_ERROR,
                     "|set certificate error|sni:%s|ret:%d", hostname, ssl_ret);
+            return XQC_SSL_FAIL;
+        }
+
+        ssl_ret = SSL_set1_chain(ssl, chain);
+        if (ssl_ret != XQC_SSL_SUCCESS) {
+            xqc_log(tls->log, XQC_LOG_ERROR,
+                    "|set chain error|sni:%s|ret:%d", hostname, ssl_ret);
             return XQC_SSL_FAIL;
         }
 

--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -380,6 +380,19 @@ xqc_server_set_conn_settings(xqc_engine_t *engine, const xqc_conn_settings_t *se
     }
 
     engine->default_conn_settings.simulate_ecn = settings->simulate_ecn;
+
+    /* compute effective blocked buffer limits (use default if not configured) */
+    if (settings->max_blocked_buf_per_stream > 0) {
+        engine->default_conn_settings.max_blocked_buf_per_stream = settings->max_blocked_buf_per_stream;
+    } else {
+        engine->default_conn_settings.max_blocked_buf_per_stream = XQC_H3_STREAM_MAX_BLOCKED_BUF_SIZE_DEFAULT;
+    }
+
+    if (settings->max_blocked_buf_per_conn > 0) {
+        engine->default_conn_settings.max_blocked_buf_per_conn = settings->max_blocked_buf_per_conn;
+    } else {
+        engine->default_conn_settings.max_blocked_buf_per_conn = XQC_H3_CONN_MAX_BLOCKED_BUF_SIZE_DEFAULT;
+    }
 }
 
 static const char * const xqc_conn_flag_to_str[XQC_CONN_FLAG_SHIFT_NUM] = {

--- a/src/transport/xqc_defs.h
+++ b/src/transport/xqc_defs.h
@@ -38,6 +38,14 @@
 
 #define XQC_CONN_MAX_CRYPTO_DATA_TOTAL_LEN (10*1024*1024)
 
+/*
+ * CWE-770 mitigation: limit buffered out-of-order CRYPTO frame resources.
+ * These caps prevent unbounded memory allocation from sparse CRYPTO fragments
+ * that keep next_read_offset pinned (RFC 9001 §5.2 attack surface).
+ */
+#define XQC_MAX_CRYPTO_FRAME_BUFFERED_COUNT     1024    /* max buffered frame nodes per crypto stream */
+#define XQC_MAX_CRYPTO_FRAME_BUFFERED_BYTES     (1*1024*1024)  /* max buffered data bytes per crypto stream (1MB), accommodates large cert chains under reordering */
+
 
 /* xquic will not send stateless reset to packets which are smaller than
    XQC_STATELESS_RESET_PKT_MIN_LEN */

--- a/src/transport/xqc_defs.h
+++ b/src/transport/xqc_defs.h
@@ -69,8 +69,8 @@ extern const unsigned char  xqc_proto_version_field[][XQC_PROTO_VERSION_LEN];
 /* max alpn length */
 #define XQC_MAX_ALPN_LEN                        255
 
-/* limit of anti-amplification */
-#define XQC_DEFAULT_ANTI_AMPLIFICATION_LIMIT    5
+/* limit of anti-amplification (RFC 9000 Section 8.1) */
+#define XQC_DEFAULT_ANTI_AMPLIFICATION_LIMIT    3
 
 #define XQC_MAX_MT_ROW                          256
 

--- a/src/transport/xqc_frame.c
+++ b/src/transport/xqc_frame.c
@@ -1651,7 +1651,7 @@ xqc_process_path_challenge_frame(xqc_connection_t *conn, xqc_packet_in_t *packet
 
     xqc_log(conn->log, XQC_LOG_DEBUG, 
             "|path:%ui|state:%d|RECV path_challenge_data:%*s|cid:%s|",
-            path->path_id, path->path_state, XQC_PATH_CHALLENGE_DATA_LEN, 
+            path->path_id, path->path_state, (size_t)XQC_PATH_CHALLENGE_DATA_LEN,
             path_challenge_data, xqc_dcid_str(conn->engine, &packet_in->pi_pkt.pkt_dcid));
 
     ret = xqc_write_path_response_frame_to_packet(conn, path, path_challenge_data);
@@ -1704,7 +1704,7 @@ xqc_process_path_response_frame(xqc_connection_t *conn, xqc_packet_in_t *packet_
      * MAY generate a connection error of type PROTOCOL_VIOLATION.
      */
 
-    if (memcmp(path->path_challenge_data, path_response_data, XQC_PATH_CHALLENGE_DATA_LEN) != 0) {
+    if (memcmp(path->path_challenge_data, path_response_data, (size_t)XQC_PATH_CHALLENGE_DATA_LEN) != 0) {
         xqc_log(conn->log, XQC_LOG_ERROR, "|path:%ui|ignore|no match path challenge data|", path->path_id);
         return XQC_OK;
     }

--- a/src/transport/xqc_frame.c
+++ b/src/transport/xqc_frame.c
@@ -674,6 +674,31 @@ xqc_insert_crypto_frame(xqc_connection_t *conn, xqc_stream_t *stream, xqc_stream
                 "|crypto frame data buffer exceed|");
         return ret;
     }
+
+    /* CWE-770 mitigation: reject if buffered frame count or data bytes exceed caps.
+     * This prevents sparse out-of-order CRYPTO fragments from causing unbounded
+     * memory allocation when next_read_offset is pinned by gaps. */
+    if (stream->stream_data_in.buffered_frame_count >= XQC_MAX_CRYPTO_FRAME_BUFFERED_COUNT) {
+        XQC_CONN_ERR(conn, TRA_CRYPTO_BUFFER_EXCEEDED);
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|crypto frame buffered count exceed|count:%ui|limit:%d|",
+                stream->stream_data_in.buffered_frame_count,
+                XQC_MAX_CRYPTO_FRAME_BUFFERED_COUNT);
+        return -XQC_ELIMIT;
+    }
+
+    if (stream->stream_data_in.buffered_data_bytes + stream_frame->data_length
+        > XQC_MAX_CRYPTO_FRAME_BUFFERED_BYTES)
+    {
+        XQC_CONN_ERR(conn, TRA_CRYPTO_BUFFER_EXCEEDED);
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|crypto frame buffered bytes exceed|bytes:%ui|new:%ud|limit:%d|",
+                stream->stream_data_in.buffered_data_bytes,
+                stream_frame->data_length,
+                XQC_MAX_CRYPTO_FRAME_BUFFERED_BYTES);
+        return -XQC_ELIMIT;
+    }
+
     xqc_list_for_each_reverse(pos, &stream->stream_data_in.frames_tailq) {
         frame = xqc_list_entry(pos, xqc_stream_frame_t, sf_list);
 
@@ -687,6 +712,10 @@ xqc_insert_crypto_frame(xqc_connection_t *conn, xqc_stream_t *stream, xqc_stream
     if (!inserted) {
         xqc_list_add(&stream_frame->sf_list, &stream->stream_data_in.frames_tailq);
     }
+
+    /* update buffered resource counters */
+    stream->stream_data_in.buffered_frame_count++;
+    stream->stream_data_in.buffered_data_bytes += stream_frame->data_length;
 
     return XQC_OK;
 }

--- a/src/transport/xqc_frame.h
+++ b/src/transport/xqc_frame.h
@@ -173,6 +173,8 @@ xqc_int_t xqc_process_padding_frame(xqc_connection_t *conn, xqc_packet_in_t *pac
 
 xqc_int_t xqc_process_stream_frame(xqc_connection_t *conn, xqc_packet_in_t *packet_in);
 
+xqc_int_t xqc_insert_crypto_frame(xqc_connection_t *conn, xqc_stream_t *stream, xqc_stream_frame_t *stream_frame);
+
 xqc_int_t xqc_process_crypto_frame(xqc_connection_t *conn, xqc_packet_in_t *packet_in);
 
 xqc_int_t xqc_process_ack_frame(xqc_connection_t *conn, xqc_packet_in_t *packet_in);

--- a/src/transport/xqc_stream.c
+++ b/src/transport/xqc_stream.c
@@ -1087,6 +1087,15 @@ xqc_read_crypto_stream(xqc_stream_t *stream)
 
         if (stream->stream_data_in.next_read_offset >= stream_frame->data_offset + stream_frame->data_length) {
             xqc_list_del(pos);
+            /* decrement buffered resource counters */
+            if (stream->stream_data_in.buffered_frame_count > 0) {
+                stream->stream_data_in.buffered_frame_count--;
+            }
+            if (stream->stream_data_in.buffered_data_bytes >= stream_frame->data_length) {
+                stream->stream_data_in.buffered_data_bytes -= stream_frame->data_length;
+            } else {
+                stream->stream_data_in.buffered_data_bytes = 0;
+            }
             xqc_destroy_stream_frame(stream_frame);
             continue;
         }
@@ -1099,6 +1108,15 @@ xqc_read_crypto_stream(xqc_stream_t *stream)
         xqc_int_t ret = xqc_tls_process_crypto_data(conn->tls, stream->stream_encrypt_level, data_start, data_len);
 
         xqc_list_del(pos);
+        /* decrement buffered resource counters */
+        if (stream->stream_data_in.buffered_frame_count > 0) {
+            stream->stream_data_in.buffered_frame_count--;
+        }
+        if (stream->stream_data_in.buffered_data_bytes >= stream_frame->data_length) {
+            stream->stream_data_in.buffered_data_bytes -= stream_frame->data_length;
+        } else {
+            stream->stream_data_in.buffered_data_bytes = 0;
+        }
         xqc_destroy_stream_frame(stream_frame);
 
         if (ret != XQC_OK) {

--- a/src/transport/xqc_stream.h
+++ b/src/transport/xqc_stream.h
@@ -92,6 +92,10 @@ typedef struct xqc_stream_data_in_s {
     uint64_t                next_read_offset;   /* next offset in stream */
     uint64_t                stream_length;
     xqc_bool_t              stream_determined;
+
+    /* buffered out-of-order frame resource tracking (CWE-770 mitigation) */
+    uint64_t                buffered_frame_count;   /* number of buffered frame nodes */
+    uint64_t                buffered_data_bytes;    /* total bytes of buffered frame data */
 } xqc_stream_data_in_t;
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -113,6 +113,7 @@ if(HAVE_CUNIT)
         ${UNIT_TEST_DIR}/xqc_datagram_test.c
         ${UNIT_TEST_DIR}/xqc_h3_ext_test.c
         ${UNIT_TEST_DIR}/xqc_ack_with_timestamp_test.c
+        ${UNIT_TEST_DIR}/xqc_crypto_frame_test.c
         ${UNIT_TEST_DIR}/xqc_send_ctl_test.c
         ${UNIT_TEST_DIR}/xqc_vn_test.c
         ${UNIT_TEST_DIR}/xqc_frame_type_bit_test.c

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -2612,6 +2612,10 @@ int main(int argc, char *argv[]) {
         conn_settings.receive_timestamps_exponent = 0;
     }
 
+    /* Set larger blocked buffer limits for QPACK to avoid triggering limits in tests */
+    conn_settings.max_blocked_buf_per_stream = 10 * 1024 * 1024;  /* 10 MB per stream */
+    conn_settings.max_blocked_buf_per_conn = 50 * 1024 * 1024;    /* 50 MB per connection */
+
     if (g_test_case == 451) {
         conn_settings.extended_ack_features = 0;
         conn_settings.max_receive_timestamps_per_ack = 40;

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -41,6 +41,7 @@
 #include "xqc_fec_scheme_test.h"
 #include "xqc_fec_test.h"
 #include "xqc_ack_with_timestamp_test.h"
+#include "xqc_crypto_frame_test.h"
 #include "xqc_send_ctl_test.h"
 #include "xqc_vn_test.h"
 #include "xqc_frame_type_bit_test.h"
@@ -93,6 +94,9 @@ main()
         || !CU_add_test(pSuite, "xqc_test_cubic_init_cwnd", xqc_test_cubic_init_cwnd)
         || !CU_add_test(pSuite, "xqc_test_short_header_parse_cid", xqc_test_short_header_packet_parse_cid)
         || !CU_add_test(pSuite, "xqc_test_long_header_parse_cid", xqc_test_long_header_packet_parse_cid)
+        || !CU_add_test(pSuite, "xqc_test_crypto_frame_flood", xqc_test_crypto_frame_flood)
+        || !CU_add_test(pSuite, "xqc_test_crypto_frame_bytes_limit", xqc_test_crypto_frame_bytes_limit)
+        || !CU_add_test(pSuite, "xqc_test_crypto_frame_recycle", xqc_test_crypto_frame_recycle)
         || !CU_add_test(pSuite, "xqc_test_stream_frame_offset_overflow", xqc_test_stream_frame_offset_overflow)
         || !CU_add_test(pSuite, "xqc_test_crypto_frame_in_0rtt_rejected", xqc_test_crypto_frame_in_0rtt_rejected)
         || !CU_add_test(pSuite, "xqc_test_crypto_frame_in_initial_accepted", xqc_test_crypto_frame_in_initial_accepted)

--- a/tests/unittest/xqc_crypto_frame_test.c
+++ b/tests/unittest/xqc_crypto_frame_test.c
@@ -1,0 +1,297 @@
+/**
+ * @copyright Copyright (c) 2022, Alibaba Group Holding Limited
+ */
+
+#include "xqc_crypto_frame_test.h"
+#include <CUnit/CUnit.h>
+#include "src/transport/xqc_conn.h"
+#include "src/transport/xqc_engine.h"
+#include "src/transport/xqc_frame.h"
+#include "src/transport/xqc_stream.h"
+#include "src/transport/xqc_defs.h"
+#include "xqc_common_test.h"
+
+/**
+ * Test: Sparse CRYPTO frame flood (CWE-770 mitigation)
+ *
+ * Simulates the attack described in ALIBABA-2026-41242004:
+ * - Insert tiny CRYPTO frames at sparse even offsets (step=2)
+ * - Odd offsets are never filled, so next_read_offset stays pinned at 0
+ * - Without the fix, all frames would be buffered indefinitely
+ * - With the fix, insertion should fail after hitting the buffered_frame_count limit
+ */
+void
+xqc_test_crypto_frame_flood()
+{
+    xqc_int_t ret;
+
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT(conn != NULL);
+    if (conn == NULL) {
+        return;
+    }
+
+    /* Create a crypto stream (Initial level) */
+    xqc_stream_t *stream = xqc_create_crypto_stream(conn, XQC_ENC_LEV_INIT, NULL);
+    CU_ASSERT(stream != NULL);
+    if (stream == NULL) {
+        xqc_engine_destroy(conn->engine);
+        return;
+    }
+    conn->crypto_stream[XQC_ENC_LEV_INIT] = stream;
+
+    /* Verify initial state */
+    CU_ASSERT(stream->stream_data_in.buffered_frame_count == 0);
+    CU_ASSERT(stream->stream_data_in.buffered_data_bytes == 0);
+    CU_ASSERT(stream->stream_data_in.next_read_offset == 0);
+
+    /*
+     * Insert sparse CRYPTO frames at even offsets (0, 2, 4, 6, ...),
+     * each with 1 byte of data. Since offset 1, 3, 5... are never filled,
+     * next_read_offset can only advance to 1 (consuming offset 0's 1 byte),
+     * leaving all subsequent frames buffered.
+     *
+     * We insert more than XQC_MAX_CRYPTO_FRAME_BUFFERED_COUNT to trigger rejection.
+     */
+    uint64_t offset_step = 2;
+    uint64_t data_len = 1;
+    uint64_t insert_count = 0;
+    uint64_t rejected_at = 0;
+
+    /* First insert offset=0 so next_read_offset advances to 1
+     * (simulating TLS processing the first byte) */
+    /* Actually for this test, we skip offset 0 entirely to keep next_read_offset pinned at 0 */
+
+    for (uint64_t i = 0; i < XQC_MAX_CRYPTO_FRAME_BUFFERED_COUNT + 100; i++) {
+        uint64_t offset = (i + 1) * offset_step;  /* start at offset 2 to leave gap at 0,1 */
+
+        xqc_stream_frame_t *frame = xqc_calloc(1, sizeof(xqc_stream_frame_t));
+        CU_ASSERT(frame != NULL);
+        if (frame == NULL) {
+            break;
+        }
+
+        frame->data = xqc_malloc(data_len);
+        CU_ASSERT(frame->data != NULL);
+        if (frame->data == NULL) {
+            xqc_free(frame);
+            break;
+        }
+        memset(frame->data, (unsigned char)(offset & 0xFF), data_len);
+        frame->data_length = data_len;
+        frame->data_offset = offset;
+
+        ret = xqc_insert_crypto_frame(conn, stream, frame);
+        if (ret != XQC_OK) {
+            /* Should be rejected due to buffered_frame_count limit */
+            rejected_at = i;
+            xqc_free(frame->data);
+            xqc_free(frame);
+            break;
+        }
+        insert_count++;
+    }
+
+    /* Verify that the limit was hit */
+    CU_ASSERT(insert_count == XQC_MAX_CRYPTO_FRAME_BUFFERED_COUNT);
+    CU_ASSERT(rejected_at == XQC_MAX_CRYPTO_FRAME_BUFFERED_COUNT);
+
+    /* Verify counters are correct */
+    CU_ASSERT(stream->stream_data_in.buffered_frame_count == XQC_MAX_CRYPTO_FRAME_BUFFERED_COUNT);
+    CU_ASSERT(stream->stream_data_in.buffered_data_bytes == XQC_MAX_CRYPTO_FRAME_BUFFERED_COUNT * data_len);
+
+    /* Verify next_read_offset is still 0 (pinned by the gap at offset 0-1) */
+    CU_ASSERT(stream->stream_data_in.next_read_offset == 0);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+/**
+ * Test: CRYPTO frame buffered bytes limit (CWE-770 mitigation)
+ *
+ * Verifies that the byte-size cap (XQC_MAX_CRYPTO_FRAME_BUFFERED_BYTES) is
+ * enforced independently of the node-count cap. Uses large fragments so the
+ * byte limit is reached before the node count limit.
+ */
+void
+xqc_test_crypto_frame_bytes_limit()
+{
+    xqc_int_t ret;
+
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT(conn != NULL);
+    if (conn == NULL) {
+        return;
+    }
+
+    xqc_stream_t *stream = xqc_create_crypto_stream(conn, XQC_ENC_LEV_INIT, NULL);
+    CU_ASSERT(stream != NULL);
+    if (stream == NULL) {
+        xqc_engine_destroy(conn->engine);
+        return;
+    }
+    conn->crypto_stream[XQC_ENC_LEV_INIT] = stream;
+
+    /*
+     * Each fragment carries a large chunk of data. Choose frag_size so that
+     * the byte cap is hit well before the node-count cap of 1024.
+     * frag_size = 4096 -> need ~256 frames to reach 1MB, far below 1024 nodes.
+     */
+    uint64_t frag_size = 4096;
+    uint64_t offset_step = frag_size * 2;   /* leave a gap so next_read_offset stays pinned */
+    uint64_t inserted_bytes = 0;
+    uint64_t insert_count = 0;
+    xqc_bool_t rejected_by_bytes = XQC_FALSE;
+
+    for (uint64_t i = 0; i < XQC_MAX_CRYPTO_FRAME_BUFFERED_COUNT; i++) {
+        uint64_t offset = (i + 1) * offset_step;  /* gap at [0, offset_step) keeps next_read_offset pinned */
+
+        xqc_stream_frame_t *frame = xqc_calloc(1, sizeof(xqc_stream_frame_t));
+        CU_ASSERT(frame != NULL);
+        if (frame == NULL) {
+            break;
+        }
+
+        frame->data = xqc_malloc(frag_size);
+        CU_ASSERT(frame->data != NULL);
+        if (frame->data == NULL) {
+            xqc_free(frame);
+            break;
+        }
+        memset(frame->data, (unsigned char)(offset & 0xFF), frag_size);
+        frame->data_length = frag_size;
+        frame->data_offset = offset;
+
+        ret = xqc_insert_crypto_frame(conn, stream, frame);
+        if (ret != XQC_OK) {
+            /* Should be rejected by the byte limit, not the node-count limit */
+            rejected_by_bytes = XQC_TRUE;
+            xqc_free(frame->data);
+            xqc_free(frame);
+            break;
+        }
+        inserted_bytes += frag_size;
+        insert_count++;
+    }
+
+    /* The byte cap must be the trigger, while node count stays below its cap */
+    CU_ASSERT(rejected_by_bytes == XQC_TRUE);
+    CU_ASSERT(insert_count < XQC_MAX_CRYPTO_FRAME_BUFFERED_COUNT);
+
+    /* Buffered bytes must never exceed the cap */
+    CU_ASSERT(stream->stream_data_in.buffered_data_bytes <= XQC_MAX_CRYPTO_FRAME_BUFFERED_BYTES);
+    CU_ASSERT(stream->stream_data_in.buffered_data_bytes == inserted_bytes);
+
+    /* Adding one more fragment would have exceeded the cap */
+    CU_ASSERT(stream->stream_data_in.buffered_data_bytes + frag_size > XQC_MAX_CRYPTO_FRAME_BUFFERED_BYTES);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+/**
+ * Test: counters are correctly recycled on sequential (in-order) consumption.
+ *
+ * Verifies the fix does NOT break normal handshake flow: when CRYPTO frames
+ * arrive in order and are consumed by xqc_read_crypto_stream, the buffered
+ * counters must decrement back to zero so legitimate connections are never
+ * falsely rejected.
+ *
+ * Note: this test exercises the counter increment path on insert and then
+ * directly removes frames the same way the read path does, validating the
+ * decrement bookkeeping without depending on a fully initialized TLS stack.
+ */
+void
+xqc_test_crypto_frame_recycle()
+{
+    xqc_int_t ret;
+
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT(conn != NULL);
+    if (conn == NULL) {
+        return;
+    }
+
+    xqc_stream_t *stream = xqc_create_crypto_stream(conn, XQC_ENC_LEV_INIT, NULL);
+    CU_ASSERT(stream != NULL);
+    if (stream == NULL) {
+        xqc_engine_destroy(conn->engine);
+        return;
+    }
+    conn->crypto_stream[XQC_ENC_LEV_INIT] = stream;
+
+    uint64_t frag_count = 100;
+    uint64_t frag_size = 10;
+
+    /* Insert contiguous in-order frames: offsets 0,10,20,... */
+    for (uint64_t i = 0; i < frag_count; i++) {
+        xqc_stream_frame_t *frame = xqc_calloc(1, sizeof(xqc_stream_frame_t));
+        CU_ASSERT(frame != NULL);
+        if (frame == NULL) {
+            break;
+        }
+        frame->data = xqc_malloc(frag_size);
+        CU_ASSERT(frame->data != NULL);
+        if (frame->data == NULL) {
+            xqc_free(frame);
+            break;
+        }
+        memset(frame->data, (unsigned char)i, frag_size);
+        frame->data_length = frag_size;
+        frame->data_offset = i * frag_size;
+
+        ret = xqc_insert_crypto_frame(conn, stream, frame);
+        CU_ASSERT(ret == XQC_OK);
+    }
+
+    /* After inserting all in-order frames, counters reflect the full buffer */
+    CU_ASSERT(stream->stream_data_in.buffered_frame_count == frag_count);
+    CU_ASSERT(stream->stream_data_in.buffered_data_bytes == frag_count * frag_size);
+
+    /*
+     * Simulate sequential consumption like xqc_read_crypto_stream does for the
+     * "already fully consumed" branch: advance next_read_offset past each frame
+     * and remove it while decrementing counters.
+     */
+    xqc_list_head_t *pos, *next;
+    xqc_list_for_each_safe(pos, next, &stream->stream_data_in.frames_tailq) {
+        xqc_stream_frame_t *sf = xqc_list_entry(pos, xqc_stream_frame_t, sf_list);
+
+        /* mark as consumed */
+        stream->stream_data_in.next_read_offset = sf->data_offset + sf->data_length;
+
+        xqc_list_del(pos);
+        if (stream->stream_data_in.buffered_frame_count > 0) {
+            stream->stream_data_in.buffered_frame_count--;
+        }
+        if (stream->stream_data_in.buffered_data_bytes >= sf->data_length) {
+            stream->stream_data_in.buffered_data_bytes -= sf->data_length;
+        } else {
+            stream->stream_data_in.buffered_data_bytes = 0;
+        }
+        xqc_destroy_stream_frame(sf);
+    }
+
+    /* Counters must be fully recycled to zero */
+    CU_ASSERT(stream->stream_data_in.buffered_frame_count == 0);
+    CU_ASSERT(stream->stream_data_in.buffered_data_bytes == 0);
+
+    /* A fresh large insert must now succeed again (no false rejection) */
+    xqc_stream_frame_t *frame = xqc_calloc(1, sizeof(xqc_stream_frame_t));
+    CU_ASSERT(frame != NULL);
+    if (frame != NULL) {
+        frame->data = xqc_malloc(frag_size);
+        CU_ASSERT(frame->data != NULL);
+        if (frame->data != NULL) {
+            memset(frame->data, 0xAB, frag_size);
+            frame->data_length = frag_size;
+            frame->data_offset = frag_count * frag_size;  /* next in-order offset */
+            ret = xqc_insert_crypto_frame(conn, stream, frame);
+            CU_ASSERT(ret == XQC_OK);
+            CU_ASSERT(stream->stream_data_in.buffered_frame_count == 1);
+        } else {
+            xqc_free(frame);
+        }
+    }
+
+    xqc_engine_destroy(conn->engine);
+}

--- a/tests/unittest/xqc_crypto_frame_test.h
+++ b/tests/unittest/xqc_crypto_frame_test.h
@@ -1,0 +1,12 @@
+/**
+ * @copyright Copyright (c) 2022, Alibaba Group Holding Limited
+ */
+
+#ifndef _XQC_CRYPTO_FRAME_TEST_H_INCLUDED_
+#define _XQC_CRYPTO_FRAME_TEST_H_INCLUDED_
+
+void xqc_test_crypto_frame_flood();
+void xqc_test_crypto_frame_bytes_limit();
+void xqc_test_crypto_frame_recycle();
+
+#endif /* _XQC_CRYPTO_FRAME_TEST_H_INCLUDED_ */


### PR DESCRIPTION
Sync security fixes : buffer overflow in xqc_vsprintf and log callback, anti-amplification limit alignment with RFC 9000, QPACK blocked buffer size limits, SSL certificate chain ordering, and CWE-770 crypto frame flood mitigation with unit tests. Also includes a NULL deref guard in the HTTP/3 header receive path.