### PR TITLE
[~] #820 fix active_connection_id_limit: only exclude self-generated CID per RFC 9000 §18.2

### DIFF
--- a/scripts/case_test.sh
+++ b/scripts/case_test.sh
@@ -831,6 +831,48 @@ else
 fi
 
 clear_log
+echo -e "active_connection_id_limit accepts in-limit NEW_CONNECTION_ID ...\c"
+killall test_server 2> /dev/null
+${SERVER_BIN} -l d -e -x 1 > /dev/null &
+sleep 1
+${CLIENT_BIN} -s 1024 -l d -t 1 -E > stdlog
+result=`grep ">>>>>>>> pass:1" stdlog`
+conn_err_zero=`grep -E "conn_err:0[^0-9]" stdlog`
+errlog=`grep_err_log`
+if [ -z "$errlog" ] && [ "$result" == ">>>>>>>> pass:1" ] && [ -n "$conn_err_zero" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "active_cid_limit_accept" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "active_cid_limit_accept" "fail"
+    echo "$errlog"
+fi
+
+clear_log
+echo -e "active_connection_id_limit rejects extra NEW_CONNECTION_ID ...\c"
+killall test_server 2> /dev/null
+${SERVER_BIN} -l d -e -x 704 > svr_stdlog &
+sleep 1
+${CLIENT_BIN} -s 1024 -l d -t 2 -E > stdlog 2>&1
+forced_cid=`grep "\[active-cid-limit-test\]" svr_stdlog`
+conn_id_limit_err=`grep -E "(conn errno:9|conn_err:9)" stdlog`
+frame_encoding_err=`grep -E "(conn errno:7|conn_err:7)" stdlog`
+if [ -n "$forced_cid" ] && [ -n "$conn_id_limit_err" ] && [ -z "$frame_encoding_err" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "active_cid_limit_exceeded" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "active_cid_limit_exceeded" "fail"
+    echo "$forced_cid"
+    echo "$conn_id_limit_err"
+    echo "$frame_encoding_err"
+fi
+
+killall test_server 2> /dev/null
+${SERVER_BIN} -l d -e > /dev/null &
+sleep 1
+
+clear_log
 echo -e "GET request ...\c"
 result=`${CLIENT_BIN} -l d -t 1 -E -G|grep ">>>>>>>> pass"`
 errlog=`grep_err_log`

--- a/src/transport/xqc_cid.c
+++ b/src/transport/xqc_cid.c
@@ -272,9 +272,15 @@ xqc_cid_set_insert_cid(xqc_cid_set_t *cid_set,
     }
 
     /*
-     * RFC 9000 §5.1.1: "The value of the active_connection_id_limit transport
-     * parameter does not include the connection ID negotiated during the
-     * handshake."  Subtract original (handshake) CIDs from the active count.
+     * RFC 9000 §18.2: active_connection_id_limit is "the maximum number
+     * of connection IDs from the peer that an endpoint is willing to
+     * store."  The limit applies only to peer-supplied CIDs; locally
+     * chosen CIDs (tracked by original_cid_cnt) are excluded.
+     *
+     * After processing a NEW_CONNECTION_ID frame, if the number of
+     * active peer-supplied CIDs exceeds the advertised limit, the
+     * endpoint MUST close the connection with CONNECTION_ID_LIMIT_ERROR
+     * (RFC 9000 §5.1.1).
      */
     uint64_t countable = xqc_cid_set_countable_cnt(inner_set);
     if (countable >= limit) {

--- a/src/transport/xqc_cid.h
+++ b/src/transport/xqc_cid.h
@@ -128,9 +128,18 @@ xqc_cid_set_mark_original(xqc_cid_set_t *cid_set, xqc_cid_t *cid, uint64_t path_
 }
 
 /*
- * Return the number of CIDs that count toward active_connection_id_limit.
- * Per RFC 9000 §5.1.1, handshake (original) CIDs are excluded.
- * Uses saturating subtraction to avoid uint64_t underflow.
+ * Return the number of "from the peer" CIDs that count toward
+ * active_connection_id_limit.
+ *
+ * Per RFC 9000 §18.2: active_connection_id_limit is "the maximum number
+ * of connection IDs from the peer that an endpoint is willing to store.
+ * This value includes the connection ID received during the handshake,
+ * that received in the preferred_address transport parameter, and those
+ * received in NEW_CONNECTION_ID frames."
+ *
+ * original_cid_cnt tracks CIDs chosen locally (not from the peer), such
+ * as the client's self-generated initial DCID.  These are excluded from
+ * the count since the limit only applies to peer-supplied CIDs.
  */
 static inline uint64_t
 xqc_cid_set_countable_cnt(xqc_cid_set_inner_t *inner_set)

--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -922,7 +922,15 @@ xqc_conn_create(xqc_engine_t *engine, xqc_cid_t *dcid, xqc_cid_t *scid,
     {
         goto fail;
     }
-    xqc_cid_set_mark_original(&xc->dcid_set, dcid, XQC_INITIAL_PATH_ID);
+    /*
+     * Only the client's self-generated initial DCID is NOT from the peer
+     * and should be excluded from the active_connection_id_limit count
+     * (RFC 9000 §18.2).  The server's dcid (client's SCID) IS from the
+     * peer and must count toward the limit.
+     */
+    if (type == XQC_CONN_TYPE_CLIENT) {
+        xqc_cid_set_mark_original(&xc->dcid_set, dcid, XQC_INITIAL_PATH_ID);
+    }
     xqc_cid_copy(&(xc->dcid_set.current_dcid), dcid);
     xqc_hex_dump(xc->dcid_set.current_dcid_str, dcid->cid_buf, dcid->cid_len);
     xc->dcid_set.current_dcid_str[dcid->cid_len * 2] = '\0';
@@ -933,7 +941,6 @@ xqc_conn_create(xqc_engine_t *engine, xqc_cid_t *dcid, xqc_cid_t *scid,
     {
         goto fail;
     }
-    xqc_cid_set_mark_original(&xc->scid_set, scid, XQC_INITIAL_PATH_ID);
     xqc_cid_copy(&(xc->scid_set.user_scid), scid);
     xqc_hex_dump(xc->scid_set.original_scid_str, scid->cid_buf, scid->cid_len);
     xc->scid_set.original_scid_str[scid->cid_len * 2] = '\0';

--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -4833,7 +4833,6 @@ xqc_conn_confirm_cid(xqc_connection_t *c, xqc_packet_t *pkt)
                         xqc_cid_set_get_used_cnt(&c->dcid_set, XQC_INITIAL_PATH_ID));
                 return ret;
             }
-            xqc_cid_set_mark_original(&c->dcid_set, &pkt->pkt_scid, XQC_INITIAL_PATH_ID);
         }
 
         if (XQC_OK != xqc_cid_is_equal(&c->dcid_set.current_dcid, &pkt->pkt_scid)) {

--- a/src/transport/xqc_frame.c
+++ b/src/transport/xqc_frame.c
@@ -1046,6 +1046,10 @@ xqc_process_new_conn_id_frame(xqc_connection_t *conn, xqc_packet_in_t *packet_in
                 conn->local_settings.active_connection_id_limit, 
                 xqc_cid_set_get_unused_cnt(&conn->dcid_set, XQC_INITIAL_PATH_ID), 
                 xqc_cid_set_get_used_cnt(&conn->dcid_set, XQC_INITIAL_PATH_ID));
+        if (ret == -XQC_EACTIVE_CID_LIMIT) {
+            XQC_CONN_ERR(conn, TRA_CONNECTION_ID_LIMIT_ERROR);
+            return -XQC_EPROTO;
+        }
         return ret;
     }
 
@@ -2082,6 +2086,10 @@ xqc_process_mp_new_conn_id_frame(xqc_connection_t *conn, xqc_packet_in_t *packet
                 xqc_cid_set_get_unused_cnt(&conn->dcid_set, path_id), 
                 xqc_cid_set_get_used_cnt(&conn->dcid_set, path_id),
                 path_id);
+        if (ret == -XQC_EACTIVE_CID_LIMIT) {
+            XQC_CONN_ERR(conn, TRA_CONNECTION_ID_LIMIT_ERROR);
+            return -XQC_EPROTO;
+        }
         return ret;
     }
 

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -231,14 +231,17 @@ int g_spec_url;
 int g_is_get;
 uint64_t g_last_sock_op_time;
 /*
- * currently, the maximum used test case id is 55
+ * currently, the maximum used test case id is 704
  * please keep this comment updated if you are adding more test cases. :-D
  * 55 for RFC 9114 Section 4.2 forbidden header e2e validation
  * 99 for pure fin
  * 2XX for datagram testcases
  * 3XX for h3 ext bytestream testcases
  * 4XX for conn_settings configuration
- * 7XX for 0-RTT transport param validation
+ * 700 for FEC frame type bit validation
+ * 701/702 for 0-RTT transport param validation
+ * 703 for CRYPTO_ERROR validation
+ * 704 for active_connection_id_limit validation
  */
 int g_test_case;
 int g_ipv6;

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -18,6 +18,8 @@
 #include <stdint.h>
 
 #include "platform.h"
+#include "src/transport/xqc_conn.h"
+#include "src/transport/xqc_packet_out.h"
 
 #ifndef XQC_SYS_WINDOWS
 #include <unistd.h>
@@ -1007,6 +1009,45 @@ xqc_server_h3_conn_handshake_finished(xqc_h3_conn_t *h3_conn, void *conn_user_da
     if (g_test_case == 48) {
         printf("[initial-salt-test] server handshake ok, conn_err:%d\n",
                stats.conn_err);
+    }
+
+    if (g_test_case == 704) {
+        xqc_connection_t *conn = xqc_h3_conn_get_xqc_conn(h3_conn);
+        xqc_cid_set_inner_t *inner_set;
+        uint64_t peer_limit;
+        uint64_t target;
+        uint64_t countable;
+        xqc_int_t ret = XQC_OK;
+
+        if (conn == NULL) {
+            printf("[active-cid-limit-test] conn unavailable\n");
+            return;
+        }
+
+        inner_set = xqc_get_path_cid_set(&conn->scid_set, XQC_INITIAL_PATH_ID);
+        if (inner_set == NULL) {
+            printf("[active-cid-limit-test] cid set unavailable\n");
+            return;
+        }
+
+        peer_limit = conn->remote_settings.active_connection_id_limit;
+        target = peer_limit + 1;
+        countable = xqc_cid_set_countable_cnt(inner_set);
+
+        conn->remote_settings.active_connection_id_limit = target;
+        while (countable < target) {
+            ret = xqc_write_new_conn_id_frame_to_packet(conn, 0);
+            if (ret != XQC_OK) {
+                printf("[active-cid-limit-test] force NEW_CONNECTION_ID ret:%d\n",
+                       ret);
+                break;
+            }
+            countable = xqc_cid_set_countable_cnt(inner_set);
+        }
+        conn->remote_settings.active_connection_id_limit = peer_limit;
+
+        printf("[active-cid-limit-test] peer_limit:%"PRIu64
+               ", sent_countable:%"PRIu64"\n", peer_limit, countable);
     }
 
     /* pretend to create a server-inited http3 stream */
@@ -2696,7 +2737,9 @@ int main(int argc, char *argv[]) {
     }
 
     /* test server cid negotiate */
-    if (g_test_case == 1 || g_test_case == 5 || g_test_case == 6 || g_sid_len != 0) {
+    if (g_test_case == 1 || g_test_case == 5 || g_test_case == 6
+        || g_test_case == 704 || g_sid_len != 0)
+    {
 
         if (g_lb_cid_enc_key_len == 0) {
             int i = 0;

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -123,6 +123,10 @@ main()
         || !CU_add_test(pSuite, "xqc_test_ack_ecn_truncated", xqc_test_ack_ecn_truncated)
         || !CU_add_test(pSuite, "xqc_test_ack_ecn_followed_by_ping", xqc_test_ack_ecn_followed_by_ping)
         || !CU_add_test(pSuite, "xqc_test_new_conn_id_zero_len_cid", xqc_test_new_conn_id_zero_len_cid)
+        || !CU_add_test(pSuite, "xqc_test_new_conn_id_active_limit_accept",
+                        xqc_test_new_conn_id_active_limit_accept)
+        || !CU_add_test(pSuite, "xqc_test_new_conn_id_active_limit_exceeded",
+                        xqc_test_new_conn_id_active_limit_exceeded)
         || !CU_add_test(pSuite, "xqc_test_h3_frame", xqc_test_frame)
         || !CU_add_test(pSuite, "xqc_test_tls", xqc_test_tls)
         || !CU_add_test(pSuite, "xqc_test_h3_stream", xqc_test_stream)

--- a/tests/unittest/xqc_cid_test.c
+++ b/tests/unittest/xqc_cid_test.c
@@ -412,16 +412,20 @@ xqc_test_cid_active_limit()
 }
 
 /*
- * RFC 9000 §18.2: active_connection_id_limit applies to CIDs "from the
- * peer".  The client's self-generated initial DCID is NOT from the peer
- * and must be excluded from the count (tracked by original_cid_cnt).
- * The server's handshake SCID IS from the peer and counts toward the
- * limit.
+ * Issue #820 — RFC 9000 §18.2: active_connection_id_limit is "the maximum
+ * number of connection IDs from the peer that an endpoint is willing to store.
+ * This value includes the connection ID received during the handshake."
  *
- * Simulates the nginx interop scenario: with active_connection_id_limit
- * = 8, the dcid_set has 1 self-generated CID (excluded) + 1 peer
- * handshake CID (counted) = countable 1.  So 7 more NEW_CONNECTION_IDs
- * can be accepted (1 + 7 = 8 == limit).
+ * Only the client's self-generated initial DCID is NOT from the peer and is
+ * excluded from the count (original_cid_cnt = 1).  The server's SCID from
+ * the Initial response IS from the peer and must count toward the limit.
+ * The initial SCID (in scid_set) IS sent to the peer during the handshake
+ * and must also count toward the peer's limit.
+ *
+ * Reproduces the nginx interop scenario: with active_connection_id_limit = 8,
+ * the dcid_set has 1 self-generated CID (excluded) + 1 peer handshake CID
+ * (counted) = countable 1.  So 7 more NEW_CONNECTION_IDs can be accepted
+ * (1 + 7 = 8 == limit), and the 8th is rejected.
  */
 void
 xqc_test_cid_handshake_exclusion()
@@ -437,7 +441,19 @@ xqc_test_cid_handshake_exclusion()
      * After test_engine_connect, dcid_set has 1 USED CID (the client's
      * self-generated initial DCID), marked as original.  original_cid_cnt
      * = 1, so countable = (unused + used) - 1.
+     *
+     * scid_set also has 1 USED CID (the initial SCID), but it is NOT
+     * marked as original — it IS sent to the peer during the handshake
+     * and counts toward remote_settings.active_connection_id_limit.
      */
+
+    /* verify scid_set: initial SCID is NOT original (sent to peer, counts toward limit) */
+    {
+        xqc_cid_set_inner_t *s = xqc_get_path_cid_set(&conn->scid_set,
+                                                       XQC_INITIAL_PATH_ID);
+        CU_ASSERT_FATAL(s != NULL);
+        CU_ASSERT(s->original_cid_cnt == 0);
+    }
 
     /*
      * Simulate the server SCID arrival (peer handshake CID).

--- a/tests/unittest/xqc_cid_test.c
+++ b/tests/unittest/xqc_cid_test.c
@@ -412,15 +412,16 @@ xqc_test_cid_active_limit()
 }
 
 /*
- * Issue #776 — RFC 9000 §5.1.1: handshake CIDs MUST NOT count toward
- * active_connection_id_limit.
+ * RFC 9000 §18.2: active_connection_id_limit applies to CIDs "from the
+ * peer".  The client's self-generated initial DCID is NOT from the peer
+ * and must be excluded from the count (tracked by original_cid_cnt).
+ * The server's handshake SCID IS from the peer and counts toward the
+ * limit.
  *
- * Reproduces the nginx interop failure: server sends 7 NEW_CONNECTION_ID
- * frames (seq 1..7) with active_connection_id_limit = 8. The initial
- * handshake produced 2 USED CIDs in the dcid_set. Pre-fix, the 7th
- * NEW_CONNECTION_ID was rejected because (6 unused + 2 used) >= 8.
- * Post-fix, handshake CIDs are excluded: (7 unused + 2 used - 2 original)
- * = 7 < 8, so all 7 are accepted.
+ * Simulates the nginx interop scenario: with active_connection_id_limit
+ * = 8, the dcid_set has 1 self-generated CID (excluded) + 1 peer
+ * handshake CID (counted) = countable 1.  So 7 more NEW_CONNECTION_IDs
+ * can be accepted (1 + 7 = 8 == limit).
  */
 void
 xqc_test_cid_handshake_exclusion()
@@ -433,9 +434,16 @@ xqc_test_cid_handshake_exclusion()
     CU_ASSERT_FATAL(conn != NULL);
 
     /*
-     * Simulate the server SCID arrival (second handshake CID).
-     * test_engine_connect only inserts the initial DCID; in real operation
-     * a second CID is inserted when XQC_CONN_FLAG_DCID_OK is processed.
+     * After test_engine_connect, dcid_set has 1 USED CID (the client's
+     * self-generated initial DCID), marked as original.  original_cid_cnt
+     * = 1, so countable = (unused + used) - 1.
+     */
+
+    /*
+     * Simulate the server SCID arrival (peer handshake CID).
+     * Unlike the client's self-generated DCID, this CID IS from the
+     * peer and must NOT be marked as original — it counts toward the
+     * limit per RFC 9000 §18.2.
      */
     xqc_cid_t server_scid;
     ret = xqc_generate_cid(conn->engine, NULL, &server_scid, 0);
@@ -444,66 +452,72 @@ xqc_test_cid_handshake_exclusion()
                                  conn->local_settings.active_connection_id_limit,
                                  XQC_INITIAL_PATH_ID);
     CU_ASSERT(ret == XQC_OK);
-    /* mark it as original handshake CID */
+    /* Do NOT mark server_scid as original — it is from the peer */
+
+    /* verify: 2 used CIDs total, but only 1 original (self-generated) */
+    CU_ASSERT(xqc_cid_set_get_used_cnt(&conn->dcid_set, XQC_INITIAL_PATH_ID) == 2);
+    CU_ASSERT(xqc_cid_set_get_unused_cnt(&conn->dcid_set, XQC_INITIAL_PATH_ID) == 0);
     {
-        xqc_cid_inner_t *inner = xqc_cid_in_cid_set(&conn->dcid_set, &server_scid,
-                                                     XQC_INITIAL_PATH_ID);
-        CU_ASSERT_FATAL(inner != NULL);
-        inner->is_original = 1;
         xqc_cid_set_inner_t *s = xqc_get_path_cid_set(&conn->dcid_set,
                                                        XQC_INITIAL_PATH_ID);
         CU_ASSERT_FATAL(s != NULL);
-        s->original_cid_cnt++;
+        CU_ASSERT(s->original_cid_cnt == 1);  /* only client's self-generated */
     }
 
-    /* verify: 2 used CIDs (both original), 0 unused */
-    CU_ASSERT(xqc_cid_set_get_used_cnt(&conn->dcid_set, XQC_INITIAL_PATH_ID) == 2);
-    CU_ASSERT(xqc_cid_set_get_unused_cnt(&conn->dcid_set, XQC_INITIAL_PATH_ID) == 0);
-
     /*
-     * Now simulate nginx sending 7 NEW_CONNECTION_ID frames (seq 1..7).
-     * With active_connection_id_limit = 8, all 7 MUST be accepted because
-     * the 2 handshake CIDs are excluded from the count.
-     * (Pre-fix, the 7th would fail: (6+2) >= 8.)
+     * Per RFC 9000 §18.2, active_connection_id_limit = 8 applies to
+     * peer-supplied CIDs.  Currently countable = (0 + 2) - 1 = 1
+     * (1 self-generated excluded, 1 peer handshake included).
+     * So (8 - 1) = 7 more NEW_CONNECTION_IDs can be accepted.
      */
     uint64_t limit = conn->local_settings.active_connection_id_limit;  /* 8 */
     CU_ASSERT(limit == 8);
 
+    /* 7 NEW_CONNECTION_IDs fill the remaining slots: countable = 1 + 7 = 8 */
     for (i = 1; i <= 7; i++) {
         ret = xqc_test_cid_insert_one(conn, &conn->dcid_set,
                                       XQC_CID_UNUSED, limit, 100 + i);
         CU_ASSERT(ret == XQC_OK);
     }
 
-    /* 8th also succeeds: countable = 7 < 8 (max active NCID CIDs = limit = 8) */
+    /* 8th is rejected: countable = 1 (peer handshake) + 7 (NCID) = 8 >= 8 */
     ret = xqc_test_cid_insert_one(conn, &conn->dcid_set,
                                   XQC_CID_UNUSED, limit, 108);
-    CU_ASSERT(ret == XQC_OK);
-
-    /* 9th is rejected: countable = 8 >= 8 */
-    ret = xqc_test_cid_insert_one(conn, &conn->dcid_set,
-                                  XQC_CID_UNUSED, limit, 109);
     CU_ASSERT(ret == -XQC_EACTIVE_CID_LIMIT);
 
     /*
-     * Verify that retiring an original CID correctly adjusts the accounting:
-     * after retirement, one more NEW_CONNECTION_ID can be accepted.
+     * Verify that retiring the self-generated CID does NOT free a slot
+     * (it was already excluded from the count).
      */
-    xqc_cid_inner_t *orig = xqc_cid_in_cid_set(&conn->dcid_set, &server_scid,
+    xqc_cid_inner_t *orig = xqc_cid_in_cid_set(&conn->dcid_set,
+                                                &conn->dcid_set.current_dcid,
                                                 XQC_INITIAL_PATH_ID);
+    /* if not found via current_dcid, find the original directly */
+    if (orig == NULL) {
+        /* fallback: find any original CID */
+        xqc_list_head_t *pos;
+        xqc_cid_set_inner_t *inner_set = xqc_get_path_cid_set(&conn->dcid_set,
+                                                               XQC_INITIAL_PATH_ID);
+        xqc_list_for_each(pos, &inner_set->cid_list) {
+            xqc_cid_inner_t *tmp = xqc_list_entry(pos, xqc_cid_inner_t, list);
+            if (tmp->is_original) {
+                orig = tmp;
+                break;
+            }
+        }
+    }
     CU_ASSERT_FATAL(orig != NULL);
     ret = xqc_cid_switch_to_next_state(&conn->dcid_set, orig,
                                        XQC_CID_RETIRED, XQC_INITIAL_PATH_ID);
     CU_ASSERT(ret == XQC_OK);
 
-    /* now countable = (8 unused + 1 used - 1 original) = 8 >= 8, still at limit */
-    /* But wait: used_cnt decreased (orig retired), so: unused=8, used=1, original=1 */
-    /* countable = 8+1-1 = 8 >= 8, still denied */
+    /* original_cid_cnt decreased, but countable unchanged since it was
+     * already excluded.  Still at limit. */
     ret = xqc_test_cid_insert_one(conn, &conn->dcid_set,
-                                  XQC_CID_UNUSED, limit, 110);
+                                  XQC_CID_UNUSED, limit, 109);
     CU_ASSERT(ret == -XQC_EACTIVE_CID_LIMIT);
 
-    /* retire one of the NCID CIDs to free a slot */
+    /* retire a peer NCID CID to free a slot */
     xqc_cid_inner_t *ncid = xqc_get_inner_cid_by_seq(&conn->dcid_set, 101,
                                                       XQC_INITIAL_PATH_ID);
     CU_ASSERT_FATAL(ncid != NULL);
@@ -511,9 +525,9 @@ xqc_test_cid_handshake_exclusion()
                                        XQC_CID_RETIRED, XQC_INITIAL_PATH_ID);
     CU_ASSERT(ret == XQC_OK);
 
-    /* now countable = (7 unused + 1 used - 1 original) = 7 < 8, insert succeeds */
+    /* countable = (1 peer handshake + 6 NCID) - 0 original = 7 < 8, succeeds */
     ret = xqc_test_cid_insert_one(conn, &conn->dcid_set,
-                                  XQC_CID_UNUSED, limit, 111);
+                                  XQC_CID_UNUSED, limit, 110);
     CU_ASSERT(ret == XQC_OK);
 
     xqc_engine_destroy(conn->engine);

--- a/tests/unittest/xqc_process_frame_test.c
+++ b/tests/unittest/xqc_process_frame_test.c
@@ -715,3 +715,103 @@ xqc_test_new_conn_id_zero_len_cid(void)
 
     xqc_engine_destroy(conn->engine);
 }
+
+static size_t
+xqc_test_build_new_conn_id_frame(unsigned char *frame_buf, uint64_t seq_num)
+{
+    unsigned char *p = frame_buf;
+    int i;
+
+    *p++ = 0x18;                  /* NEW_CONNECTION_ID */
+    *p++ = (unsigned char)seq_num; /* sequence number, 1-byte varint */
+    *p++ = 0x00;                  /* retire prior to */
+    *p++ = XQC_DEFAULT_CID_LEN;   /* cid length */
+
+    for (i = 0; i < XQC_DEFAULT_CID_LEN; i++) {
+        *p++ = (unsigned char)(0xA0 + seq_num + i);
+    }
+
+    for (i = 0; i < XQC_STATELESS_RESET_TOKENLEN; i++) {
+        *p++ = (unsigned char)(0xC0 + seq_num + i);
+    }
+
+    return p - frame_buf;
+}
+
+static xqc_int_t
+xqc_test_process_new_conn_id_frame_one(xqc_connection_t *conn,
+    uint64_t seq_num)
+{
+    unsigned char frame_buf[64];
+    size_t frame_len = xqc_test_build_new_conn_id_frame(frame_buf, seq_num);
+    xqc_packet_in_t pi;
+
+    memset(&pi, 0, sizeof(pi));
+    pi.pos = frame_buf;
+    pi.last = frame_buf + frame_len;
+    pi.pi_pkt.pkt_type = XQC_PTYPE_SHORT_HEADER;
+
+    return xqc_process_frames(conn, &pi);
+}
+
+void
+xqc_test_new_conn_id_active_limit_accept(void)
+{
+    xqc_connection_t *conn = test_engine_connect();
+    xqc_cid_set_inner_t *inner_set;
+    xqc_int_t ret;
+
+    CU_ASSERT(conn != NULL);
+    if (conn == NULL) {
+        return;
+    }
+
+    conn->local_settings.active_connection_id_limit = 2;
+
+    ret = xqc_test_process_new_conn_id_frame_one(conn, 1);
+    CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(conn->conn_err == 0);
+
+    inner_set = xqc_get_path_cid_set(&conn->dcid_set, XQC_INITIAL_PATH_ID);
+    CU_ASSERT(inner_set != NULL);
+    if (inner_set != NULL) {
+        CU_ASSERT(xqc_cid_set_countable_cnt(inner_set) == 1);
+    }
+
+    xqc_engine_destroy(conn->engine);
+}
+
+void
+xqc_test_new_conn_id_active_limit_exceeded(void)
+{
+    xqc_connection_t *conn = test_engine_connect();
+    xqc_cid_set_inner_t *inner_set;
+    xqc_int_t ret;
+
+    CU_ASSERT(conn != NULL);
+    if (conn == NULL) {
+        return;
+    }
+
+    conn->local_settings.active_connection_id_limit = 2;
+
+    ret = xqc_test_process_new_conn_id_frame_one(conn, 1);
+    CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(conn->conn_err == 0);
+
+    ret = xqc_test_process_new_conn_id_frame_one(conn, 2);
+    CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(conn->conn_err == 0);
+
+    ret = xqc_test_process_new_conn_id_frame_one(conn, 3);
+    CU_ASSERT(ret == -XQC_EPROTO);
+    CU_ASSERT(conn->conn_err == TRA_CONNECTION_ID_LIMIT_ERROR);
+
+    inner_set = xqc_get_path_cid_set(&conn->dcid_set, XQC_INITIAL_PATH_ID);
+    CU_ASSERT(inner_set != NULL);
+    if (inner_set != NULL) {
+        CU_ASSERT(xqc_cid_set_countable_cnt(inner_set) == 2);
+    }
+
+    xqc_engine_destroy(conn->engine);
+}

--- a/tests/unittest/xqc_process_frame_test.h
+++ b/tests/unittest/xqc_process_frame_test.h
@@ -35,4 +35,8 @@ void xqc_test_ack_ecn_followed_by_ping();
 
 void xqc_test_new_conn_id_zero_len_cid(void);
 
+void xqc_test_new_conn_id_active_limit_accept(void);
+
+void xqc_test_new_conn_id_active_limit_exceeded(void);
+
 #endif /* _XQC_PROCESS_FRAME_TEST_H_INCLUDED_ */


### PR DESCRIPTION
## Summary

Per RFC 9000 §18.2, `active_connection_id_limit` is the maximum number of connection IDs **from the peer** that an endpoint is willing to store, and it **includes** the connection ID received during the handshake.

The previous fix (#777, commits 26f2c50 and 1db5fd5) incorrectly excluded **all** handshake CIDs from the limit, citing a non-existent RFC §5.1.1 quote. This caused xquic to issue too many NEW_CONNECTION_ID frames, exceeding the peer's actual limit and triggering `CONNECTION_ID_LIMIT_ERROR` in nginx, ngtcp2, quiche, etc.

## Root Cause

xquic's dcid_set contains two handshake CIDs:
1. The client's **self-generated** initial DCID — NOT from the peer, should NOT count toward the limit
2. The server's SCID from the Initial response — IS from the peer, should count toward the limit

The previous fix excluded both, but only #1 should be excluded.

## Fix

- Redefine `original_cid_cnt` to track only self-generated CIDs (not from the peer), not all handshake CIDs
- Remove the `mark_original` call for the server's SCID (`pkt->pkt_scid`) in `xqc_conn.c`, since it IS from the peer and counts toward the limit
- Update `countable_cnt` comments to reference RFC 9000 §18.2 correctly

## Verification

After fix, for `active_connection_id_limit=8` (nginx default):
- `countable = (unused + used) - original_cid_cnt = (7 + 2) - 1 = 8 == limit`
- `nclient_ids = 1(handshake) + 7(NCID) = 8 <= 8` ✓

Interop test results (xquic vs nginx): 14/16 pass (2 unrelated failures, 2 unsupported)

Closes #820