### PR TITLE
[+] #566 #567 reject RESET_STREAM on send-only and STOP_SENDING on recv-only stream

### DIFF
--- a/src/transport/xqc_frame_parser.c
+++ b/src/transport/xqc_frame_parser.c
@@ -1451,12 +1451,24 @@ xqc_parse_reset_stream_frame(xqc_packet_in_t *packet_in, xqc_stream_id_t *stream
     const unsigned char first_byte = *p++;
 
     int vlen;
+    xqc_stream_type_t stype;
 
     vlen = xqc_vint_read(p, end, stream_id);
     if (vlen < 0) {
         return -XQC_EVINTREAD;
     }
     p += vlen;
+
+    /* RFC 9000 §19.4: reject RESET_STREAM on a send-only stream */
+    stype = xqc_get_stream_type(*stream_id);
+    if ((conn->conn_type == XQC_CONN_TYPE_CLIENT && stype == XQC_CLI_UNI)
+        || (conn->conn_type == XQC_CONN_TYPE_SERVER && stype == XQC_SVR_UNI))
+    {
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|RESET_STREAM on send-only stream|stream_id:%ui|", *stream_id);
+        XQC_CONN_ERR(conn, TRA_STREAM_STATE_ERROR);
+        return -XQC_EPROTO;
+    }
 
     vlen = xqc_vint_read(p, end, err_code);
     if (vlen < 0) {
@@ -1529,12 +1541,24 @@ xqc_parse_stop_sending_frame(xqc_packet_in_t *packet_in, xqc_stream_id_t *stream
     const unsigned char first_byte = *p++;
 
     int vlen;
+    xqc_stream_type_t stype;
 
     vlen = xqc_vint_read(p, end, stream_id);
     if (vlen < 0) {
         return -XQC_EVINTREAD;
     }
     p += vlen;
+
+    /* RFC 9000 §19.5: reject STOP_SENDING on a recv-only stream */
+    stype = xqc_get_stream_type(*stream_id);
+    if ((conn->conn_type == XQC_CONN_TYPE_CLIENT && stype == XQC_SVR_UNI)
+        || (conn->conn_type == XQC_CONN_TYPE_SERVER && stype == XQC_CLI_UNI))
+    {
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|STOP_SENDING on recv-only stream|stream_id:%ui|", *stream_id);
+        XQC_CONN_ERR(conn, TRA_STREAM_STATE_ERROR);
+        return -XQC_EPROTO;
+    }
 
     vlen = xqc_vint_read(p, end, err_code);
     if (vlen < 0) {

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -143,6 +143,17 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite,
                         "xqc_test_conn_close_transport_error_type_overlap",
                         xqc_test_conn_close_transport_error_type_overlap)
+        /* issue #566/#567: RESET_STREAM/STOP_SENDING on send-only/recv-only stream */
+        || !CU_add_test(pSuite, "xqc_test_reset_stream_on_send_only_stream", xqc_test_reset_stream_on_send_only_stream)
+        || !CU_add_test(pSuite, "xqc_test_stop_sending_on_recv_only_stream", xqc_test_stop_sending_on_recv_only_stream)
+        || !CU_add_test(pSuite, "xqc_test_reset_stream_on_send_only_stream_server",
+                        xqc_test_reset_stream_on_send_only_stream_server)
+        || !CU_add_test(pSuite, "xqc_test_stop_sending_on_recv_only_stream_server",
+                        xqc_test_stop_sending_on_recv_only_stream_server)
+        || !CU_add_test(pSuite, "xqc_test_reset_stream_on_recv_only_stream_accepted",
+                        xqc_test_reset_stream_on_recv_only_stream_accepted)
+        || !CU_add_test(pSuite, "xqc_test_stop_sending_on_send_only_stream_accepted",
+                        xqc_test_stop_sending_on_send_only_stream_accepted)
         || !CU_add_test(pSuite, "xqc_test_h3_frame", xqc_test_frame)
         || !CU_add_test(pSuite, "xqc_test_h3_single_vint_frame_valid",
                         xqc_test_h3_single_vint_frame_valid)

--- a/tests/unittest/xqc_process_frame_test.c
+++ b/tests/unittest/xqc_process_frame_test.c
@@ -904,3 +904,231 @@ xqc_test_new_conn_id_active_limit_exceeded(void)
 
     xqc_engine_destroy(conn->engine);
 }
+
+
+void
+xqc_test_reset_stream_on_send_only_stream(void)
+{
+    /*
+     * RFC 9000 §19.4: receiving RESET_STREAM on a send-only stream must
+     * trigger STREAM_STATE_ERROR.
+     *
+     * test_engine_connect() creates a CLIENT connection.
+     * stream_id=2 -> XQC_CLI_UNI -> client's send-only unidirectional stream.
+     *
+     * RESET_STREAM frame layout: type(1) + stream_id(varint) + err_code(varint) + final_size(varint)
+     * 0x04 = RESET_STREAM type, 0x02 = stream_id 2, 0x00 = err_code 0, 0x00 = final_size 0
+     */
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT(conn != NULL);
+    if (conn == NULL) {
+        return;
+    }
+
+    conn->conn_err = 0;
+
+    unsigned char frame_buf[] = {0x04, 0x02, 0x00, 0x00};
+    xqc_stream_id_t stream_id;
+    uint64_t err_code, final_size;
+    xqc_packet_in_t pi;
+    memset(&pi, 0, sizeof(pi));
+    pi.pos = frame_buf;
+    pi.last = frame_buf + sizeof(frame_buf);
+    pi.pi_pkt.pkt_type = XQC_PTYPE_SHORT_HEADER;
+
+    xqc_int_t ret = xqc_parse_reset_stream_frame(&pi, &stream_id, &err_code, &final_size, conn);
+    CU_ASSERT(ret == -XQC_EPROTO);
+    CU_ASSERT(conn->conn_err == TRA_STREAM_STATE_ERROR);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
+void
+xqc_test_stop_sending_on_recv_only_stream(void)
+{
+    /*
+     * RFC 9000 §19.5: receiving STOP_SENDING on a recv-only stream must
+     * trigger STREAM_STATE_ERROR.
+     *
+     * test_engine_connect() creates a CLIENT connection.
+     * stream_id=3 -> XQC_SVR_UNI -> server's send-only stream = client's recv-only stream.
+     *
+     * STOP_SENDING frame layout: type(1) + stream_id(varint) + err_code(varint)
+     * 0x05 = STOP_SENDING type, 0x03 = stream_id 3, 0x00 = err_code 0
+     */
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT(conn != NULL);
+    if (conn == NULL) {
+        return;
+    }
+
+    conn->conn_err = 0;
+
+    unsigned char frame_buf[] = {0x05, 0x03, 0x00};
+    xqc_stream_id_t stream_id;
+    uint64_t err_code;
+    xqc_packet_in_t pi;
+    memset(&pi, 0, sizeof(pi));
+    pi.pos = frame_buf;
+    pi.last = frame_buf + sizeof(frame_buf);
+    pi.pi_pkt.pkt_type = XQC_PTYPE_SHORT_HEADER;
+
+    xqc_int_t ret = xqc_parse_stop_sending_frame(&pi, &stream_id, &err_code, conn);
+    CU_ASSERT(ret == -XQC_EPROTO);
+    CU_ASSERT(conn->conn_err == TRA_STREAM_STATE_ERROR);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
+void
+xqc_test_reset_stream_on_send_only_stream_server(void)
+{
+    /*
+     * Server-side variant of the RFC 9000 19.4 check.
+     *
+     * test_engine_connect() builds a CLIENT connection; the parser only reads
+     * conn->conn_type, so flipping it exercises the server branch of the check.
+     * stream_id=3 -> XQC_SVR_UNI -> server's send-only unidirectional stream.
+     */
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT(conn != NULL);
+    if (conn == NULL) {
+        return;
+    }
+
+    conn->conn_type = XQC_CONN_TYPE_SERVER;
+    conn->conn_err = 0;
+
+    unsigned char frame_buf[] = {0x04, 0x03, 0x00, 0x00};
+    xqc_stream_id_t stream_id;
+    uint64_t err_code, final_size;
+    xqc_packet_in_t pi;
+    memset(&pi, 0, sizeof(pi));
+    pi.pos = frame_buf;
+    pi.last = frame_buf + sizeof(frame_buf);
+    pi.pi_pkt.pkt_type = XQC_PTYPE_SHORT_HEADER;
+
+    xqc_int_t ret = xqc_parse_reset_stream_frame(&pi, &stream_id, &err_code, &final_size, conn);
+    CU_ASSERT(ret == -XQC_EPROTO);
+    CU_ASSERT(conn->conn_err == TRA_STREAM_STATE_ERROR);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
+void
+xqc_test_stop_sending_on_recv_only_stream_server(void)
+{
+    /*
+     * Server-side variant of the RFC 9000 19.5 check.
+     * stream_id=2 -> XQC_CLI_UNI -> client's send-only stream = server's
+     * recv-only stream.
+     */
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT(conn != NULL);
+    if (conn == NULL) {
+        return;
+    }
+
+    conn->conn_type = XQC_CONN_TYPE_SERVER;
+    conn->conn_err = 0;
+
+    unsigned char frame_buf[] = {0x05, 0x02, 0x00};
+    xqc_stream_id_t stream_id;
+    uint64_t err_code;
+    xqc_packet_in_t pi;
+    memset(&pi, 0, sizeof(pi));
+    pi.pos = frame_buf;
+    pi.last = frame_buf + sizeof(frame_buf);
+    pi.pi_pkt.pkt_type = XQC_PTYPE_SHORT_HEADER;
+
+    xqc_int_t ret = xqc_parse_stop_sending_frame(&pi, &stream_id, &err_code, conn);
+    CU_ASSERT(ret == -XQC_EPROTO);
+    CU_ASSERT(conn->conn_err == TRA_STREAM_STATE_ERROR);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
+void
+xqc_test_reset_stream_on_recv_only_stream_accepted(void)
+{
+    /*
+     * Negative control for the RFC 9000 19.4 check: RESET_STREAM is legal on a
+     * recv-only stream and MUST still be accepted.  Without this case a check
+     * that is too broad (e.g. rejecting every unidirectional stream regardless
+     * of conn_type) would go unnoticed.
+     *
+     * client + stream_id=3 -> XQC_SVR_UNI -> client's recv-only stream.
+     * err_code = 10, final_size = 5 so the parsed values can be asserted.
+     */
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT(conn != NULL);
+    if (conn == NULL) {
+        return;
+    }
+
+    conn->conn_err = 0;
+
+    unsigned char frame_buf[] = {0x04, 0x03, 0x0a, 0x05};
+    xqc_stream_id_t stream_id;
+    uint64_t err_code, final_size;
+    xqc_packet_in_t pi;
+    memset(&pi, 0, sizeof(pi));
+    pi.pos = frame_buf;
+    pi.last = frame_buf + sizeof(frame_buf);
+    pi.pi_pkt.pkt_type = XQC_PTYPE_SHORT_HEADER;
+
+    xqc_int_t ret = xqc_parse_reset_stream_frame(&pi, &stream_id, &err_code, &final_size, conn);
+    CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(conn->conn_err == 0);
+    CU_ASSERT(stream_id == 3);
+    CU_ASSERT(err_code == 10);
+    CU_ASSERT(final_size == 5);
+    CU_ASSERT(pi.pi_frame_types & XQC_FRAME_BIT_RESET_STREAM);
+    CU_ASSERT(pi.pos == frame_buf + sizeof(frame_buf));
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
+void
+xqc_test_stop_sending_on_send_only_stream_accepted(void)
+{
+    /*
+     * Negative control for the RFC 9000 19.5 check: STOP_SENDING is legal on a
+     * send-only stream and MUST still be accepted.  This is the normal case for
+     * an HTTP/3 client control stream.
+     *
+     * client + stream_id=2 -> XQC_CLI_UNI -> client's send-only stream.
+     * err_code = 7 so the parsed value can be asserted.
+     */
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT(conn != NULL);
+    if (conn == NULL) {
+        return;
+    }
+
+    conn->conn_err = 0;
+
+    unsigned char frame_buf[] = {0x05, 0x02, 0x07};
+    xqc_stream_id_t stream_id;
+    uint64_t err_code;
+    xqc_packet_in_t pi;
+    memset(&pi, 0, sizeof(pi));
+    pi.pos = frame_buf;
+    pi.last = frame_buf + sizeof(frame_buf);
+    pi.pi_pkt.pkt_type = XQC_PTYPE_SHORT_HEADER;
+
+    xqc_int_t ret = xqc_parse_stop_sending_frame(&pi, &stream_id, &err_code, conn);
+    CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(conn->conn_err == 0);
+    CU_ASSERT(stream_id == 2);
+    CU_ASSERT(err_code == 7);
+    CU_ASSERT(pi.pi_frame_types & XQC_FRAME_BIT_STOP_SENDING);
+    CU_ASSERT(pi.pos == frame_buf + sizeof(frame_buf));
+
+    xqc_engine_destroy(conn->engine);
+}

--- a/tests/unittest/xqc_process_frame_test.h
+++ b/tests/unittest/xqc_process_frame_test.h
@@ -43,4 +43,16 @@ void xqc_test_conn_close_application_error_type(void);
 
 void xqc_test_conn_close_transport_error_type_overlap(void);
 
+void xqc_test_reset_stream_on_send_only_stream(void);
+
+void xqc_test_stop_sending_on_recv_only_stream(void);
+
+void xqc_test_reset_stream_on_send_only_stream_server(void);
+
+void xqc_test_stop_sending_on_recv_only_stream_server(void);
+
+void xqc_test_reset_stream_on_recv_only_stream_accepted(void);
+
+void xqc_test_stop_sending_on_send_only_stream_accepted(void);
+
 #endif /* _XQC_PROCESS_FRAME_TEST_H_INCLUDED_ */


### PR DESCRIPTION
Fix #566 and #567. Add RFC 9000 §19.4/§19.5 compliance: reject RESET_STREAM on send-only stream and STOP_SENDING on recv-only stream with STREAM_STATE_ERROR.