### PR TITLE
fix: correct 0-RTT transport param validation guard and test mock

### DIFF
--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -6070,8 +6070,9 @@ xqc_check_fec_trans_param(xqc_connection_t *conn, xqc_transport_params_t params)
 }
 
 /*
- * RFC 9000 Section 7.4.1: validate that new transport parameters do not
- * reduce MUST parameters below the remembered (0-RTT) values.
+ * RFC 9000 Section 7.4.1 and RFC 9221 Section 3: validate that new
+ * transport parameters do not reduce 0-RTT-sensitive parameters below the
+ * remembered values.
  *
  * Returns XQC_OK if all parameters are valid, or an error code
  * (TRA_0RTT_TRANS_PARAMS_ERROR) if any MUST parameter was reduced.
@@ -6187,8 +6188,8 @@ xqc_conn_tls_transport_params_cb(const uint8_t *tp, size_t len, void *user_data)
     }
 
     /*
-     * RFC 9000 Section 7.4.1: when a client has sent 0-RTT data AND the
-     * server accepted early data, the server MUST NOT reduce certain
+     * RFC 9000 Section 7.4.1: when a client has sent 0-RTT data and the
+     * server accepted early data, the server MUST NOT reduce the core
      * transport parameters below the remembered values.  The client MUST
      * validate this and close with TRANSPORT_PARAMETER_ERROR if any MUST
      * parameter was reduced.
@@ -6209,6 +6210,22 @@ xqc_conn_tls_transport_params_cb(const uint8_t *tp, size_t len, void *user_data)
             XQC_CONN_ERR(conn, ret);
             return;
         }
+    }
+
+    /*
+     * RFC 9221 Section 3: if max_datagram_frame_size is remembered as 0-RTT
+     * state, the new value MUST NOT be smaller.  This check is not gated on
+     * the TLS early-data result; for non-0RTT connections the remembered value
+     * is zero, so it remains a no-op.
+     */
+    if (params.max_datagram_frame_size < conn->remote_settings.max_datagram_frame_size) {
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|0rtt_param_reduced|max_datagram_frame_size|"
+                "remembered:%ui|new:%ui|",
+                conn->remote_settings.max_datagram_frame_size,
+                params.max_datagram_frame_size);
+        XQC_CONN_ERR(conn, TRA_0RTT_TRANS_PARAMS_ERROR);
+        return;
     }
 
     /* set remote transport param */

--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -6069,6 +6069,93 @@ xqc_check_fec_trans_param(xqc_connection_t *conn, xqc_transport_params_t params)
     }
 }
 
+/*
+ * RFC 9000 Section 7.4.1: validate that new transport parameters do not
+ * reduce MUST parameters below the remembered (0-RTT) values.
+ *
+ * Returns XQC_OK if all parameters are valid, or an error code
+ * (TRA_0RTT_TRANS_PARAMS_ERROR) if any MUST parameter was reduced.
+ */
+xqc_int_t
+xqc_conn_validate_0rtt_transport_params(xqc_connection_t *conn,
+                                        const xqc_transport_params_t *params)
+{
+    xqc_trans_settings_t *remembered = &conn->remote_settings;
+
+    if (params->initial_max_data < remembered->max_data) {
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|0rtt_param_reduced|initial_max_data|"
+                "remembered:%ui|new:%ui|",
+                remembered->max_data, params->initial_max_data);
+        return TRA_0RTT_TRANS_PARAMS_ERROR;
+    }
+
+    if (params->initial_max_stream_data_bidi_local < remembered->max_stream_data_bidi_local) {
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|0rtt_param_reduced|initial_max_stream_data_bidi_local|"
+                "remembered:%ui|new:%ui|",
+                remembered->max_stream_data_bidi_local,
+                params->initial_max_stream_data_bidi_local);
+        return TRA_0RTT_TRANS_PARAMS_ERROR;
+    }
+
+    if (params->initial_max_stream_data_bidi_remote < remembered->max_stream_data_bidi_remote) {
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|0rtt_param_reduced|initial_max_stream_data_bidi_remote|"
+                "remembered:%ui|new:%ui|",
+                remembered->max_stream_data_bidi_remote,
+                params->initial_max_stream_data_bidi_remote);
+        return TRA_0RTT_TRANS_PARAMS_ERROR;
+    }
+
+    if (params->initial_max_stream_data_uni < remembered->max_stream_data_uni) {
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|0rtt_param_reduced|initial_max_stream_data_uni|"
+                "remembered:%ui|new:%ui|",
+                remembered->max_stream_data_uni,
+                params->initial_max_stream_data_uni);
+        return TRA_0RTT_TRANS_PARAMS_ERROR;
+    }
+
+    if (params->initial_max_streams_bidi < remembered->max_streams_bidi) {
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|0rtt_param_reduced|initial_max_streams_bidi|"
+                "remembered:%ui|new:%ui|",
+                remembered->max_streams_bidi,
+                params->initial_max_streams_bidi);
+        return TRA_0RTT_TRANS_PARAMS_ERROR;
+    }
+
+    if (params->initial_max_streams_uni < remembered->max_streams_uni) {
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|0rtt_param_reduced|initial_max_streams_uni|"
+                "remembered:%ui|new:%ui|",
+                remembered->max_streams_uni,
+                params->initial_max_streams_uni);
+        return TRA_0RTT_TRANS_PARAMS_ERROR;
+    }
+
+    if (params->active_connection_id_limit < remembered->active_connection_id_limit) {
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|0rtt_param_reduced|active_connection_id_limit|"
+                "remembered:%ui|new:%ui|",
+                remembered->active_connection_id_limit,
+                params->active_connection_id_limit);
+        return TRA_0RTT_TRANS_PARAMS_ERROR;
+    }
+
+    if (params->max_datagram_frame_size < remembered->max_datagram_frame_size) {
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|0rtt_param_reduced|max_datagram_frame_size|"
+                "remembered:%ui|new:%ui|",
+                remembered->max_datagram_frame_size,
+                params->max_datagram_frame_size);
+        return TRA_0RTT_TRANS_PARAMS_ERROR;
+    }
+
+    return XQC_OK;
+}
+
 void
 xqc_conn_tls_transport_params_cb(const uint8_t *tp, size_t len, void *user_data)
 {
@@ -6117,101 +6204,11 @@ xqc_conn_tls_transport_params_cb(const uint8_t *tp, size_t len, void *user_data)
         && (conn->conn_flag & XQC_CONN_FLAG_HAS_0RTT)
         && xqc_tls_is_early_data_accepted(conn->tls) == XQC_TLS_EARLY_DATA_ACCEPT)
     {
-        xqc_trans_settings_t *remembered = &conn->remote_settings;
-
-        /*
-         * MUST parameters -- server MUST NOT reduce these after 0-RTT is
-         * accepted (RFC 9000 Section 7.4.1):
-         *   - active_connection_id_limit
-         *   - initial_max_data
-         *   - initial_max_stream_data_bidi_local
-         *   - initial_max_stream_data_bidi_remote
-         *   - initial_max_stream_data_uni
-         *   - initial_max_streams_bidi
-         *   - initial_max_streams_uni
-         */
-        if (params.initial_max_data < remembered->max_data) {
-            xqc_log(conn->log, XQC_LOG_ERROR,
-                    "|0rtt_param_reduced|initial_max_data|"
-                    "remembered:%ui|new:%ui|",
-                    remembered->max_data, params.initial_max_data);
-            XQC_CONN_ERR(conn, TRA_0RTT_TRANS_PARAMS_ERROR);
+        ret = xqc_conn_validate_0rtt_transport_params(conn, &params);
+        if (ret != XQC_OK) {
+            XQC_CONN_ERR(conn, ret);
             return;
         }
-
-        if (params.initial_max_stream_data_bidi_local < remembered->max_stream_data_bidi_local) {
-            xqc_log(conn->log, XQC_LOG_ERROR,
-                    "|0rtt_param_reduced|initial_max_stream_data_bidi_local|"
-                    "remembered:%ui|new:%ui|",
-                    remembered->max_stream_data_bidi_local,
-                    params.initial_max_stream_data_bidi_local);
-            XQC_CONN_ERR(conn, TRA_0RTT_TRANS_PARAMS_ERROR);
-            return;
-        }
-
-        if (params.initial_max_stream_data_bidi_remote < remembered->max_stream_data_bidi_remote) {
-            xqc_log(conn->log, XQC_LOG_ERROR,
-                    "|0rtt_param_reduced|initial_max_stream_data_bidi_remote|"
-                    "remembered:%ui|new:%ui|",
-                    remembered->max_stream_data_bidi_remote,
-                    params.initial_max_stream_data_bidi_remote);
-            XQC_CONN_ERR(conn, TRA_0RTT_TRANS_PARAMS_ERROR);
-            return;
-        }
-
-        if (params.initial_max_stream_data_uni < remembered->max_stream_data_uni) {
-            xqc_log(conn->log, XQC_LOG_ERROR,
-                    "|0rtt_param_reduced|initial_max_stream_data_uni|"
-                    "remembered:%ui|new:%ui|",
-                    remembered->max_stream_data_uni,
-                    params.initial_max_stream_data_uni);
-            XQC_CONN_ERR(conn, TRA_0RTT_TRANS_PARAMS_ERROR);
-            return;
-        }
-
-        if (params.initial_max_streams_bidi < remembered->max_streams_bidi) {
-            xqc_log(conn->log, XQC_LOG_ERROR,
-                    "|0rtt_param_reduced|initial_max_streams_bidi|"
-                    "remembered:%ui|new:%ui|",
-                    remembered->max_streams_bidi,
-                    params.initial_max_streams_bidi);
-            XQC_CONN_ERR(conn, TRA_0RTT_TRANS_PARAMS_ERROR);
-            return;
-        }
-
-        if (params.initial_max_streams_uni < remembered->max_streams_uni) {
-            xqc_log(conn->log, XQC_LOG_ERROR,
-                    "|0rtt_param_reduced|initial_max_streams_uni|"
-                    "remembered:%ui|new:%ui|",
-                    remembered->max_streams_uni,
-                    params.initial_max_streams_uni);
-            XQC_CONN_ERR(conn, TRA_0RTT_TRANS_PARAMS_ERROR);
-            return;
-        }
-
-        if (params.active_connection_id_limit < remembered->active_connection_id_limit) {
-            xqc_log(conn->log, XQC_LOG_ERROR,
-                    "|0rtt_param_reduced|active_connection_id_limit|"
-                    "remembered:%ui|new:%ui|",
-                    remembered->active_connection_id_limit,
-                    params.active_connection_id_limit);
-            XQC_CONN_ERR(conn, TRA_0RTT_TRANS_PARAMS_ERROR);
-            return;
-        }
-
-    }
-
-    /* check datagram parameter -- unconditional, not gated on early_data
-     * accepted.  For non-0RTT connections remote_settings.max_datagram_frame_size
-     * is 0, so this is a no-op. */
-    if (params.max_datagram_frame_size < conn->remote_settings.max_datagram_frame_size) {
-        xqc_log(conn->log, XQC_LOG_ERROR,
-                "|0rtt_param_reduced|max_datagram_frame_size|"
-                "remembered:%ui|new:%ui|",
-                conn->remote_settings.max_datagram_frame_size,
-                params.max_datagram_frame_size);
-        XQC_CONN_ERR(conn, TRA_0RTT_TRANS_PARAMS_ERROR);
-        return;
     }
 
     /* set remote transport param */

--- a/src/transport/xqc_conn.h
+++ b/src/transport/xqc_conn.h
@@ -749,4 +749,15 @@ void xqc_conn_set_init_idle_timeout(xqc_connection_t *conn, xqc_msec_t init_idle
 void xqc_conn_try_to_enable_pmtud(xqc_connection_t *conn);
 
 xqc_int_t xqc_conn_server_accept(xqc_connection_t *c);
+
+/*
+ * RFC 9000 Section 7.4.1: validate that new transport parameters do not
+ * reduce MUST parameters below the remembered (0-RTT) values.
+ *
+ * Returns XQC_OK if all parameters are valid, or TRA_0RTT_TRANS_PARAMS_ERROR
+ * if any MUST parameter was reduced.
+ */
+xqc_int_t xqc_conn_validate_0rtt_transport_params(xqc_connection_t *conn,
+                                                   const xqc_transport_params_t *params);
+
 #endif /* _XQC_CONN_H_INCLUDED_ */

--- a/src/transport/xqc_conn.h
+++ b/src/transport/xqc_conn.h
@@ -751,8 +751,8 @@ void xqc_conn_try_to_enable_pmtud(xqc_connection_t *conn);
 xqc_int_t xqc_conn_server_accept(xqc_connection_t *c);
 
 /*
- * RFC 9000 Section 7.4.1: validate that new transport parameters do not
- * reduce MUST parameters below the remembered (0-RTT) values.
+ * RFC 9000 Section 7.4.1 and RFC 9221 Section 3: validate that new transport
+ * parameters do not reduce 0-RTT-sensitive parameters below remembered values.
  *
  * Returns XQC_OK if all parameters are valid, or TRA_0RTT_TRANS_PARAMS_ERROR
  * if any MUST parameter was reduced.

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -105,6 +105,14 @@ main()
         || !CU_add_test(pSuite, "xqc_test_crypto_frame_dispatched_via_xqc_process_frame", xqc_test_crypto_frame_dispatched_via_xqc_process_frame)
         || !CU_add_test(pSuite, "xqc_test_crypto_in_0rtt_emits_connection_close", xqc_test_crypto_in_0rtt_emits_connection_close)
         || !CU_add_test(pSuite, "xqc_test_crypto", xqc_test_crypto)
+        /* issue #717: 0-RTT transport parameter validation (RFC 9000 Section 7.4.1)
+         * registered before hp_sample_boundary to avoid a pre-existing SIGSEGV */
+        || !CU_add_test(pSuite, "xqc_test_0rtt_params_all_equal",
+                        xqc_test_0rtt_params_all_equal)
+        || !CU_add_test(pSuite, "xqc_test_0rtt_params_all_increased",
+                        xqc_test_0rtt_params_all_increased)
+        || !CU_add_test(pSuite, "xqc_test_0rtt_params_each_reduced",
+                        xqc_test_0rtt_params_each_reduced)
         || !CU_add_test(pSuite, "xqc_test_hp_sample_boundary", xqc_test_hp_sample_boundary)
         || !CU_add_test(pSuite, "xqc_test_packet_encrypt_hp_sample_boundary", xqc_test_packet_encrypt_hp_sample_boundary)
         || !CU_add_test(pSuite, "xqc_test_empty_pkt", xqc_test_empty_pkt)
@@ -221,13 +229,6 @@ main()
         || !CU_add_test(pSuite, "xqc_test_initial_salt_length", xqc_test_initial_salt_length)
         || !CU_add_test(pSuite, "xqc_test_initial_salt_v1_value", xqc_test_initial_salt_v1_value)
         || !CU_add_test(pSuite, "xqc_test_initial_salt_null_byte_regression", xqc_test_initial_salt_null_byte_regression)
-        /* issue #717: 0-RTT transport parameter validation (RFC 9000 Section 7.4.1) */
-        || !CU_add_test(pSuite, "xqc_test_0rtt_params_all_equal",
-                        xqc_test_0rtt_params_all_equal)
-        || !CU_add_test(pSuite, "xqc_test_0rtt_params_all_increased",
-                        xqc_test_0rtt_params_all_increased)
-        || !CU_add_test(pSuite, "xqc_test_0rtt_params_each_reduced",
-                        xqc_test_0rtt_params_each_reduced)
         /* ALPN negotiation tests (issue #709) */
         || !CU_add_test(pSuite, "xqc_test_alpn_error_code_value",
                         xqc_test_alpn_error_code_value)

--- a/tests/unittest/xqc_conn_test.c
+++ b/tests/unittest/xqc_conn_test.c
@@ -348,9 +348,9 @@ xqc_test_conn_tls_error_cb_constructs_crypto_error()
 /* -------------------------------------------------------------------------
  * 0-RTT transport parameter validation tests for issue #717.
  *
- * RFC 9000 Section 7.4.1: when a client attempts 0-RTT, the server MUST NOT
- * reduce certain transport parameters below the values remembered from the
- * previous connection.
+ * RFC 9000 Section 7.4.1 and RFC 9221 Section 3: when a client attempts
+ * 0-RTT, the server MUST NOT reduce certain transport parameters below the
+ * values remembered from the previous connection.
  *
  * Tests call xqc_conn_validate_0rtt_transport_params() directly, which only
  * compares new params against conn->remote_settings.  No TLS state, CID

--- a/tests/unittest/xqc_conn_test.c
+++ b/tests/unittest/xqc_conn_test.c
@@ -350,21 +350,13 @@ xqc_test_conn_tls_error_cb_constructs_crypto_error()
  *
  * RFC 9000 Section 7.4.1: when a client attempts 0-RTT, the server MUST NOT
  * reduce certain transport parameters below the values remembered from the
- * previous connection.  The client MUST validate this and close with
- * TRANSPORT_PARAMETER_ERROR if any MUST parameter was reduced.
+ * previous connection.
  *
- * The production code under test lives in xqc_conn_tls_transport_params_cb().
- * Each test creates a fresh client connection, plants remembered values into
- * conn->remote_settings, encodes new transport parameters with
- * xqc_encode_transport_params(), and calls the callback directly.
+ * Tests call xqc_conn_validate_0rtt_transport_params() directly, which only
+ * compares new params against conn->remote_settings.  No TLS state, CID
+ * setup, or encode/decode round-trip is needed.
  * ------------------------------------------------------------------------- */
 
-/* declared in xqc_conn.c, not static */
-extern void xqc_conn_tls_transport_params_cb(const uint8_t *tp, size_t len,
-                                             void *user_data);
-
-/* baseline "remembered" values stored in conn->remote_settings before
- * the callback fires.  Non-zero for every field the fix checks. */
 #define REMEMBERED_MAX_DATA                     1000000
 #define REMEMBERED_MAX_STREAM_DATA_BIDI_LOCAL   100000
 #define REMEMBERED_MAX_STREAM_DATA_BIDI_REMOTE  100000
@@ -373,41 +365,17 @@ extern void xqc_conn_tls_transport_params_cb(const uint8_t *tp, size_t len,
 #define REMEMBERED_MAX_STREAMS_UNI              100
 #define REMEMBERED_ACTIVE_CID_LIMIT             4
 #define REMEMBERED_MAX_DGRAM_FRAME_SIZE         1200
-#define REMEMBERED_MAX_IDLE_TIMEOUT             30000
-#define REMEMBERED_MAX_UDP_PAYLOAD_SIZE         1350
 
 /*
- * Set up a client connection that looks like it did a 0-RTT handshake:
- *   - conn_type  = CLIENT
- *   - HAS_0RTT   flag set
- *   - remote_settings populated with "remembered" values
- *   - dcid_set.current_dcid seeded with a generated CID (server's SCID)
- *
- * *out_server_scid receives the server SCID so the caller can embed the
- * matching initial_source_connection_id in the encoded transport parameters.
+ * Create a client connection and plant remembered values into
+ * conn->remote_settings as the 0-RTT baseline.
  */
 static xqc_connection_t *
-xqc_0rtt_test_make_conn(xqc_cid_t *out_server_scid)
+xqc_0rtt_test_make_conn(void)
 {
     xqc_connection_t *conn = test_engine_connect();
     CU_ASSERT_FATAL(conn != NULL);
-    CU_ASSERT_FATAL(conn->conn_type == XQC_CONN_TYPE_CLIENT);
 
-    /* deterministic server SCID so ISCID validation passes */
-    xqc_cid_t server_scid;
-    xqc_generate_cid(conn->engine, NULL, &server_scid, 0);
-    xqc_cid_copy(&conn->dcid_set.current_dcid, &server_scid);
-    if (out_server_scid) {
-        xqc_cid_copy(out_server_scid, &server_scid);
-    }
-
-    /* mark the connection as having 0-RTT */
-    conn->conn_flag |= XQC_CONN_FLAG_HAS_0RTT;
-    /* clear any prior errors */
-    conn->conn_err = 0;
-    conn->conn_flag &= ~XQC_CONN_FLAG_ERROR;
-
-    /* plant "remembered" values in remote_settings (the 0-RTT baseline) */
     conn->remote_settings.max_data                     = REMEMBERED_MAX_DATA;
     conn->remote_settings.max_stream_data_bidi_local   = REMEMBERED_MAX_STREAM_DATA_BIDI_LOCAL;
     conn->remote_settings.max_stream_data_bidi_remote  = REMEMBERED_MAX_STREAM_DATA_BIDI_REMOTE;
@@ -416,34 +384,16 @@ xqc_0rtt_test_make_conn(xqc_cid_t *out_server_scid)
     conn->remote_settings.max_streams_uni              = REMEMBERED_MAX_STREAMS_UNI;
     conn->remote_settings.active_connection_id_limit   = REMEMBERED_ACTIVE_CID_LIMIT;
     conn->remote_settings.max_datagram_frame_size      = REMEMBERED_MAX_DGRAM_FRAME_SIZE;
-    conn->remote_settings.max_idle_timeout             = REMEMBERED_MAX_IDLE_TIMEOUT;
-    conn->remote_settings.max_udp_payload_size         = REMEMBERED_MAX_UDP_PAYLOAD_SIZE;
-    conn->remote_settings.disable_active_migration     = 0;
 
     return conn;
 }
 
-/*
- * Populate a xqc_transport_params_t struct with CID fields that match
- * the connection (so xqc_conn_check_transport_params passes) and baseline
- * numeric values equal to the remembered settings.
- */
+/* populate params with values equal to the remembered baseline */
 static void
-xqc_0rtt_test_init_params(xqc_transport_params_t *params,
-                          xqc_connection_t *conn,
-                          const xqc_cid_t *server_scid)
+xqc_0rtt_test_init_params(xqc_transport_params_t *params)
 {
     memset(params, 0, sizeof(*params));
 
-    /* CID fields required by xqc_conn_check_transport_params (client side) */
-    xqc_cid_set(&params->initial_source_connection_id,
-                server_scid->cid_buf, server_scid->cid_len);
-    params->initial_source_connection_id_present = 1;
-    xqc_cid_set(&params->original_dest_connection_id,
-                conn->original_dcid.cid_buf, conn->original_dcid.cid_len);
-    params->original_dest_connection_id_present = 1;
-
-    /* satisfy the 2^60 ceiling in xqc_conn_check_transport_params */
     params->initial_max_data                     = REMEMBERED_MAX_DATA;
     params->initial_max_stream_data_bidi_local   = REMEMBERED_MAX_STREAM_DATA_BIDI_LOCAL;
     params->initial_max_stream_data_bidi_remote  = REMEMBERED_MAX_STREAM_DATA_BIDI_REMOTE;
@@ -452,33 +402,6 @@ xqc_0rtt_test_init_params(xqc_transport_params_t *params,
     params->initial_max_streams_uni              = REMEMBERED_MAX_STREAMS_UNI;
     params->active_connection_id_limit           = REMEMBERED_ACTIVE_CID_LIMIT;
     params->max_datagram_frame_size              = REMEMBERED_MAX_DGRAM_FRAME_SIZE;
-    params->max_idle_timeout                     = REMEMBERED_MAX_IDLE_TIMEOUT;
-    params->max_udp_payload_size                 = REMEMBERED_MAX_UDP_PAYLOAD_SIZE;
-    params->disable_active_migration             = 0;
-
-    /* defaults that the decode path expects */
-    params->ack_delay_exponent = XQC_DEFAULT_ACK_DELAY_EXPONENT;
-    params->max_ack_delay      = XQC_DEFAULT_MAX_ACK_DELAY;
-}
-
-/*
- * Encode params and invoke the callback.  Returns the conn_err value
- * set (or 0 if no error).
- */
-static xqc_int_t
-xqc_0rtt_test_fire(xqc_connection_t *conn, xqc_transport_params_t *params)
-{
-    uint8_t buf[XQC_MAX_TRANSPORT_PARAM_BUF_LEN];
-    size_t  len = 0;
-    xqc_int_t ret;
-
-    ret = xqc_encode_transport_params(params, XQC_TP_TYPE_ENCRYPTED_EXTENSIONS,
-                                      buf, sizeof(buf), &len);
-    CU_ASSERT_FATAL(ret == XQC_OK);
-    CU_ASSERT_FATAL(len > 0);
-
-    xqc_conn_tls_transport_params_cb(buf, len, conn);
-    return conn->conn_err;
 }
 
 /* ---- individual test cases ---- */
@@ -486,15 +409,13 @@ xqc_0rtt_test_fire(xqc_connection_t *conn, xqc_transport_params_t *params)
 void
 xqc_test_0rtt_params_all_equal(void)
 {
-    xqc_cid_t server_scid;
-    xqc_connection_t *conn = xqc_0rtt_test_make_conn(&server_scid);
+    xqc_connection_t *conn = xqc_0rtt_test_make_conn();
 
     xqc_transport_params_t params;
-    xqc_0rtt_test_init_params(&params, conn, &server_scid);
-    /* all values equal to remembered -- must succeed */
+    xqc_0rtt_test_init_params(&params);
 
-    xqc_int_t err = xqc_0rtt_test_fire(conn, &params);
-    CU_ASSERT_EQUAL(err, 0);
+    xqc_int_t ret = xqc_conn_validate_0rtt_transport_params(conn, &params);
+    CU_ASSERT_EQUAL(ret, XQC_OK);
 
     xqc_engine_destroy(conn->engine);
 }
@@ -539,13 +460,12 @@ xqc_test_conn_tls_error_first_writer_wins()
 void
 xqc_test_0rtt_params_all_increased(void)
 {
-    xqc_cid_t server_scid;
-    xqc_connection_t *conn = xqc_0rtt_test_make_conn(&server_scid);
+    xqc_connection_t *conn = xqc_0rtt_test_make_conn();
 
     xqc_transport_params_t params;
-    xqc_0rtt_test_init_params(&params, conn, &server_scid);
+    xqc_0rtt_test_init_params(&params);
 
-    /* increase every MUST parameter -- must succeed */
+    /* increase every parameter -- must succeed */
     params.initial_max_data                   *= 2;
     params.initial_max_stream_data_bidi_local *= 2;
     params.initial_max_stream_data_bidi_remote*= 2;
@@ -555,8 +475,8 @@ xqc_test_0rtt_params_all_increased(void)
     params.active_connection_id_limit         *= 2;
     params.max_datagram_frame_size            *= 2;
 
-    xqc_int_t err = xqc_0rtt_test_fire(conn, &params);
-    CU_ASSERT_EQUAL(err, 0);
+    xqc_int_t ret = xqc_conn_validate_0rtt_transport_params(conn, &params);
+    CU_ASSERT_EQUAL(ret, XQC_OK);
 
     xqc_engine_destroy(conn->engine);
 }
@@ -589,46 +509,43 @@ xqc_test_0rtt_params_each_reduced(void)
 {
     /*
      * Reduce each MUST parameter individually and verify that every
-     * branch in the validation code triggers TRA_0RTT_TRANS_PARAMS_ERROR.
-     * Uses offset-based mutation so one loop covers all 8 fields.
+     * branch triggers TRA_0RTT_TRANS_PARAMS_ERROR.
      */
     struct {
-        size_t   tp_offset;       /* offset into xqc_transport_params_t */
-        size_t   rs_offset;       /* offset into xqc_trans_settings_t (for datagram) */
+        size_t   tp_offset;
         uint64_t remembered_val;
     } cases[] = {
         { offsetof(xqc_transport_params_t, initial_max_data),
-          0, REMEMBERED_MAX_DATA },
+          REMEMBERED_MAX_DATA },
         { offsetof(xqc_transport_params_t, initial_max_stream_data_bidi_local),
-          0, REMEMBERED_MAX_STREAM_DATA_BIDI_LOCAL },
+          REMEMBERED_MAX_STREAM_DATA_BIDI_LOCAL },
         { offsetof(xqc_transport_params_t, initial_max_stream_data_bidi_remote),
-          0, REMEMBERED_MAX_STREAM_DATA_BIDI_REMOTE },
+          REMEMBERED_MAX_STREAM_DATA_BIDI_REMOTE },
         { offsetof(xqc_transport_params_t, initial_max_stream_data_uni),
-          0, REMEMBERED_MAX_STREAM_DATA_UNI },
+          REMEMBERED_MAX_STREAM_DATA_UNI },
         { offsetof(xqc_transport_params_t, initial_max_streams_bidi),
-          0, REMEMBERED_MAX_STREAMS_BIDI },
+          REMEMBERED_MAX_STREAMS_BIDI },
         { offsetof(xqc_transport_params_t, initial_max_streams_uni),
-          0, REMEMBERED_MAX_STREAMS_UNI },
+          REMEMBERED_MAX_STREAMS_UNI },
         { offsetof(xqc_transport_params_t, active_connection_id_limit),
-          0, REMEMBERED_ACTIVE_CID_LIMIT },
+          REMEMBERED_ACTIVE_CID_LIMIT },
         { offsetof(xqc_transport_params_t, max_datagram_frame_size),
-          0, REMEMBERED_MAX_DGRAM_FRAME_SIZE },
+          REMEMBERED_MAX_DGRAM_FRAME_SIZE },
     };
     size_t n = sizeof(cases) / sizeof(cases[0]);
 
     for (size_t i = 0; i < n; i++) {
-        xqc_cid_t server_scid;
-        xqc_connection_t *conn = xqc_0rtt_test_make_conn(&server_scid);
+        xqc_connection_t *conn = xqc_0rtt_test_make_conn();
 
         xqc_transport_params_t params;
-        xqc_0rtt_test_init_params(&params, conn, &server_scid);
+        xqc_0rtt_test_init_params(&params);
 
         /* reduce exactly one field below remembered */
         uint64_t *field = (uint64_t *)((char *)&params + cases[i].tp_offset);
         *field = cases[i].remembered_val - 1;
 
-        xqc_int_t err = xqc_0rtt_test_fire(conn, &params);
-        CU_ASSERT_EQUAL(err, TRA_0RTT_TRANS_PARAMS_ERROR);
+        xqc_int_t ret = xqc_conn_validate_0rtt_transport_params(conn, &params);
+        CU_ASSERT_EQUAL(ret, TRA_0RTT_TRANS_PARAMS_ERROR);
 
         xqc_engine_destroy(conn->engine);
     }

--- a/tests/unittest/xqc_packet_test.c
+++ b/tests/unittest/xqc_packet_test.c
@@ -219,9 +219,16 @@ xqc_test_packet_encrypt_hp_sample_boundary()
 {
     test_ctx         svr_tctx   = {0};
     test_ctx         cli_tctx   = {0};
+    xqc_packet_out_t *po        = NULL;
 
     svr_tctx.engine = test_create_engine_buf_server(&svr_tctx);
     cli_tctx.engine = test_create_engine_buf_client(&cli_tctx);
+
+    CU_ASSERT(svr_tctx.engine != NULL);
+    CU_ASSERT(cli_tctx.engine != NULL);
+    if (svr_tctx.engine == NULL || cli_tctx.engine == NULL) {
+        goto finish;
+    }
 
     xqc_conn_settings_t conn_settings;
     memset(&conn_settings, 0, sizeof(xqc_conn_settings_t));
@@ -229,8 +236,13 @@ xqc_test_packet_encrypt_hp_sample_boundary()
     xqc_conn_ssl_config_t conn_ssl_config;
     memset(&conn_ssl_config, 0, sizeof(conn_ssl_config));
 
-    xqc_connect(cli_tctx.engine, &conn_settings, NULL, 0, "", 0,
+    const xqc_cid_t *cid = xqc_connect(cli_tctx.engine, &conn_settings, NULL, 0, "", 0,
                 &conn_ssl_config, NULL, 0, "transport", &cli_tctx);
+    CU_ASSERT(cid != NULL);
+    CU_ASSERT(cli_tctx.c != NULL);
+    if (cid == NULL || cli_tctx.c == NULL) {
+        goto finish;
+    }
 
     struct sockaddr_in6 peer_addr;
     socklen_t peer_addrlen = sizeof(peer_addr);
@@ -242,8 +254,11 @@ xqc_test_packet_encrypt_hp_sample_boundary()
                               (struct sockaddr *)&local_addr, local_addrlen,
                               (struct sockaddr *)&peer_addr, peer_addrlen, xqc_now(), &svr_tctx);
 
-    xqc_packet_out_t *po = xqc_packet_out_create(2048);
+    po = xqc_packet_out_create(2048);
     CU_ASSERT(po != NULL);
+    if (po == NULL) {
+        goto finish;
+    }
 
     memcpy(po->po_pkt.pkt_scid.cid_buf, cli_tctx.c->scid_set.user_scid.cid_buf,
            cli_tctx.c->scid_set.user_scid.cid_len);
@@ -265,12 +280,24 @@ xqc_test_packet_encrypt_hp_sample_boundary()
     xqc_int_t ret = xqc_packet_encrypt_buf(cli_tctx.c, po, enc_buf, sizeof(enc_buf), &enc_len);
     CU_ASSERT(ret == XQC_OK);
 
-    xqc_packet_out_destroy(po);
-    xqc_conn_close(cli_tctx.engine, &cli_tctx.cid);
-    xqc_engine_destroy(cli_tctx.engine);
+finish:
+    if (po != NULL) {
+        xqc_packet_out_destroy(po);
+    }
 
-    xqc_conn_close(svr_tctx.engine, &svr_tctx.cid);
-    xqc_engine_destroy(svr_tctx.engine);
+    if (cli_tctx.engine != NULL) {
+        if (cli_tctx.c != NULL) {
+            xqc_conn_close(cli_tctx.engine, &cli_tctx.cid);
+        }
+        xqc_engine_destroy(cli_tctx.engine);
+    }
+
+    if (svr_tctx.engine != NULL) {
+        if (svr_tctx.c != NULL) {
+            xqc_conn_close(svr_tctx.engine, &svr_tctx.cid);
+        }
+        xqc_engine_destroy(svr_tctx.engine);
+    }
 }
 
 


### PR DESCRIPTION
## Summary

- Keep the RFC 9000 0-RTT transport-parameter validation on the real production condition: client 0-RTT was attempted and TLS reports early data accepted at `xqc_conn_tls_transport_params_cb()` time.
- Extract `xqc_conn_validate_0rtt_transport_params()` so unit tests can directly cover the remembered-value comparison without mock TLS/CID/encode-decode setup.
- Restore the RFC 9221 `max_datagram_frame_size` 0-RTT remembered-value check outside the TLS early-data guard. This preserves the existing case-test behavior where reducing or disabling DATAGRAM support must raise `TRA_0RTT_TRANS_PARAMS_ERROR` and clear the saved 0-RTT ticket.
- Fix `xqc_test_packet_encrypt_hp_sample_boundary` to guard NULL engine/connection pointers so missing local TLS cert files fail the test instead of crashing the CUnit process.
- Keep the 0-RTT unit tests registered before `hp_sample_boundary` so their coverage is not hidden by unrelated cert-path failures.

## Root cause

### 0-RTT validation guard

For the RFC 9000 core transport parameters, the production callback should only validate remembered values when the client attempted 0-RTT and TLS reports early data accepted. The earlier `|| XQC_CONN_FLAG_0RTT_OK` workaround was ineffective in production because `0RTT_OK` is set after the transport-parameters callback.

The unit-test problem was that mock connections created by `test_engine_connect()` do not carry real resumption/early-data TLS state, so the callback guard was unreachable in those tests. Directly testing the extracted validator keeps the unit coverage focused on the comparison logic.

### DATAGRAM remembered parameter

`max_datagram_frame_size` follows RFC 9221 Section 3. If the client remembers this transport parameter for 0-RTT, the value received in the new handshake must not be smaller than the remembered value. That check must remain effective for the existing DATAGRAM case tests, including the path where the server disables DATAGRAM after a ticket was generated with DATAGRAM enabled.

### hp_sample_boundary SIGSEGV

`xqc_test_packet_encrypt_hp_sample_boundary` uses test helpers that load `./server.key` and `./server.crt`. When those files are absent from the current working directory, engine creation can fail. The test now checks those pointers before dereferencing them, so the suite reports a failed assertion instead of crashing.

## Test plan

- [x] `make -C build -j4` on local macOS worktree
- [x] `cd build && ./tests/run_tests`: 127 tests passed, 0 failed
- [x] GitHub Actions `Build on Ubuntu` for the latest PR head commit: run #875 passed

## References

- RFC 9000 Section 7.4.1 - Values of Transport Parameters for 0-RTT
- RFC 9221 Section 3 - Transport Parameter
- Issue #717
