### PR TITLE
Fix active_connection_id_limit error handling

### DIFF
--- a/scripts/case_test.sh
+++ b/scripts/case_test.sh
@@ -831,6 +831,48 @@ else
 fi
 
 clear_log
+echo -e "active_connection_id_limit accepts in-limit NEW_CONNECTION_ID ...\c"
+killall test_server 2> /dev/null
+${SERVER_BIN} -l d -e -x 1 > /dev/null &
+sleep 1
+${CLIENT_BIN} -s 1024 -l d -t 1 -E > stdlog
+result=`grep ">>>>>>>> pass:1" stdlog`
+conn_err_zero=`grep -E "conn_err:0[^0-9]" stdlog`
+errlog=`grep_err_log`
+if [ -z "$errlog" ] && [ "$result" == ">>>>>>>> pass:1" ] && [ -n "$conn_err_zero" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "active_cid_limit_accept" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "active_cid_limit_accept" "fail"
+    echo "$errlog"
+fi
+
+clear_log
+echo -e "active_connection_id_limit rejects extra NEW_CONNECTION_ID ...\c"
+killall test_server 2> /dev/null
+${SERVER_BIN} -l d -e -x 704 > svr_stdlog &
+sleep 1
+${CLIENT_BIN} -s 1024 -l d -t 2 -E > stdlog 2>&1
+forced_cid=`grep "\[active-cid-limit-test\]" svr_stdlog`
+conn_id_limit_err=`grep -E "(conn errno:9|conn_err:9)" stdlog`
+frame_encoding_err=`grep -E "(conn errno:7|conn_err:7)" stdlog`
+if [ -n "$forced_cid" ] && [ -n "$conn_id_limit_err" ] && [ -z "$frame_encoding_err" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "active_cid_limit_exceeded" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "active_cid_limit_exceeded" "fail"
+    echo "$forced_cid"
+    echo "$conn_id_limit_err"
+    echo "$frame_encoding_err"
+fi
+
+killall test_server 2> /dev/null
+${SERVER_BIN} -l d -e > /dev/null &
+sleep 1
+
+clear_log
 echo -e "GET request ...\c"
 result=`${CLIENT_BIN} -l d -t 1 -E -G|grep ">>>>>>>> pass"`
 errlog=`grep_err_log`

--- a/src/transport/xqc_frame.c
+++ b/src/transport/xqc_frame.c
@@ -1046,6 +1046,10 @@ xqc_process_new_conn_id_frame(xqc_connection_t *conn, xqc_packet_in_t *packet_in
                 conn->local_settings.active_connection_id_limit, 
                 xqc_cid_set_get_unused_cnt(&conn->dcid_set, XQC_INITIAL_PATH_ID), 
                 xqc_cid_set_get_used_cnt(&conn->dcid_set, XQC_INITIAL_PATH_ID));
+        if (ret == -XQC_EACTIVE_CID_LIMIT) {
+            XQC_CONN_ERR(conn, TRA_CONNECTION_ID_LIMIT_ERROR);
+            return -XQC_EPROTO;
+        }
         return ret;
     }
 
@@ -2082,6 +2086,10 @@ xqc_process_mp_new_conn_id_frame(xqc_connection_t *conn, xqc_packet_in_t *packet
                 xqc_cid_set_get_unused_cnt(&conn->dcid_set, path_id), 
                 xqc_cid_set_get_used_cnt(&conn->dcid_set, path_id),
                 path_id);
+        if (ret == -XQC_EACTIVE_CID_LIMIT) {
+            XQC_CONN_ERR(conn, TRA_CONNECTION_ID_LIMIT_ERROR);
+            return -XQC_EPROTO;
+        }
         return ret;
     }
 

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -231,14 +231,17 @@ int g_spec_url;
 int g_is_get;
 uint64_t g_last_sock_op_time;
 /*
- * currently, the maximum used test case id is 55
+ * currently, the maximum used test case id is 704
  * please keep this comment updated if you are adding more test cases. :-D
  * 55 for RFC 9114 Section 4.2 forbidden header e2e validation
  * 99 for pure fin
  * 2XX for datagram testcases
  * 3XX for h3 ext bytestream testcases
  * 4XX for conn_settings configuration
- * 7XX for 0-RTT transport param validation
+ * 700 for FEC frame type bit validation
+ * 701/702 for 0-RTT transport param validation
+ * 703 for CRYPTO_ERROR validation
+ * 704 for active_connection_id_limit validation
  */
 int g_test_case;
 int g_ipv6;

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -18,6 +18,8 @@
 #include <stdint.h>
 
 #include "platform.h"
+#include "src/transport/xqc_conn.h"
+#include "src/transport/xqc_packet_out.h"
 
 #ifndef XQC_SYS_WINDOWS
 #include <unistd.h>
@@ -1007,6 +1009,45 @@ xqc_server_h3_conn_handshake_finished(xqc_h3_conn_t *h3_conn, void *conn_user_da
     if (g_test_case == 48) {
         printf("[initial-salt-test] server handshake ok, conn_err:%d\n",
                stats.conn_err);
+    }
+
+    if (g_test_case == 704) {
+        xqc_connection_t *conn = xqc_h3_conn_get_xqc_conn(h3_conn);
+        xqc_cid_set_inner_t *inner_set;
+        uint64_t peer_limit;
+        uint64_t target;
+        uint64_t countable;
+        xqc_int_t ret = XQC_OK;
+
+        if (conn == NULL) {
+            printf("[active-cid-limit-test] conn unavailable\n");
+            return;
+        }
+
+        inner_set = xqc_get_path_cid_set(&conn->scid_set, XQC_INITIAL_PATH_ID);
+        if (inner_set == NULL) {
+            printf("[active-cid-limit-test] cid set unavailable\n");
+            return;
+        }
+
+        peer_limit = conn->remote_settings.active_connection_id_limit;
+        target = peer_limit + 1;
+        countable = xqc_cid_set_countable_cnt(inner_set);
+
+        conn->remote_settings.active_connection_id_limit = target;
+        while (countable < target) {
+            ret = xqc_write_new_conn_id_frame_to_packet(conn, 0);
+            if (ret != XQC_OK) {
+                printf("[active-cid-limit-test] force NEW_CONNECTION_ID ret:%d\n",
+                       ret);
+                break;
+            }
+            countable = xqc_cid_set_countable_cnt(inner_set);
+        }
+        conn->remote_settings.active_connection_id_limit = peer_limit;
+
+        printf("[active-cid-limit-test] peer_limit:%"PRIu64
+               ", sent_countable:%"PRIu64"\n", peer_limit, countable);
     }
 
     /* pretend to create a server-inited http3 stream */
@@ -2696,7 +2737,9 @@ int main(int argc, char *argv[]) {
     }
 
     /* test server cid negotiate */
-    if (g_test_case == 1 || g_test_case == 5 || g_test_case == 6 || g_sid_len != 0) {
+    if (g_test_case == 1 || g_test_case == 5 || g_test_case == 6
+        || g_test_case == 704 || g_sid_len != 0)
+    {
 
         if (g_lb_cid_enc_key_len == 0) {
             int i = 0;

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -123,6 +123,10 @@ main()
         || !CU_add_test(pSuite, "xqc_test_ack_ecn_truncated", xqc_test_ack_ecn_truncated)
         || !CU_add_test(pSuite, "xqc_test_ack_ecn_followed_by_ping", xqc_test_ack_ecn_followed_by_ping)
         || !CU_add_test(pSuite, "xqc_test_new_conn_id_zero_len_cid", xqc_test_new_conn_id_zero_len_cid)
+        || !CU_add_test(pSuite, "xqc_test_new_conn_id_active_limit_accept",
+                        xqc_test_new_conn_id_active_limit_accept)
+        || !CU_add_test(pSuite, "xqc_test_new_conn_id_active_limit_exceeded",
+                        xqc_test_new_conn_id_active_limit_exceeded)
         || !CU_add_test(pSuite, "xqc_test_h3_frame", xqc_test_frame)
         || !CU_add_test(pSuite, "xqc_test_tls", xqc_test_tls)
         || !CU_add_test(pSuite, "xqc_test_h3_stream", xqc_test_stream)

--- a/tests/unittest/xqc_process_frame_test.c
+++ b/tests/unittest/xqc_process_frame_test.c
@@ -715,3 +715,103 @@ xqc_test_new_conn_id_zero_len_cid(void)
 
     xqc_engine_destroy(conn->engine);
 }
+
+static size_t
+xqc_test_build_new_conn_id_frame(unsigned char *frame_buf, uint64_t seq_num)
+{
+    unsigned char *p = frame_buf;
+    int i;
+
+    *p++ = 0x18;                  /* NEW_CONNECTION_ID */
+    *p++ = (unsigned char)seq_num; /* sequence number, 1-byte varint */
+    *p++ = 0x00;                  /* retire prior to */
+    *p++ = XQC_DEFAULT_CID_LEN;   /* cid length */
+
+    for (i = 0; i < XQC_DEFAULT_CID_LEN; i++) {
+        *p++ = (unsigned char)(0xA0 + seq_num + i);
+    }
+
+    for (i = 0; i < XQC_STATELESS_RESET_TOKENLEN; i++) {
+        *p++ = (unsigned char)(0xC0 + seq_num + i);
+    }
+
+    return p - frame_buf;
+}
+
+static xqc_int_t
+xqc_test_process_new_conn_id_frame_one(xqc_connection_t *conn,
+    uint64_t seq_num)
+{
+    unsigned char frame_buf[64];
+    size_t frame_len = xqc_test_build_new_conn_id_frame(frame_buf, seq_num);
+    xqc_packet_in_t pi;
+
+    memset(&pi, 0, sizeof(pi));
+    pi.pos = frame_buf;
+    pi.last = frame_buf + frame_len;
+    pi.pi_pkt.pkt_type = XQC_PTYPE_SHORT_HEADER;
+
+    return xqc_process_frames(conn, &pi);
+}
+
+void
+xqc_test_new_conn_id_active_limit_accept(void)
+{
+    xqc_connection_t *conn = test_engine_connect();
+    xqc_cid_set_inner_t *inner_set;
+    xqc_int_t ret;
+
+    CU_ASSERT(conn != NULL);
+    if (conn == NULL) {
+        return;
+    }
+
+    conn->local_settings.active_connection_id_limit = 2;
+
+    ret = xqc_test_process_new_conn_id_frame_one(conn, 1);
+    CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(conn->conn_err == 0);
+
+    inner_set = xqc_get_path_cid_set(&conn->dcid_set, XQC_INITIAL_PATH_ID);
+    CU_ASSERT(inner_set != NULL);
+    if (inner_set != NULL) {
+        CU_ASSERT(xqc_cid_set_countable_cnt(inner_set) == 1);
+    }
+
+    xqc_engine_destroy(conn->engine);
+}
+
+void
+xqc_test_new_conn_id_active_limit_exceeded(void)
+{
+    xqc_connection_t *conn = test_engine_connect();
+    xqc_cid_set_inner_t *inner_set;
+    xqc_int_t ret;
+
+    CU_ASSERT(conn != NULL);
+    if (conn == NULL) {
+        return;
+    }
+
+    conn->local_settings.active_connection_id_limit = 2;
+
+    ret = xqc_test_process_new_conn_id_frame_one(conn, 1);
+    CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(conn->conn_err == 0);
+
+    ret = xqc_test_process_new_conn_id_frame_one(conn, 2);
+    CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(conn->conn_err == 0);
+
+    ret = xqc_test_process_new_conn_id_frame_one(conn, 3);
+    CU_ASSERT(ret == -XQC_EPROTO);
+    CU_ASSERT(conn->conn_err == TRA_CONNECTION_ID_LIMIT_ERROR);
+
+    inner_set = xqc_get_path_cid_set(&conn->dcid_set, XQC_INITIAL_PATH_ID);
+    CU_ASSERT(inner_set != NULL);
+    if (inner_set != NULL) {
+        CU_ASSERT(xqc_cid_set_countable_cnt(inner_set) == 2);
+    }
+
+    xqc_engine_destroy(conn->engine);
+}

--- a/tests/unittest/xqc_process_frame_test.h
+++ b/tests/unittest/xqc_process_frame_test.h
@@ -35,4 +35,8 @@ void xqc_test_ack_ecn_followed_by_ping();
 
 void xqc_test_new_conn_id_zero_len_cid(void);
 
+void xqc_test_new_conn_id_active_limit_accept(void);
+
+void xqc_test_new_conn_id_active_limit_exceeded(void);
+
 #endif /* _XQC_PROCESS_FRAME_TEST_H_INCLUDED_ */


### PR DESCRIPTION
### Summary

Close connections with `CONNECTION_ID_LIMIT_ERROR` when a received
`NEW_CONNECTION_ID` exceeds `active_connection_id_limit`.

### Changes

- Map active CID limit insert failures in both normal and multipath
  `NEW_CONNECTION_ID` receive paths to `TRA_CONNECTION_ID_LIMIT_ERROR`.
- Add unit coverage for accepted in-limit `NEW_CONNECTION_ID` frames and
  rejected over-limit frames.
- Add case-test coverage for the successful CID negotiation path and a server
  test mode that intentionally sends one CID beyond the peer limit.

### Related

Follow-up to #821.

### Tests

- `cmake --build build --target run_tests test_client test_server -j 4`
- `build/tests/run_tests` passes the new
  `xqc_test_new_conn_id_active_limit_accept` and
  `xqc_test_new_conn_id_active_limit_exceeded` tests.
- `build/tests/test_server -l d -e -x 1` with
  `build/tests/test_client -s 1024 -l d -t 1 -E`
- `build/tests/test_server -l d -e -x 704` with
  `build/tests/test_client -s 1024 -l d -t 2 -E`

### Notes

The full local CUnit run currently reports one unrelated failure in
`xqc_test_0rtt_params_each_reduced`; the new active CID limit tests pass in
that run.
