### PR TITLE
[+] #565 reject STREAM frame on send-only or locally initiated uncreated stream

### DIFF
--- a/src/transport/xqc_frame.c
+++ b/src/transport/xqc_frame.c
@@ -486,11 +486,8 @@ xqc_process_stream_frame(xqc_connection_t *conn, xqc_packet_in_t *packet_in)
             }
 
         } else {
-            /* RFC 9000 §19.8: locally initiated stream not yet created */
-            xqc_log(conn->log, XQC_LOG_ERROR,
-                    "|STREAM frame for locally initiated uncreated stream|stream_id:%ui|", stream_id);
-            XQC_CONN_ERR(conn, TRA_STREAM_STATE_ERROR);
-            ret = -XQC_EPROTO;
+            xqc_log(conn->log, XQC_LOG_WARN, "|cannot find stream|stream_id:%ui|", stream_id);
+            ret = XQC_OK; /* STREAM frame retransmitted after stream is closed. Ignore it. */
             goto error;
         }
     }

--- a/src/transport/xqc_frame.c
+++ b/src/transport/xqc_frame.c
@@ -486,8 +486,11 @@ xqc_process_stream_frame(xqc_connection_t *conn, xqc_packet_in_t *packet_in)
             }
 
         } else {
-            xqc_log(conn->log, XQC_LOG_WARN, "|cannot find stream|stream_id:%ui|", stream_id);
-            ret = XQC_OK; /* STREAM frame retransmitted after stream is closed. Ignore it. */
+            /* RFC 9000 §19.8: locally initiated stream not yet created */
+            xqc_log(conn->log, XQC_LOG_ERROR,
+                    "|STREAM frame for locally initiated uncreated stream|stream_id:%ui|", stream_id);
+            XQC_CONN_ERR(conn, TRA_STREAM_STATE_ERROR);
+            ret = -XQC_EPROTO;
             goto error;
         }
     }

--- a/src/transport/xqc_frame_parser.c
+++ b/src/transport/xqc_frame_parser.c
@@ -303,6 +303,19 @@ xqc_parse_stream_frame(xqc_packet_in_t *packet_in, xqc_connection_t *conn,
     }
     p += vlen;
 
+    /* RFC 9000 §19.8: reject STREAM frame on a locally initiated send-only stream */
+    {
+        xqc_stream_type_t stype = xqc_get_stream_type(*stream_id);
+        if ((conn->conn_type == XQC_CONN_TYPE_CLIENT && stype == XQC_CLI_UNI)
+            || (conn->conn_type == XQC_CONN_TYPE_SERVER && stype == XQC_SVR_UNI))
+        {
+            xqc_log(conn->log, XQC_LOG_ERROR,
+                    "|STREAM frame on send-only stream|stream_id:%ui|", *stream_id);
+            XQC_CONN_ERR(conn, TRA_STREAM_STATE_ERROR);
+            return -XQC_EPROTO;
+        }
+    }
+
     if (first_byte & 0x04) {
         vlen = xqc_vint_read(p, end, &offset);
         if (vlen < 0) {

--- a/src/transport/xqc_frame_parser.c
+++ b/src/transport/xqc_frame_parser.c
@@ -291,6 +291,7 @@ xqc_parse_stream_frame(xqc_packet_in_t *packet_in, xqc_connection_t *conn,
     uint64_t length;
     uint64_t max_stream_data_offset = (UINT64_C(1) << 62) - 1;
     int      vlen;
+    xqc_stream_type_t stype;
 
     const unsigned char *p = packet_in->pos;
     const unsigned char *end = packet_in->last;
@@ -304,16 +305,14 @@ xqc_parse_stream_frame(xqc_packet_in_t *packet_in, xqc_connection_t *conn,
     p += vlen;
 
     /* RFC 9000 §19.8: reject STREAM frame on a locally initiated send-only stream */
+    stype = xqc_get_stream_type(*stream_id);
+    if ((conn->conn_type == XQC_CONN_TYPE_CLIENT && stype == XQC_CLI_UNI)
+        || (conn->conn_type == XQC_CONN_TYPE_SERVER && stype == XQC_SVR_UNI))
     {
-        xqc_stream_type_t stype = xqc_get_stream_type(*stream_id);
-        if ((conn->conn_type == XQC_CONN_TYPE_CLIENT && stype == XQC_CLI_UNI)
-            || (conn->conn_type == XQC_CONN_TYPE_SERVER && stype == XQC_SVR_UNI))
-        {
-            xqc_log(conn->log, XQC_LOG_ERROR,
-                    "|STREAM frame on send-only stream|stream_id:%ui|", *stream_id);
-            XQC_CONN_ERR(conn, TRA_STREAM_STATE_ERROR);
-            return -XQC_EPROTO;
-        }
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|STREAM frame on send-only stream|stream_id:%ui|", *stream_id);
+        XQC_CONN_ERR(conn, TRA_STREAM_STATE_ERROR);
+        return -XQC_EPROTO;
     }
 
     if (first_byte & 0x04) {

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -123,6 +123,8 @@ main()
         || !CU_add_test(pSuite, "xqc_test_ack_ecn_truncated", xqc_test_ack_ecn_truncated)
         || !CU_add_test(pSuite, "xqc_test_ack_ecn_followed_by_ping", xqc_test_ack_ecn_followed_by_ping)
         || !CU_add_test(pSuite, "xqc_test_new_conn_id_zero_len_cid", xqc_test_new_conn_id_zero_len_cid)
+        /* issue #565: STREAM frame on send-only / locally initiated uncreated stream */
+        || !CU_add_test(pSuite, "xqc_test_stream_frame_on_send_only_stream", xqc_test_stream_frame_on_send_only_stream)
         || !CU_add_test(pSuite, "xqc_test_h3_frame", xqc_test_frame)
         || !CU_add_test(pSuite, "xqc_test_tls", xqc_test_tls)
         || !CU_add_test(pSuite, "xqc_test_h3_stream", xqc_test_stream)

--- a/tests/unittest/xqc_process_frame_test.c
+++ b/tests/unittest/xqc_process_frame_test.c
@@ -715,3 +715,40 @@ xqc_test_new_conn_id_zero_len_cid(void)
 
     xqc_engine_destroy(conn->engine);
 }
+
+
+void
+xqc_test_stream_frame_on_send_only_stream(void)
+{
+    /*
+     * RFC 9000 §19.8: receiving a STREAM frame on a send-only stream
+     * must trigger STREAM_STATE_ERROR.
+     *
+     * test_engine_connect() creates a CLIENT connection.
+     * stream_id=2 → XQC_CLI_UNI → client's send-only unidirectional stream.
+     * Frame bytes (after type byte): 0x02 (stream_id=2), 0x01 (len=1), 0x00 (data).
+     * Type byte 0x0a = STREAM|LEN, consumed by xqc_process_frames before dispatch.
+     */
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT(conn != NULL);
+    if (conn == NULL) {
+        return;
+    }
+
+    conn->conn_err = 0;
+
+    /* build packet_in with STREAM frame type 0x0a, stream_id=2 */
+    char frame_buf[] = {0x0a, 0x02, 0x01, 0x00};
+    xqc_packet_in_t pi;
+    memset(&pi, 0, sizeof(pi));
+    pi.pos = frame_buf;
+    pi.last = frame_buf + sizeof(frame_buf);
+    pi.pi_pkt.pkt_type = XQC_PTYPE_SHORT_HEADER;
+
+    /* call xqc_process_stream_frame directly; it expects pos at the type byte */
+    xqc_int_t ret = xqc_process_stream_frame(conn, &pi);
+    CU_ASSERT(ret == -XQC_EPROTO);
+    CU_ASSERT(conn->conn_err == TRA_STREAM_STATE_ERROR);
+
+    xqc_engine_destroy(conn->engine);
+}

--- a/tests/unittest/xqc_process_frame_test.h
+++ b/tests/unittest/xqc_process_frame_test.h
@@ -35,4 +35,6 @@ void xqc_test_ack_ecn_followed_by_ping();
 
 void xqc_test_new_conn_id_zero_len_cid(void);
 
+void xqc_test_stream_frame_on_send_only_stream(void);
+
 #endif /* _XQC_PROCESS_FRAME_TEST_H_INCLUDED_ */


### PR DESCRIPTION
Fix #565. Add RFC 9000 §19.8 compliance: reject STREAM frame on send-only stream with STREAM_STATE_ERROR, and reject on locally initiated uncreated stream.