### PR TITLE
[+] Add project development harness

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,70 @@
+### Summary
+
+<!-- Describe the current behavior or need, its impact, the observable
+acceptance criteria, and the implementation approach. -->
+
+### Changes
+
+<!-- List the concrete code, test, documentation, or tooling changes. -->
+
+### Related Issue
+
+<!-- Add the exact line `Fixes: #123` when this PR resolves an issue.
+Otherwise write `Not applicable`. -->
+
+### Specification
+
+<!-- For protocol behavior, cite the exact RFC or draft revision and section,
+state whether the requirement is normative, and describe the expected and
+previous wire behavior. Otherwise write `Not applicable`. -->
+
+### CONTRIBUTING.md Checklist
+
+<!-- These checks come from CONTRIBUTING.md and apply in addition to the
+harness validation evidence below. -->
+
+- [ ] The branch uses the documented `dev/`, `fix/`, `perf/`, or `doc/`
+      prefix.
+- [ ] Commit messages follow `[<type>]: <subject>` using `+`, `-`, `=`, or
+      `~`.
+- [ ] The change follows the Nginx-derived XQUIC code style, or is
+      documentation-only.
+- [ ] The full test suite and sufficient relevant tests have passed, with
+      exact evidence recorded below, or a documentation/tooling exemption is
+      explained.
+- [ ] Required continuous-integration checks pass before merge.
+- [ ] The branch is rebased on its current base branch, and review-fix commits
+      will be squashed before merge.
+- [ ] The Contributor License Agreement is signed or will be completed before
+      merge.
+
+### Validation
+
+<!-- Production behavior changes must complete every field below with results
+from the current PR head. A checked box without the command, name, result, and
+tested commit SHA does not pass the gate. Documentation-only or validation-
+tooling changes must replace runtime evidence with deterministic checks and
+explain why runtime coverage does not apply. -->
+
+- Validation applicability: `<production behavior / documentation / tooling>`
+- Runtime-coverage exemption, if applicable: `<reason and deterministic checks>`
+- [ ] Tested commit SHA: `<sha>`
+- [ ] Complete local unit suite:
+  - Command: `unset XQC_TEST_NAME && ./scripts/validate.sh test`
+  - Result: `<pass/fail and concise summary>`
+- [ ] Happy-path unit test: `<test name and result>`
+- [ ] Abnormal-path unit test: `<test name and result>`
+- [ ] Happy-path client-to-server case:
+  - Case name: `<case_print_result name>`
+  - Command: `<exact command>`
+  - Result: `<pass/fail>`
+- [ ] Abnormal-path client-to-server case:
+  - Case name: `<case_print_result name>`
+  - Command: `<exact command>`
+  - Result: `<pass/fail>`
+
+### Risk and Scope
+
+<!-- Name affected layers, compatibility risks, untested configurations, and
+documentation impact. Confirm generated or temporary artifacts are absent and
+that the PR contains one cohesive contribution. -->

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ bss/
 *.swp
 third_party/
 .idea/
+.agents/
 cmake-build-debug/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,99 @@
+# XQUIC Agent Guide
+
+Keep this file short. It is a map to the repository's sources of truth, not a
+replacement for them.
+
+## First-Time Harness Setup
+
+At the first task in a fresh checkout, ensure that the harness skills and
+pipeline are registered in the active discovery directories. The default
+project-local adapters are `.agents/skills/` and
+`.agents/pipelines/dev-pipeline.md`. If either registration is absent, run:
+
+```bash
+./scripts/setup_harness.sh
+```
+
+Run this bootstrap once per checkout, not once per task. The script is
+idempotent and refuses to overwrite existing paths. Pass its directory options
+when the active tool uses native discovery paths, and check those targets on
+later tasks. Do not install the optional pre-push hook unless the user or
+contributor explicitly opts in.
+
+## Mandatory Code-Task Preflight
+
+Before planning, inspecting implementation paths, or editing any code, test,
+build script, validation tool, or repository automation, read the
+[development pipeline](harness/pipelines/dev-pipeline.md) in full. Apply this
+gate at the start of every code task, including a new task in an existing
+session. Do not begin implementation until the requirement and acceptance
+criteria stages have been completed.
+
+## Start Here
+
+- Read [`README.md`](README.md) for supported features and dependency setup.
+- Read [`CONTRIBUTING.md`](CONTRIBUTING.md) before changing code or preparing
+  a pull request.
+- Read the [harness index](harness/README.md) to locate project specifications,
+  pipelines, and reusable skills.
+- Read the
+  [project instructions](harness/spec/PROJECT_INSTRUCTIONS.md) for task
+  routing and repository-wide constraints.
+- Read [`harness/spec/architecture.md`](harness/spec/architecture.md)
+  before changing module boundaries.
+- Before submitting an issue, use
+  [`issue-check`](harness/skills/issue-check/SKILL.md) and then
+  [`issue-submit`](harness/skills/issue-submit/SKILL.md).
+- Read the closest module documentation and protocol specification before
+  changing wire behavior.
+
+## Build and Validate
+
+The repository-wide validation entry point is:
+
+```bash
+./scripts/validate.sh build
+./scripts/validate.sh test
+XQC_BUILD_DIR=build ./scripts/validate.sh full
+```
+
+These commands must remain independent of any feature, bug, issue number, or
+pull request. Use tests, not issue-specific build modes, to express a
+regression.
+
+The default validation profile is a Debug build with BoringSSL and tests
+enabled. It writes only ignored build output beneath `build/validation/`.
+Environment overrides and validation levels are documented in the
+[validation specification](harness/spec/validation.md). For validation tasks,
+also follow the [`validate` skill](harness/skills/validate/SKILL.md).
+
+## Change Rules
+
+- Keep changes scoped to the requested behavior.
+- Preserve unrelated user changes and untracked files.
+- Do not edit vendored content under `third_party/`.
+- For every production behavior change, add or update unit tests that cover
+  both the happy path and an abnormal or error branch.
+- Add matching client-to-server case tests for both the successful and
+  abnormal end-to-end paths.
+- For protocol behavior, cite the exact RFC or draft section in the test or
+  nearby implementation comment when it materially explains the invariant.
+- Follow the Nginx-derived C style in `CONTRIBUTING.md`, including 4-space
+  indentation, no `//` comments, and an 80-column target.
+
+## Definition of Done
+
+A code change is done when:
+
+- the requested behavior and its acceptance criteria are satisfied;
+- paired happy-path and abnormal-path unit tests cover each production
+  behavior change;
+- paired client-to-server case tests cover the corresponding end-to-end
+  behavior;
+- the complete local unit suite and both relevant case tests pass;
+- the diff has been reviewed for scope and regressions; and
+- the pull request contains the evidence required by the
+  [pull-request specification](harness/spec/pull-requests.md).
+
+When preparing or updating a pull request, follow the
+[`xquic-pr-formatting` skill](harness/skills/xquic-pr-formatting/SKILL.md).

--- a/harness/README.md
+++ b/harness/README.md
@@ -1,0 +1,80 @@
+# XQUIC Development Harness
+
+This directory is the repository-owned, tool-neutral source for project
+specifications, development pipelines, and reusable agent skills. Root
+`AGENTS.md` remains the broadly discoverable entry point and links here.
+
+## Layout
+
+```text
+harness/
+├── spec/        project instructions, facts, and evidence contracts
+├── pipelines/   ordered workflows that apply the specifications
+└── skills/      reusable task procedures, one SKILL.md per skill
+```
+
+## Entry Points
+
+- [Project instructions](spec/PROJECT_INSTRUCTIONS.md)
+- [Development pipeline](pipelines/dev-pipeline.md)
+- [Validation skill](skills/validate/SKILL.md)
+- [Issue verification skill](skills/issue-check/SKILL.md)
+- [Issue submission skill](skills/issue-submit/SKILL.md)
+- [Pull request formatting skill](skills/xquic-pr-formatting/SKILL.md)
+
+## Setup
+
+From the repository root, run
+[`setup_harness.sh`](../scripts/setup_harness.sh) to register the harness:
+
+```bash
+./scripts/setup_harness.sh
+```
+
+Root [`AGENTS.md`](../AGENTS.md#first-time-harness-setup) directs agents to
+run this bootstrap once when a fresh checkout's active discovery targets have
+no registered adapters.
+
+The default registration creates project-local symbolic links under
+`.agents/skills/` and `.agents/pipelines/`. These generated adapters are
+ignored by Git; `harness/` remains the only committed source. Re-running the
+command is safe. Existing files or links to another source are never
+overwritten.
+
+Use `--skills-dir` and `--pipelines-dir` to target a tool-native discovery
+directory. To install the optional pre-push validation hook:
+
+```bash
+./scripts/setup_harness.sh --install-pre-push-hook
+```
+
+The [pre-push hook](../scripts/hooks/pre-push) runs the complete local unit
+and case-test suites. It is an early failure signal, not a substitute for
+naming the relevant happy-path and abnormal-path tests and their current-head
+results in the pull request.
+
+## Naming
+
+- Top-level harness directories use the stable names `spec/`, `pipelines/`,
+  and `skills/`.
+- Markdown filenames use lowercase kebab-case, except conventional
+  `README.md`, `SKILL.md`, and the adapter template
+  `PROJECT_INSTRUCTIONS.md`.
+- Skill directories use the same lowercase hyphenated name as the `name`
+  field in their `SKILL.md`.
+- Capability behavior specifications use
+  `spec/<capability>/spec.md`.
+- Temporary plans, retrospectives, logs, and validation output do not belong
+  in `harness/`.
+- Task-scoped issue-check reports belong under the ignored
+  `build/harness/<task-id>/` directory and must not be committed.
+
+## Portability
+
+`harness/` is the canonical committed source, independent of a particular
+agent product. Tools that require native discovery directories may install or
+link these skills into their own ignored directory, but should not maintain a
+second committed copy. Every skill keeps its portable instructions in
+`SKILL.md`; platform-specific metadata is optional. Project-instruction
+adapters should link to or be generated from
+`spec/PROJECT_INSTRUCTIONS.md`.

--- a/harness/pipelines/dev-pipeline.md
+++ b/harness/pipelines/dev-pipeline.md
@@ -1,0 +1,135 @@
+# Development Pipeline
+
+This is the issue-independent workflow for XQUIC code changes. It adapts the
+development loop from the reference harness to the specifications and
+validation entry points maintained in this repository.
+
+Reading this file in full is a mandatory preflight for every code task. Read
+it before planning, inspecting implementation paths, or editing source,
+tests, build scripts, validation tooling, or repository automation.
+
+```text
+Requirement analysis -> Acceptance criteria -> Implementation
+                     -> Validation -> Review and PR evidence
+```
+
+## Stage 1: Requirement Analysis
+
+1. Read `AGENTS.md` and the
+   [project instructions](../spec/PROJECT_INSTRUCTIONS.md).
+2. Classify whether the task fixes a reported issue. If it does:
+   1. Run the [`issue-check` skill](../skills/issue-check/SKILL.md) against
+      the issue, the authoritative RFC or draft, and the current checkout.
+   2. Verify the issue's truth gate and investigate the source root cause,
+      preserving the complete required report, source excerpts, commit SHA,
+      root-cause status, and blocking evidence.
+   3. Write the report to the task-scoped, ignored temporary artifact
+      `build/harness/<task-id>/issue-check.md`. Do not stage or commit it.
+   4. Continue the issue fix only when `check_result: true`. For
+      `not-a-problem`, stop the fix and report the verified explanation. For
+      `inconclusive`, gather the blocking evidence and rerun `issue-check`
+      before deciding whether implementation is justified.
+3. Identify the affected modules using the
+   [architecture map](../spec/architecture.md).
+4. Read the relevant source, callers, tests, public headers, and module docs.
+5. For wire behavior, identify the governing RFC or draft section.
+6. Record non-goals and unrelated local changes that must remain untouched.
+
+Exit when the current behavior, desired behavior, affected boundary, and
+source of truth are understood. For an issue fix, the task-scoped issue-check
+report must exist, its gate must be true, and its root-cause status and any
+blocking evidence must be explicit.
+
+## Stage 2: Acceptance Criteria
+
+1. For an issue fix, use the issue-check report's verified specification,
+   implementation comparison, and root-cause analysis as requirement inputs.
+2. Express completion as observable behavior rather than an issue-specific
+   build mode, branch name, or configuration flag.
+3. Identify a happy-path unit test for the changed behavior.
+4. Identify an abnormal, rejection, boundary, or error-branch unit test.
+5. Identify matching happy-path and abnormal-path client-to-server cases in
+   `scripts/case_test.sh`.
+6. Identify broader compatibility or interoperability evidence when the
+   paired tests cannot establish the peer-visible result.
+7. Choose the expected validation level from the
+   [validation specification](../spec/validation.md).
+
+Exit when the criteria can distinguish the intended behavior from the
+pre-change behavior.
+
+## Stage 3: Implementation
+
+1. For an issue fix, read
+   `build/harness/<task-id>/issue-check.md` before editing production code.
+   Treat its verified mechanism, source trace, root-cause status, and blocking
+   evidence as implementation inputs. Rerun `issue-check` if a relevant
+   issue claim, specification revision, or source path changed.
+2. Add or update paired happy-path and abnormal-path unit tests.
+3. Add or update paired happy-path and abnormal-path client-to-server case
+   tests.
+4. Make the smallest production change that satisfies the criteria.
+5. Follow `CONTRIBUTING.md` and adjacent project conventions.
+6. Re-read the modified path and trace affected callers and callees.
+7. Update durable specifications or module documentation when contracts,
+   boundaries, commands, or maintenance obligations changed.
+
+Exit when the implementation, tests, and durable documentation agree.
+
+## Stage 4: Validation
+
+Follow the [`validate` skill](../skills/validate/SKILL.md). Before a production
+code pull request, run the complete local unit suite with `XQC_TEST_NAME`
+unset, then run both relevant client-to-server case tests:
+
+```bash
+unset XQC_TEST_NAME
+./scripts/validate.sh test
+```
+
+Use `XQC_BUILD_DIR=build ./scripts/validate.sh full` when the paired case-test
+blocks cannot be run independently. Record exact commands, paired test names,
+and results. Keep the pull request in draft after a missing or failed gate.
+
+Exit only when the complete unit suite and both relevant case tests pass.
+
+## Stage 5: Review and PR Evidence
+
+1. Review staged and unstaged diffs separately and verify the final scope.
+2. Confirm generated headers, validation artifacts, and task-scoped
+   `build/harness/` issue-check reports are absent from the commit.
+3. Check that documentation links and referenced commands still resolve.
+4. Assemble the evidence required by the
+   [pull-request specification](../spec/pull-requests.md).
+5. Use the
+   [`xquic-pr-formatting` skill](../skills/xquic-pr-formatting/SKILL.md)
+   when drafting or updating the pull request.
+6. Complete the repository
+   [pull-request template](../../.github/pull_request_template.md) with
+   current-head local validation results. For production behavior changes,
+   name the complete unit-suite command and the paired happy-path and
+   abnormal-path unit and client-to-server case tests.
+
+Complete the loop only when the acceptance criteria, paired unit and case-test
+coverage, validation evidence, scope review, and pull request evidence are
+consistent.
+
+## Enforcement Rules
+
+1. Build and validation interfaces must not depend on a feature, bug, issue
+   number, or pull request.
+2. A behavior-changing code edit must not leave stale tests or durable
+   documentation.
+3. Every production behavior change requires paired happy-path and
+   abnormal-path unit tests.
+4. Every production behavior change requires paired happy-path and
+   abnormal-path client-to-server case tests.
+5. A failed build is resolved before tests continue.
+6. The complete local unit suite and relevant case-test pair must pass before
+   review.
+7. Generated and temporary artifacts are never committed as source.
+8. A production code pull request remains draft while any required local
+   result or paired test name is missing from its description.
+9. An issue fix must not enter implementation with a false or inconclusive
+   issue-check gate, and its task-scoped issue-check report must never be
+   committed.

--- a/harness/skills/issue-check/SKILL.md
+++ b/harness/skills/issue-check/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: issue-check
+description: Verify whether a proposed XQUIC bug issue is real by checking the cited RFC or Internet-Draft mechanism against the repository's actual source behavior, tracing any root cause to current file and line evidence, and returning a fail-closed boolean gate. Use when validating an issue draft, investigating a claimed QUIC, HTTP/3, QPACK, or MoQT protocol violation, or before issue-submit may publish an issue.
+---
+
+# XQUIC Issue Check
+
+Produce an evidence-backed validity report. Do not create or modify a GitHub
+issue while performing this check.
+
+## Required Workflow
+
+1. Normalize the claim into:
+   - affected protocol, version, and negotiated feature;
+   - triggering inputs and configuration;
+   - expected behavior;
+   - actual behavior; and
+   - claimed RFC or draft section.
+2. Read the authoritative specification:
+   - use RFC Editor for published RFCs;
+   - use IETF Datatracker for active Internet-Drafts;
+   - identify the exact section and, for a draft, the exact revision; and
+   - distinguish normative requirements from explanatory text.
+3. Verify applicability. Check protocol version, endpoint role, connection
+   state, negotiated parameters, preconditions, and documented exceptions.
+4. Inspect the current XQUIC checkout. Trace the relevant parser, state
+   transition, caller, error path, and tests rather than relying only on names
+   or issue-provided snippets.
+5. Reproduce the reported behavior or run the nearest deterministic test when
+   practical. Record the exact command, configuration, and result. If the
+   behavior is not reproduced, distinguish direct source proof from an
+   unverified runtime assumption.
+6. Compare the specification mechanism with the implementation logic:
+   - state the specification rule in plain language;
+   - state the source behavior along the same decision path;
+   - identify the exact divergence, if any; and
+   - rule out configuration, unsupported-version, permissive-language, and
+     documented implementation-choice explanations.
+7. Attempt to locate the root cause. Never promote correlation or a nearby
+   line into a confirmed cause without tracing how it produces the reported
+   behavior.
+8. Return the gate report in the format below.
+
+## Specification Evidence
+
+Link to the exact section, not only the RFC or draft landing page. Preserve
+normative keywords such as MUST, MUST NOT, SHOULD, and MAY when they determine
+the result. Quote only the shortest decisive excerpt and paraphrase its
+surrounding mechanism and applicability.
+
+For an Internet-Draft, record both its revision and section because draft
+requirements can change. Treat an implementation that follows a different
+draft revision as a version mismatch until compatibility expectations prove
+otherwise.
+
+## Source and Root-Cause Evidence
+
+Resolve evidence against the current checkout and record `git rev-parse HEAD`.
+Re-read line numbers from the file; do not trust stale line references from
+the proposed issue.
+
+For each decisive source location, provide:
+
+- the repository-relative path;
+- the current commit SHA;
+- the smallest useful line range;
+- a short exact source excerpt; and
+- an explanation of how that branch implements or violates the mechanism.
+
+Use a commit-pinned GitHub permalink when available. Otherwise use
+`path:line` with the commit SHA. Distinguish root-cause status as:
+
+- `confirmed`: the traced branch necessarily produces the discrepancy;
+- `probable`: evidence points to it but a missing observation remains; or
+- `unresolved`: the defect is verified but its cause is not yet isolated.
+
+A verified behavioral defect may pass with an unresolved root cause. Do not
+invent file, line, or code evidence to make the report appear complete.
+
+## Gate Decision
+
+Return `check_result: true` only when:
+
+1. the authoritative mechanism applies to the reported scenario;
+2. the repository behavior conflicts with that mechanism or contains an
+   independently demonstrable logic error; and
+3. a reasonable implementation choice, negotiated configuration, or stated
+   exception does not explain the difference.
+
+Return `check_result: false` with `classification: not-a-problem` when the
+implementation conforms, the requirement does not apply, the text is
+permissive, or the difference is a valid implementation tradeoff.
+
+Return `check_result: false` with `classification: inconclusive` when required
+specification, source, configuration, or reproduction evidence is missing.
+This fails the submission gate; it is not proof that the implementation is
+correct.
+
+Source reasoning alone may verify a defect when the relevant branch and
+outcome are deterministic. Otherwise, failure to reproduce the claimed
+runtime behavior is inconclusive.
+
+A SHOULD-level difference is not automatically a defect: inspect whether the
+implementation has valid reasons and understands the consequences. A local
+preference cannot override an applicable MUST or MUST NOT.
+
+## Required Output
+
+```yaml
+check_result: true | false
+classification: verified-defect | not-a-problem | inconclusive
+summary: <one-sentence decision>
+specification:
+  document: <RFC or draft revision>
+  section: <section number and title>
+  url: <exact section URL>
+  requirement: <normative mechanism and applicability>
+implementation:
+  commit: <full SHA>
+  observed_logic: <what the current code does>
+  locations:
+    - path: <repo-relative path>
+      lines: <current line or narrow range>
+      excerpt: <short exact source content>
+      explanation: <how this code implements the observed behavior>
+comparison:
+  divergence: <exact mismatch, or none>
+  alternatives_ruled_out:
+    - <configuration, version, or design explanation checked>
+root_cause:
+  status: confirmed | probable | unresolved | not-applicable
+  locations:
+    - path: <repo-relative path>
+      lines: <current line or narrow range>
+      excerpt: <short exact source content>
+      explanation: <causal relationship>
+blocking_evidence:
+  - <missing evidence; empty when verified>
+```
+
+After the YAML block, give a concise human-readable analysis with the
+specification evidence, source excerpts, and reasoning needed to audit the
+decision.
+
+## Guardrails
+
+- Prefer primary RFC Editor, IETF Datatracker, repository source, tests, and
+  captured behavior over secondary summaries.
+- Do not return true merely because the issue text cites an RFC.
+- Do not treat unsupported functionality as a defect unless support is
+  claimed or required for the negotiated protocol.
+- Do not expose credentials, private logs, or security-vulnerability details
+  in a public-ready report.
+- Re-run the check after any relevant source, draft revision, reproduction, or
+  issue-claim change.

--- a/harness/skills/issue-submit/SKILL.md
+++ b/harness/skills/issue-submit/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: issue-submit
+description: Draft and submit evidence-backed XQUIC GitHub bug issues in the repository's CONTRIBUTING and issue-template format. Use when preparing or opening an alibaba/xquic issue that must identify an exact RFC or draft mechanism, expected-versus-actual behavior, reproduction evidence, and optional verified source root cause; requires issue-check to return true before any GitHub submission.
+---
+
+# XQUIC Issue Submit
+
+Prepare one specific, reproducible, non-duplicate issue and publish it only
+after the [`issue-check` skill](../issue-check/SKILL.md) clears the claim.
+
+## Required Workflow
+
+1. Read root [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) and the
+   [`bug_report.yml`](../../../.github/ISSUE_TEMPLATE/bug_report.yml) issue
+   template.
+2. Reject public submission of suspected security vulnerabilities. Direct
+   them to the repository security policy without disclosing details.
+3. Search open and closed issues for duplicates using protocol terms, error
+   codes, symptoms, and relevant function names.
+4. Draft a single-bug report using the format below.
+5. Run the complete
+   [`issue-check` workflow](../issue-check/SKILL.md) against the draft and the
+   current checkout.
+6. Require `check_result: true`. If it is false, stop and return the check
+   report; do not create or update a GitHub issue.
+7. Confirm the check's commit SHA still matches the source evidence. Re-run
+   the check if the draft, relevant source, or governing draft changed.
+8. Write the multiline body to a Markdown file and submit that file through
+   the available GitHub client.
+9. Fetch the published issue and verify its title, headings, links, code
+   excerpts, and real line breaks.
+
+## Issue Format
+
+Use the repository bug prefix and template fields:
+
+````markdown
+Title: [Bug]: <specific observable failure>
+
+### What happened?
+
+<Concise impact and trigger.>
+
+#### Expected behavior
+
+<Behavior required by the applicable mechanism.>
+
+#### Actual behavior
+
+<Observed XQUIC behavior under the same preconditions.>
+
+#### Governing specification
+
+- Document: <RFC number or exact draft revision>
+- Section: <number and title>
+- Link: <exact section URL>
+- Mechanism: <normative rule, applicability, and concise explanation>
+
+### Steps To Reproduce
+
+1. <environment and configuration>
+2. <minimal deterministic action>
+3. <observable result>
+
+### Verification evidence
+
+- XQUIC commit: `<full SHA>`
+- Protocol version and negotiated features: <values>
+- Evidence: <test, log, trace, or packet observation>
+
+### Root cause
+
+<Include only when issue-check verified a useful cause.>
+
+- Source: `<repo-relative path>:<line or narrow range>`
+- Permalink: <commit-pinned GitHub URL when available>
+
+```c
+<small exact source excerpt>
+```
+
+<Explain how this branch causes the expected/actual difference.>
+
+### Relevant log output
+
+```shell
+<minimal redacted log, or "Not available">
+```
+````
+
+Keep expected and actual behavior directly comparable. State endpoint role,
+state, protocol version, negotiated parameters, and configuration when they
+affect applicability.
+
+## Root-Cause Rules
+
+Include the root-cause section only for evidence classified `confirmed`, or
+when a `probable` cause is explicitly labeled and useful to maintainers. Omit
+it when unresolved. Never present speculation as fact.
+
+Refresh file line numbers from the verified commit. Keep source quotation
+short and include enough surrounding control flow to make the claim
+auditable. Do not quote generated or vendored code as the XQUIC root cause.
+
+## Submission Gate
+
+All conditions must hold before GitHub submission:
+
+- the report follows `CONTRIBUTING.md` and the bug template;
+- the report is reproducible, specific, unique, and scoped to one bug;
+- the exact RFC or draft revision and section are linked;
+- expected and actual behavior are separately stated;
+- `issue-check` returned `check_result: true`;
+- the issue draft matches the checked facts and source commit;
+- no security-policy or duplicate-issue blocker remains; and
+- logs and excerpts contain no credentials, personal data, or private
+  infrastructure details.
+
+The truth gate and publication gate are distinct. A real defect can still be
+blocked from public submission because it is security-sensitive or a
+duplicate.
+
+## Guardrails
+
+- Never submit when `issue-check` is false or stale.
+- Never weaken or omit contradictory evidence to obtain a true result.
+- Do not cite an RFC landing page without the applicable section.
+- Do not use inline escaped newline strings for a multiline GitHub body.
+- Do not create an issue unless the user explicitly requested submission.
+- Do not mix multiple independent defects into one issue.

--- a/harness/skills/validate/SKILL.md
+++ b/harness/skills/validate/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: validate
+description: Enforce XQUIC test coverage and local validation gates. Use after code, build, or test changes; before commit or pull request; or when asked to build, test, validate, or verify XQUIC. Requires paired happy-path and abnormal-path unit tests, paired client-to-server case tests, the complete local unit suite, and the relevant case tests for production behavior changes.
+---
+
+# XQUIC Validate
+
+Use the repository-wide `scripts/validate.sh` interface and the
+[validation specification](../../spec/validation.md).
+
+## Coverage Gate
+
+Before running validation for a production behavior change, verify that the
+diff contains:
+
+1. Unit coverage tied to the changed path.
+2. At least one happy-path unit test.
+3. At least one abnormal, rejection, boundary, or error-branch unit test.
+4. A client-to-server happy-path case in `scripts/case_test.sh`.
+5. A client-to-server abnormal-path case that proves the expected rejection,
+   error, close, or recovery behavior.
+
+Give the two case tests distinct `case_print_result` names. Assert the
+observable client and server results needed to prove the behavior. Reusing an
+unrelated test or asserting only that the process exited is not sufficient.
+
+## Workflow
+
+1. Inspect the changed-file scope and preserve unrelated user changes.
+2. Apply the Coverage Gate before treating validation as complete.
+3. During development, use a focused registered CUnit test for fast feedback:
+
+   ```bash
+   XQC_TEST_NAME=<test-name> ./scripts/validate.sh test
+   ```
+
+4. Before creating or updating a code pull request, clear the focused-test
+   selector and run the complete unit suite:
+
+   ```bash
+   unset XQC_TEST_NAME
+   ./scripts/validate.sh test
+   ```
+
+5. Run both relevant client-to-server case-test blocks, including their setup,
+   cleanup, and assertions. Because `scripts/case_test.sh` has no generic
+   name filter, use the following conservative command unless the exact
+   standalone commands for both blocks are executed and recorded:
+
+   ```bash
+   XQC_BUILD_DIR=build ./scripts/validate.sh full
+   ```
+
+6. Require the complete unit suite and both relevant case tests to pass. Check
+   the case output for both expected `[       OK ]` names and for any
+   `[     FAIL ]` or `>>>>>>>> pass:0` result; do not rely only on the script's
+   exit code.
+7. Verify that `include/xquic/xqc_configure.h` and other generated artifacts
+   did not enter the source diff.
+8. Report the changed scope, paired unit-test names, paired case-test names,
+   exact commands, and pass/fail results.
+9. Put those current-head results in the repository
+   [pull-request template](../../../.github/pull_request_template.md).
+   Missing, stale, focused-only, or failed local evidence does not pass the
+   PR gate.
+
+Documentation-only changes may use link, format, and command-syntax checks
+instead of inventing runtime tests. Validation-tooling changes require the
+closest deterministic self-checks. State why runtime coverage is not
+applicable.
+
+## Guardrails
+
+- Do not add issue-specific validation modes, targets, paths, or flags.
+- Do not install packages, clone dependencies, or modify external services.
+- Do not edit production code while acting only on a validation request.
+- Stop after a failed build; diagnose it before running tests.
+- Do not submit a code pull request with a missing happy-path or abnormal-path
+  unit test.
+- Do not submit a code pull request with a missing happy-path or abnormal-path
+  client-to-server case test.
+- Do not use a focused test as pull-request evidence in place of the complete
+  local unit suite.
+- Do not treat an environment blocker as a passing gate; keep the pull request
+  in draft or resolve the blocker before review.
+- Keep raw logs under the ignored validation artifact directory.
+- Treat the optional pre-push hook as an early check only. The pull request
+  must still contain the required named local evidence.

--- a/harness/skills/xquic-pr-formatting/SKILL.md
+++ b/harness/skills/xquic-pr-formatting/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: xquic-pr-formatting
+description: Format and update XQUIC pull request descriptions, comments, and review summaries. Use when preparing or editing an alibaba/xquic pull request or issue-linked PR body so contributor requirements, validation evidence, and Markdown formatting remain consistent.
+---
+
+# XQUIC PR Formatting
+
+## Required Workflow
+
+1. Read `CONTRIBUTING.md` and the
+   [pull-request specification](../../spec/pull-requests.md).
+2. Start from the repository
+   [pull-request template](../../../.github/pull_request_template.md).
+3. Treat that template as the canonical PR body structure. Preserve its
+   contribution checklist and harness validation sections rather than
+   replacing them with a shorter body.
+4. Check the branch prefix, commit format, CLA state, rebase and squash state,
+   code style, full-suite result, relevant tests, CI state, and issue-closing
+   syntax against `CONTRIBUTING.md`.
+5. For a production behavior change, require the PR body to name paired
+   happy-path and abnormal-path unit tests plus paired client-to-server case
+   tests.
+6. Require evidence that the complete local unit suite and both relevant case
+   tests passed; a focused unit test is insufficient.
+7. Include exact validation commands actually run and state limitations
+   plainly.
+8. For issue fixes, include `Fixes: #<issue-number>`.
+9. Write multiline descriptions or comments to a Markdown file first, then
+   submit the file through the available GitHub client.
+10. Fetch the published body after updating it and verify real line breaks,
+   headings, issue links, and test evidence.
+
+## Pull Request Body
+
+Use `.github/pull_request_template.md` as the single body shape. Complete each
+applicable field and write `Not applicable` with a reason where the template
+allows an exemption. A checkbox is evidence only when the corresponding
+branch, commit, command, result, or contributor state supports it.
+
+## Guardrails
+
+- Keep claims factual and source-backed.
+- Do not use escaped newline strings for multiline GitHub content.
+- Do not claim a full suite passed when only a focused test ran.
+- Do not move a production code pull request to review without paired coverage
+  and passing local gate evidence.
+- Do not accept a checked template box without the corresponding command,
+  test or case name, result, and current-head evidence.
+- Do not mark a `CONTRIBUTING.md` checkbox complete when the branch, commits,
+  CLA, rebase state, style, tests, CI, or issue syntax do not support it.
+- Do not include internal agent names, temporary artifacts, or process
+  chatter in contributor-facing content.
+- Preserve the distinction between issue-independent harness work and a
+  product change that happens to exercise it.

--- a/harness/spec/PROJECT_INSTRUCTIONS.md
+++ b/harness/spec/PROJECT_INSTRUCTIONS.md
@@ -1,0 +1,147 @@
+# XQUIC Project Instructions
+
+This is the portable project-instruction source and specification index for
+coding-agent adapters. Root [`AGENTS.md`](../../AGENTS.md) is the checked-in
+discovery entry point; keep its critical constraints aligned with this
+document.
+
+## Project
+
+XQUIC is Alibaba's C implementation of QUIC and HTTP/3. The source tree,
+dependency direction, and protocol invariants are described in the
+[architecture map](architecture.md). Supported features and dependency setup
+remain in the root [`README.md`](../../README.md).
+
+## Document Organization
+
+- Root convention files retain their established uppercase names, such as
+  `README.md`, `CONTRIBUTING.md`, and `AGENTS.md`.
+- Specification documents use lowercase kebab-case names;
+  `PROJECT_INSTRUCTIONS.md` retains its adapter-template name.
+- Capability-specific behavioral specifications belong under
+  `spec/<capability>/spec.md`.
+- Pipelines and skills live in the sibling `pipelines/` and `skills/`
+  directories rather than being mixed with project facts.
+- Task-specific notes, retrospectives, logs, and generated evidence remain
+  outside `harness/`.
+
+## Principles
+
+1. Repository knowledge is discoverable from a short root-level map.
+2. Build and validation workflows describe project capabilities, never a
+   particular issue or pull request.
+3. Behavioral regressions are represented by tests and acceptance criteria,
+   not by special build targets or configuration flags.
+4. Important constraints are made executable when practical.
+5. Guidance grows from recurring, verified development friction instead of
+   one-off task details or speculative rules.
+
+## Task Routing
+
+| Task | Required entry point |
+|------|----------------------|
+| Code change, feature, refactor, or bug fix | [Development pipeline](../pipelines/dev-pipeline.md) |
+| Build, test, or validation | [Validation specification](validation.md) and [`validate` skill](../skills/validate/SKILL.md) |
+| Verify an issue or protocol-defect claim | [`issue-check` skill](../skills/issue-check/SKILL.md) |
+| Prepare or submit a GitHub issue | [`issue-submit` skill](../skills/issue-submit/SKILL.md), gated by [`issue-check`](../skills/issue-check/SKILL.md) |
+| Pull request preparation or update | [Pull-request specification](pull-requests.md) and [`xquic-pr-formatting` skill](../skills/xquic-pr-formatting/SKILL.md) |
+| Query or analysis | Relevant source, tests, module docs, and [architecture map](architecture.md) |
+
+Before task routing in a fresh checkout, follow the
+[first-time harness setup](../../AGENTS.md#first-time-harness-setup). Run
+`scripts/setup_harness.sh` only when the active skill or pipeline discovery
+targets lack their adapters. Do not install the optional pre-push hook without
+an explicit opt-in.
+
+Read the selected entry point in full before changing code, build behavior, or
+pull-request artifacts.
+
+For every code task, the development pipeline is a mandatory preflight. Read
+it before planning, inspecting implementation paths, or editing source,
+tests, build scripts, validation tooling, or repository automation.
+
+## Git and Scope
+
+- Never push directly to a remote `main` or `master` branch.
+- Use a scoped feature branch and submit changes through a pull request.
+- Preserve unrelated user changes, staged state, and untracked files.
+- Do not edit vendored content under `third_party/`.
+- Keep generated headers, validation logs, and temporary evidence out of
+  source control.
+
+## Implementation
+
+1. Read the relevant source path before claiming behavior or applying a fix.
+2. Express acceptance criteria as observable behavior, independent of an
+   issue number, branch, or pull request.
+3. Make the smallest change that satisfies the criteria.
+4. Follow [`CONTRIBUTING.md`](../../CONTRIBUTING.md), including its
+   Nginx-derived C style and commit convention.
+5. Add or update happy-path and abnormal-path unit tests for each production
+   behavior change.
+6. Add or update matching happy-path and abnormal-path client-to-server cases
+   in `scripts/case_test.sh`.
+7. Re-read the modified path and trace affected callers and callees.
+8. Update durable project or module documentation when a contract, boundary,
+   command, or public API changes.
+
+For protocol behavior, identify the governing RFC or draft section and use the
+most specific required error or negotiation behavior.
+
+For a reported-issue fix, follow the development pipeline's issue branch
+before implementation. Run `issue-check`, write its complete report to
+`build/harness/<task-id>/issue-check.md`, and continue only when
+`check_result: true`. Use the verified specification, implementation
+comparison, source trace, and root-cause status as inputs to acceptance
+criteria and implementation. The report is temporary evidence and must not be
+committed.
+
+## Validation
+
+Before a production code pull request, run the complete local unit suite with
+the focused-test selector cleared:
+
+```bash
+unset XQC_TEST_NAME
+./scripts/validate.sh test
+```
+
+Then run the matching happy-path and abnormal-path client-to-server case
+tests. Use `XQC_BUILD_DIR=build ./scripts/validate.sh full` when they cannot
+be invoked independently. Record exact commands, paired test names, and
+results. A focused unit test is useful during development but cannot satisfy
+the pull-request gate.
+
+## Definition of Done
+
+A change is complete when:
+
+- its acceptance criteria are satisfied;
+- paired happy-path and abnormal-path unit tests cover every production
+  behavior change;
+- paired happy-path and abnormal-path client-to-server case tests cover the
+  corresponding end-to-end behavior;
+- the complete local unit suite and both relevant case tests pass;
+- generated and temporary artifacts are absent from the diff;
+- durable documentation and relative links remain accurate; and
+- the pull request contains the evidence required by
+  [pull-requests.md](pull-requests.md).
+
+## Reference Documents
+
+Public headers, tests, and governing IETF specifications are the
+behavior-level sources of truth. When sources disagree, executable behavior
+and the governing protocol specification identify the defect; update stale
+documentation in the same change when it affects future work.
+
+| Topic | Path |
+|-------|------|
+| Root discovery and definition of done | [AGENTS.md](../../AGENTS.md) |
+| Harness layout and naming | [Harness README](../README.md) |
+| Architecture and dependency boundaries | [architecture.md](architecture.md) |
+| Development workflow | [dev-pipeline.md](../pipelines/dev-pipeline.md) |
+| Harness registration | [setup_harness.sh](../../scripts/setup_harness.sh) |
+| Build and test validation | [validation.md](validation.md) |
+| Pull-request evidence | [pull-requests.md](pull-requests.md) |
+| Contribution and code style | [CONTRIBUTING.md](../../CONTRIBUTING.md) |
+| Supported features and setup | [README.md](../../README.md) |

--- a/harness/spec/architecture.md
+++ b/harness/spec/architecture.md
@@ -1,0 +1,118 @@
+# XQUIC Architecture Map
+
+This document is a navigation aid and boundary description. Detailed behavior
+belongs in module documentation, public headers, tests, and the protocol
+specifications that XQUIC implements.
+
+See the
+[project instructions](PROJECT_INSTRUCTIONS.md) for related project contracts
+and the [development pipeline](../pipelines/dev-pipeline.md) for the execution
+order.
+
+## Repository Map
+
+- `include/xquic/`: public XQUIC and HTTP/3 API.
+- `src/common/`: shared data structures, memory helpers, logging, and utilities.
+- `src/transport/`: QUIC engine, connections, streams, packets, recovery, and
+  transport extensions.
+- `src/tls/`: TLS integration, with backend-specific adapters under
+  `src/tls/boringssl/` and `src/tls/babassl/`.
+- `src/http3/`: HTTP/3 connection and stream behavior.
+- `src/http3/frame/`: HTTP/3 frame encoding and parsing.
+- `src/http3/qpack/`: QPACK state, encoding, and decoding.
+- `src/congestion_control/`: congestion-control implementations.
+- `tests/unittest/`: CUnit regression and unit tests.
+- `tests/`, `demo/`, and `mini/`: executable test and example applications.
+- `moq/` and `include/moq/`: optional Media over QUIC support, enabled with
+  `XQC_ENABLE_MOQ`.
+- `cmake/` and the root `CMakeLists.txt`: build graph and dependency discovery.
+- `scripts/`: repository-wide build, test, interoperability, and analysis tools.
+
+## Protocol Stack and Specifications
+
+### HTTP/3 Stack
+
+The logical protocol stack for HTTP/3 is:
+
+```text
+application protocol    HTTP/3, QPACK, HTTP priority
+transport-security      QUIC-TLS
+core transport          QUIC Transport, Recovery, QUIC DATAGRAM, Multipath
+network                 UDP/IP
+```
+
+### MoQ Stack
+
+The logical protocol stack for MoQ is:
+
+```text
+application protocol    LOC / MSF
+media transport         MoQT
+transport-security      QUIC-TLS
+core transport          QUIC Transport, Recovery, QUIC DATAGRAM, Multipath
+network                 UDP/IP
+```
+
+These views describe protocol relationships, not compile-time dependency
+direction. The published standards below map only to capabilities represented
+in the repository; they do not imply support for every RFC produced by the
+QUIC or HTTP working groups.
+
+### Published Standards
+
+| Protocol or capability | Governing specification | Primary implementation |
+|------------------------|-------------------------|------------------------|
+| QUIC invariants | [RFC 8999: Version-Independent Properties of QUIC](https://www.rfc-editor.org/rfc/rfc8999.html) | QUIC packet and version processing in `src/transport/` |
+| QUIC Transport | [RFC 9000: QUIC: A UDP-Based Multiplexed and Secure Transport](https://www.rfc-editor.org/rfc/rfc9000.html) | `src/transport/` |
+| Recovery | [RFC 9002: QUIC Loss Detection and Congestion Control](https://www.rfc-editor.org/rfc/rfc9002.html) | `src/transport/xqc_send_ctl.*` and `src/congestion_control/` |
+| QUIC-TLS | [RFC 9001: Using TLS to Secure QUIC](https://www.rfc-editor.org/rfc/rfc9001.html) | `src/tls/` |
+| HTTP/3 | [RFC 9114: HTTP/3](https://www.rfc-editor.org/rfc/rfc9114.html) | `src/http3/` and `src/http3/frame/` |
+| QPACK | [RFC 9204: QPACK: Field Compression for HTTP/3](https://www.rfc-editor.org/rfc/rfc9204.html) | `src/http3/qpack/` |
+| HTTP priority | [RFC 9218: Extensible Prioritization Scheme for HTTP](https://www.rfc-editor.org/rfc/rfc9218.html) | HTTP/3 request and stream priority handling in `src/http3/` |
+| QUIC DATAGRAM | [RFC 9221: An Unreliable Datagram Extension to QUIC](https://www.rfc-editor.org/rfc/rfc9221.html) | `src/transport/xqc_datagram.*` |
+
+### Work-in-Progress Standards
+
+Internet-Drafts can change or be replaced. These version-independent
+Datatracker links resolve to the current revision:
+
+| Protocol or capability | Governing draft | Primary implementation |
+|------------------------|-----------------|------------------------|
+| Multipath QUIC | [Managing multiple paths for a QUIC connection](https://datatracker.ietf.org/doc/draft-ietf-quic-multipath/) | `src/transport/xqc_multipath.*`, `src/transport/scheduler/`, and `src/transport/reinjection_control/` |
+| MoQT | [Media over QUIC Transport](https://datatracker.ietf.org/doc/draft-ietf-moq-transport/) | Optional `moq/` and `include/moq/`, enabled with `XQC_ENABLE_MOQ` |
+
+## Dependency Direction
+
+The intended high-level dependency direction is:
+
+```text
+applications and tests
+        |
+public API (include/xquic)
+        |
+HTTP/3 and optional application protocols
+        |
+QUIC transport
+        |
+TLS adapters, congestion control, and common utilities
+```
+
+Public headers must not depend on test or demo code. Core QUIC and HTTP/3 code
+must not depend on the optional MoQ module. Backend-specific TLS behavior stays
+behind the TLS integration layer.
+
+## Protocol Invariants
+
+- Wire behavior is governed by the applicable IETF RFC or draft.
+- Normative requirements take precedence over local implementation
+  convenience.
+- Protocol errors must use the most specific error code required by the
+  governing specification.
+- Unsupported extensions must follow the specification's negotiation and
+  error-handling rules.
+- A protocol fix requires a regression test at the lowest layer that can
+  observe the invariant reliably.
+
+These boundaries are initially documented rather than mechanically enforced.
+When the same class of violation recurs, promote the invariant into a test,
+lint, or structural check.

--- a/harness/spec/pull-requests.md
+++ b/harness/spec/pull-requests.md
@@ -1,0 +1,103 @@
+# Pull Request Evidence
+
+See the [project instructions](PROJECT_INSTRUCTIONS.md) for related
+architecture and validation contracts. When drafting or updating a pull
+request, follow the
+[`xquic-pr-formatting` skill](../skills/xquic-pr-formatting/SKILL.md).
+Start from the repository
+[pull-request template](../../.github/pull_request_template.md).
+
+Every pull request should let a reviewer answer four questions quickly:
+
+1. What behavior or project capability changes?
+2. Why is the change correct?
+3. How was it validated?
+4. What remains risky or unverified?
+
+## CONTRIBUTING.md Compliance
+
+The repository [contribution guide](../../CONTRIBUTING.md) remains the
+authoritative contribution contract. Harness evidence extends it and does not
+replace it. Before review, confirm:
+
+- the branch uses the documented `dev/`, `fix/`, `perf/`, or `doc/` prefix;
+- every commit header follows `[<type>]: <subject>` with an allowed `+`, `-`,
+  `=`, or `~` type;
+- the contributor has signed or will complete the CLA before merge;
+- the change follows the Nginx-derived XQUIC code style;
+- the full test suite and sufficient relevant tests pass;
+- required continuous-integration checks pass before merge;
+- the branch is rebased on its current base, and review-fix commits are
+  squashed before merge; and
+- an issue-closing pull request contains the exact `Fixes: #<number>` line.
+
+Documentation-only changes follow the same review process. They may use the
+documented runtime-test exemption, but must provide their applicable link,
+format, and command-syntax evidence.
+
+## Required Content
+
+- **Problem:** current behavior and user or protocol impact.
+- **Acceptance criteria:** observable conditions that define completion.
+- **Approach:** the smallest useful explanation of the implementation.
+- **Validation:** the complete local unit-suite command, exact relevant
+  case-test commands, and concise pass/fail results.
+- **Coverage map:** the happy-path and abnormal-path unit-test names plus the
+  matching happy-path and abnormal-path client-to-server case names.
+- **Evidence:** relevant tests and, when applicable, logs, traces, packet
+  captures, interoperability reports, or screenshots.
+- **Risk:** affected layers, compatibility concerns, and untested platforms or
+  configurations.
+- **Documentation impact:** durable guidance updated, or an explicit statement
+  that no project documentation changed.
+- **Issue link:** use the repository convention, for example `Fixes: #123`.
+
+## Protocol Changes
+
+For QUIC, HTTP/3, QPACK, or MoQ behavior, also include:
+
+- the exact RFC or draft section;
+- whether the requirement is normative;
+- the wire-visible behavior before and after the change; and
+- the lowest-level regression test that proves the required behavior.
+
+Use interoperability and packet-capture evidence when unit tests cannot prove
+the peer-visible outcome.
+
+## Required Test Evidence
+
+Every production behavior change must identify:
+
+- a happy-path unit test;
+- an abnormal, rejection, boundary, or error-branch unit test;
+- a happy-path client-to-server case in `scripts/case_test.sh`; and
+- an abnormal-path client-to-server case in `scripts/case_test.sh`.
+
+The pull request must show that `XQC_TEST_NAME` was unset when the complete
+local unit suite ran. It must also show that both relevant case tests passed.
+If the case pair cannot run independently, use
+`XQC_BUILD_DIR=build ./scripts/validate.sh full`. Evidence must come from the
+current pull request head and be refreshed after every code revision.
+
+The PR validation gate is not satisfied by a checkbox alone. The description
+must contain the exact complete-suite command and result, both unit-test
+names, both client-to-server case names and commands, and the tested commit
+SHA. Keep a production code pull request in draft when any field is missing,
+failed, stale, or replaced by focused-test output.
+
+Documentation-only changes may replace runtime evidence with link, format, and
+command-syntax checks. Validation-tooling changes use the closest
+deterministic self-checks and explain why runtime coverage does not apply.
+
+## Scope Rules
+
+- Do not mix harness construction with unrelated product fixes unless the
+  harness change is required to validate the fix.
+- Do not add issue-specific build directories, targets, options, or CI jobs.
+- Keep generated and diagnostic artifacts out of source control unless they
+  are stable, intentionally reviewable deliverables.
+- A failure discovered during validation is fixed before the pull request is
+  presented as ready.
+- Keep a production code pull request in draft while paired coverage is
+  missing, the complete local unit suite fails, or either relevant case test
+  fails.

--- a/harness/spec/validation.md
+++ b/harness/spec/validation.md
@@ -1,0 +1,194 @@
+# Validation
+
+XQUIC validation is layered so local development can get fast feedback while
+pull requests can provide broader evidence.
+
+See the [project instructions](PROJECT_INSTRUCTIONS.md) for related
+architecture and pull-request contracts. Agents executing these commands
+should also follow the [`validate` skill](../skills/validate/SKILL.md).
+
+## Entry Point
+
+Use the repository-wide script from the repository root:
+
+```bash
+./scripts/validate.sh build
+./scripts/validate.sh test
+XQC_BUILD_DIR=build ./scripts/validate.sh full
+```
+
+The commands are intentionally independent of issue and pull request numbers.
+Build and unit-test validation default to `build/validation/`. The full
+command uses the root `build/` directory expected by the existing
+`scripts/case_test.sh`.
+
+## Required Coverage Contract
+
+Every production behavior change must include tests tied to the changed path.
+The required minimum is:
+
+- one happy-path unit test;
+- one abnormal, rejection, boundary, or error-branch unit test;
+- one client-to-server happy-path case in `scripts/case_test.sh`; and
+- one client-to-server abnormal-path case in `scripts/case_test.sh`.
+
+The paired case tests must use distinct `case_print_result` names and exercise
+the real `tests/test_client` to `tests/test_server` path. Their assertions must
+prove the expected endpoint-visible result. For an error path, prove the
+specific rejection, connection error, close, or recovery behavior rather than
+accepting any failure.
+
+Documentation-only changes are exempt from runtime test creation and instead
+use link, format, and command-syntax checks. Validation-tooling changes require
+the closest deterministic self-checks. The pull request must state why paired
+runtime coverage does not apply.
+
+## Levels
+
+### Build
+
+`./scripts/validate.sh build`
+
+- configures a Debug build;
+- uses BoringSSL by default;
+- enables the core test and example targets;
+- enables the congestion-control and QPACK compatibility symbols required by
+  the existing test and example targets;
+- disables optional MoQ support; and
+- compiles the configured targets.
+
+This is the minimum check for documentation that changes build commands and
+for implementation work that cannot yet run tests. It is not sufficient
+pre-PR evidence for a production behavior change.
+
+### Test
+
+`./scripts/validate.sh test`
+
+Runs the Build level and then the CTest unit suite with failure output. This is
+the mandatory complete-unit-suite gate for every production code pull request.
+`XQC_TEST_NAME` must be unset for this gate.
+
+### Full
+
+`XQC_BUILD_DIR=build ./scripts/validate.sh full`
+
+Runs the Test level and the existing `scripts/case_test.sh` integration suite.
+This is the conservative pre-PR command: it runs the complete unit suite and
+all case tests, including the pair relevant to the current change.
+
+Protocol-specific interoperability, sanitizers, coverage, alternate TLS
+backends, optional modules, and platform matrices remain additional checks.
+They should be selected by change risk or CI policy rather than hidden inside
+an issue-specific build.
+
+## Mandatory Local Pre-PR Gate
+
+Before creating or moving a production code pull request to review:
+
+1. Confirm the paired unit tests and paired client-to-server case tests exist.
+2. Run the complete local unit suite with no focused-test selector:
+
+   ```bash
+   unset XQC_TEST_NAME
+   ./scripts/validate.sh test
+   ```
+
+3. Run both relevant case-test blocks, including their server/client setup,
+   state cleanup, and assertions.
+4. If the case blocks cannot be invoked independently, run the full suite:
+
+   ```bash
+   unset XQC_TEST_NAME
+   XQC_BUILD_DIR=build ./scripts/validate.sh full
+   ```
+
+5. Require all unit tests and both relevant cases to pass before submitting
+   the pull request. Confirm both expected `[       OK ]` case names are
+   present and no relevant `[     FAIL ]` or `>>>>>>>> pass:0` result exists;
+   the legacy case script's process exit code alone is not sufficient.
+
+The pull request evidence must name:
+
+- the happy-path unit test;
+- the abnormal-path unit test;
+- the happy-path `case_print_result` case;
+- the abnormal-path `case_print_result` case;
+- the command that ran the complete unit suite; and
+- the commands and results for the relevant case-test pair.
+
+A focused unit test is iteration evidence only. A missing test, failed test,
+or environment blocker does not satisfy the gate; keep the pull request in
+draft until the gate passes. Repeat the gate after every subsequent code
+change so the recorded evidence matches the pull request's current head.
+
+## Optional Pre-Push Gate
+
+Register the repository harness and install its optional pre-push hook with:
+
+```bash
+./scripts/setup_harness.sh --install-pre-push-hook
+```
+
+The hook clears `XQC_TEST_NAME`, runs
+`XQC_BUILD_DIR=build ./scripts/validate.sh full`, and rejects the push if the
+command fails or the legacy case output contains a failure result. Existing
+hooks are never overwritten. Use `git push --no-verify` only for an explicit
+exception; bypassing the hook does not relax the pull-request gate.
+
+Regardless of hook use, a production code pull request must record the
+current-head complete unit-suite result and the relevant happy-path and
+abnormal-path unit and client-to-server case evidence required above.
+
+## Configuration
+
+The default profile supports macOS and Linux with a prebuilt BoringSSL
+checkout. Override paths without editing the script:
+
+```bash
+XQC_BUILD_DIR=build/debug \
+XQC_SSL_PATH=/path/to/boringssl \
+./scripts/validate.sh test
+```
+
+During test development, run one registered CUnit test by name:
+
+```bash
+XQC_TEST_NAME=xqc_test_h3_stream ./scripts/validate.sh test
+```
+
+A focused test is fast feedback, not a replacement for the full Test level in
+pull request evidence.
+
+Supported environment variables:
+
+- `XQC_BUILD_DIR`: CMake build directory.
+- `XQC_BUILD_TYPE`: CMake build type, default `Debug`.
+- `XQC_BUILD_JOBS`: maximum parallel build jobs.
+- `XQC_SSL_TYPE`: TLS backend name, default `boringssl`.
+- `XQC_SSL_PATH`: TLS backend root.
+- `XQC_SSL_INCLUDE`: explicit TLS include directory.
+- `XQC_SSL_LIBS`: semicolon-separated TLS library paths.
+- `XQC_TEST_NAME`: optional registered CUnit test name for focused feedback.
+- `XQC_VALIDATION_ARTIFACT_DIR`: validation evidence directory.
+
+The script does not install packages, clone dependencies, or modify external
+services. Dependency provisioning remains an explicit environment setup step.
+
+## Artifacts
+
+Each invocation writes ignored artifacts below
+`build/validation/artifacts/` by default. The conservative full command writes
+them below `build/artifacts/` because it selects `XQC_BUILD_DIR=build`.
+
+- `environment.txt`: commit, branch, platform, compiler, CMake version, and
+  selected profile;
+- `<level>.log`: complete command output for the selected validation level.
+
+Pull requests should summarize the result and name the commands run. Raw logs
+are evidence for diagnosis and audit; they are not a substitute for a concise
+pull request summary.
+
+The current CMake configuration generates `include/xquic/xqc_configure.h` in
+the source tree. The validation script preserves and restores its pre-build
+contents so validation does not leave a source diff.

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Optional complete local validation gate installed by setup_harness.sh.
+
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+OUTPUT_FILE="$(mktemp "${TMPDIR:-/tmp}/xquic-pre-push.XXXXXX")"
+
+cleanup()
+{
+    rm -f "${OUTPUT_FILE}"
+}
+
+trap cleanup EXIT HUP INT TERM
+
+echo "xquic pre-push: running the complete local validation gate"
+echo "xquic pre-push: use git push --no-verify only for an explicit exception"
+
+unset XQC_TEST_NAME
+
+set +e
+XQC_BUILD_DIR="${XQC_BUILD_DIR:-build}" \
+    "${ROOT_DIR}/scripts/validate.sh" full 2>&1 | tee "${OUTPUT_FILE}"
+VALIDATION_STATUS="${PIPESTATUS[0]}"
+set -e
+
+if [[ "${VALIDATION_STATUS}" -ne 0 ]]; then
+    echo "xquic pre-push: validation command failed" >&2
+    exit "${VALIDATION_STATUS}"
+fi
+
+if grep -Eq '\[[[:space:]]+FAIL[[:space:]]+\]|>>>>>>>> pass:0' \
+    "${OUTPUT_FILE}"
+then
+    echo "xquic pre-push: case-test failure output detected" >&2
+    exit 1
+fi
+
+echo "xquic pre-push: complete local validation passed"

--- a/scripts/setup_harness.sh
+++ b/scripts/setup_harness.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+#
+# Register repository-owned harness skills, pipelines, and optional hooks.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HARNESS_DIR="${ROOT_DIR}/harness"
+AGENT_DIR="${ROOT_DIR}/.agents"
+SKILLS_DIR="${XQUIC_HARNESS_SKILLS_DIR:-${AGENT_DIR}/skills}"
+PIPELINES_DIR="${XQUIC_HARNESS_PIPELINES_DIR:-${AGENT_DIR}/pipelines}"
+HOOKS_DIR=""
+INSTALL_PRE_PUSH_HOOK=0
+
+usage()
+{
+    cat <<'EOF'
+usage: ./scripts/setup_harness.sh [options]
+
+Register the canonical XQUIC harness using symbolic links.
+
+Options:
+  --skills-dir DIR        Override the skill discovery directory.
+  --pipelines-dir DIR     Override the pipeline discovery directory.
+  --install-pre-push-hook Install the optional complete validation hook.
+  --hooks-dir DIR         Override the Git hooks directory for hook install.
+  -h, --help              Show this help.
+
+Environment:
+  XQUIC_HARNESS_SKILLS_DIR
+  XQUIC_HARNESS_PIPELINES_DIR
+EOF
+}
+
+absolute_path()
+{
+    local path="$1"
+
+    if [[ "${path}" == /* ]]; then
+        printf '%s\n' "${path}"
+
+    else
+        printf '%s\n' "${ROOT_DIR}/${path}"
+    fi
+}
+
+register_link()
+{
+    local source="$1"
+    local target="$2"
+    local current
+
+    mkdir -p "$(dirname "${target}")"
+
+    if [[ -L "${target}" ]]; then
+        current="$(readlink "${target}")"
+
+        if [[ "${current}" == "${source}" ]]; then
+            echo "registered: ${target}"
+            return
+        fi
+
+        echo "refusing to replace link: ${target} -> ${current}" >&2
+        return 1
+    fi
+
+    if [[ -e "${target}" ]]; then
+        echo "refusing to replace existing path: ${target}" >&2
+        return 1
+    fi
+
+    ln -s "${source}" "${target}"
+    echo "registered: ${target} -> ${source}"
+}
+
+default_hooks_dir()
+{
+    local path
+
+    path="$(git -C "${ROOT_DIR}" rev-parse --git-path hooks)"
+    absolute_path "${path}"
+}
+
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        --skills-dir)
+            [[ "$#" -ge 2 ]] || {
+                echo "--skills-dir requires a value" >&2
+                exit 2
+            }
+            SKILLS_DIR="$2"
+            shift 2
+            ;;
+        --pipelines-dir)
+            [[ "$#" -ge 2 ]] || {
+                echo "--pipelines-dir requires a value" >&2
+                exit 2
+            }
+            PIPELINES_DIR="$2"
+            shift 2
+            ;;
+        --install-pre-push-hook)
+            INSTALL_PRE_PUSH_HOOK=1
+            shift
+            ;;
+        --hooks-dir)
+            [[ "$#" -ge 2 ]] || {
+                echo "--hooks-dir requires a value" >&2
+                exit 2
+            }
+            HOOKS_DIR="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit
+            ;;
+        *)
+            echo "unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+SKILLS_DIR="$(absolute_path "${SKILLS_DIR}")"
+PIPELINES_DIR="$(absolute_path "${PIPELINES_DIR}")"
+
+for skill_file in "${HARNESS_DIR}"/skills/*/SKILL.md; do
+    skill_dir="${skill_file%/SKILL.md}"
+    skill_name="${skill_dir##*/}"
+    register_link "${skill_dir}" "${SKILLS_DIR}/${skill_name}"
+done
+
+for pipeline_file in "${HARNESS_DIR}"/pipelines/*.md; do
+    pipeline_name="${pipeline_file##*/}"
+    register_link "${pipeline_file}" \
+        "${PIPELINES_DIR}/${pipeline_name}"
+done
+
+if [[ "${INSTALL_PRE_PUSH_HOOK}" -eq 1 ]]; then
+    if [[ -z "${HOOKS_DIR}" ]]; then
+        HOOKS_DIR="$(default_hooks_dir)"
+
+    else
+        HOOKS_DIR="$(absolute_path "${HOOKS_DIR}")"
+    fi
+
+    register_link "${ROOT_DIR}/scripts/hooks/pre-push" \
+        "${HOOKS_DIR}/pre-push"
+fi
+
+echo "xquic harness setup complete"

--- a/scripts/tests/pre_push_hook_test.sh
+++ b/scripts/tests/pre_push_hook_test.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+#
+# Test pre-push behavior with a fake validator; setup tests hook registration.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="${ROOT_DIR}/scripts/hooks/pre-push"
+TEST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/xquic-pre-push-test.XXXXXX")"
+FAKE_REPO="${TEST_DIR}/repo"
+
+cleanup()
+{
+    rm -rf "${TEST_DIR}"
+}
+
+fail()
+{
+    echo "pre_push_hook_test: $*" >&2
+    exit 1
+}
+
+run_hook()
+{
+    (
+        cd "${FAKE_REPO}"
+        XQC_TEST_NAME=focused "${HOOK}"
+    )
+}
+
+expect_hook_failure()
+{
+    local message="$1"
+
+    if run_hook >/dev/null 2>&1; then
+        fail "${message}"
+    fi
+}
+
+trap cleanup EXIT HUP INT TERM
+
+mkdir -p "${FAKE_REPO}/scripts"
+git -C "${FAKE_REPO}" init -q
+
+cat > "${FAKE_REPO}/scripts/validate.sh" <<'EOF'
+#!/bin/bash
+
+if [[ "$1" != "full" ]]; then
+    exit 8
+fi
+
+if [[ "${XQC_BUILD_DIR:-}" != "build" ]]; then
+    exit 9
+fi
+
+if [[ -n "${XQC_TEST_NAME:-}" ]]; then
+    exit 10
+fi
+
+printf '%s\n' "${FAKE_VALIDATION_OUTPUT:-[       OK ] fake.case}"
+exit "${FAKE_VALIDATION_STATUS:-0}"
+EOF
+chmod +x "${FAKE_REPO}/scripts/validate.sh"
+
+run_hook >/dev/null || fail "successful validation was rejected"
+
+FAKE_VALIDATION_OUTPUT='[     FAIL ] fake.case' \
+    expect_hook_failure "case failure marker was accepted"
+FAKE_VALIDATION_OUTPUT='>>>>>>>> pass:0' \
+    expect_hook_failure "legacy failure marker was accepted"
+FAKE_VALIDATION_STATUS=7 \
+    expect_hook_failure "validation command failure was accepted"
+
+echo "pre_push_hook_test: all checks passed"

--- a/scripts/tests/setup_harness_test.sh
+++ b/scripts/tests/setup_harness_test.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+#
+# Test the setup registration contract; hook behavior has a separate test.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SETUP_SCRIPT="${ROOT_DIR}/scripts/setup_harness.sh"
+TEST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/xquic-harness-test.XXXXXX")"
+
+cleanup()
+{
+    rm -rf "${TEST_DIR}"
+}
+
+fail()
+{
+    echo "setup_harness_test: $*" >&2
+    exit 1
+}
+
+assert_link()
+{
+    local target="$1"
+    local expected="$2"
+
+    [[ -L "${target}" ]] || fail "missing link: ${target}"
+    [[ "$(readlink "${target}")" == "${expected}" ]] \
+        || fail "wrong link target: ${target}"
+}
+
+assert_entry_count()
+{
+    local directory="$1"
+    local expected="$2"
+    local actual
+
+    actual="$(
+        find "${directory}" -mindepth 1 -maxdepth 1 | wc -l | tr -d ' '
+    )"
+    [[ "${actual}" == "${expected}" ]] \
+        || fail "unexpected entry count in ${directory}: ${actual}"
+}
+
+run_setup()
+{
+    "${SETUP_SCRIPT}" \
+        --skills-dir "${SKILLS_DIR}" \
+        --pipelines-dir "${PIPELINES_DIR}" \
+        --hooks-dir "${HOOKS_DIR}" \
+        --install-pre-push-hook
+}
+
+trap cleanup EXIT HUP INT TERM
+
+SKILLS_DIR="${TEST_DIR}/positive/skills"
+PIPELINES_DIR="${TEST_DIR}/positive/pipelines"
+HOOKS_DIR="${TEST_DIR}/positive/hooks"
+EXPECTED_SKILLS=(
+    issue-check
+    issue-submit
+    validate
+    xquic-pr-formatting
+)
+
+run_setup
+
+for skill_name in "${EXPECTED_SKILLS[@]}"; do
+    assert_link "${SKILLS_DIR}/${skill_name}" \
+        "${ROOT_DIR}/harness/skills/${skill_name}"
+done
+
+assert_entry_count "${SKILLS_DIR}" "${#EXPECTED_SKILLS[@]}"
+assert_link "${PIPELINES_DIR}/dev-pipeline.md" \
+    "${ROOT_DIR}/harness/pipelines/dev-pipeline.md"
+assert_entry_count "${PIPELINES_DIR}" 1
+assert_link "${HOOKS_DIR}/pre-push" \
+    "${ROOT_DIR}/scripts/hooks/pre-push"
+assert_entry_count "${HOOKS_DIR}" 1
+
+run_setup
+
+COLLISION_DIR="${TEST_DIR}/collision"
+mkdir -p "${COLLISION_DIR}/skills"
+printf 'preserve me\n' > "${COLLISION_DIR}/skills/issue-check"
+
+if "${SETUP_SCRIPT}" \
+    --skills-dir "${COLLISION_DIR}/skills" \
+    --pipelines-dir "${COLLISION_DIR}/pipelines"
+then
+    fail "existing skill collision unexpectedly succeeded"
+fi
+
+grep -Fx 'preserve me' "${COLLISION_DIR}/skills/issue-check" >/dev/null \
+    || fail "existing path was modified"
+
+echo "setup_harness_test: all checks passed"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+#
+# Repository-wide XQUIC build and validation entry point.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VALIDATION_LEVEL="${1:-test}"
+
+case "${VALIDATION_LEVEL}" in
+    build|test|full)
+        ;;
+    *)
+        echo "usage: $0 [build|test|full]" >&2
+        exit 2
+        ;;
+esac
+
+BUILD_DIR="${XQC_BUILD_DIR:-${ROOT_DIR}/build/validation}"
+if [[ "${BUILD_DIR}" != /* ]]; then
+    BUILD_DIR="${ROOT_DIR}/${BUILD_DIR}"
+fi
+
+BUILD_TYPE="${XQC_BUILD_TYPE:-Debug}"
+BUILD_JOBS="${XQC_BUILD_JOBS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 2)}"
+SSL_TYPE="${XQC_SSL_TYPE:-boringssl}"
+SSL_PATH="${XQC_SSL_PATH:-${ROOT_DIR}/third_party/boringssl}"
+SSL_INCLUDE="${XQC_SSL_INCLUDE:-${SSL_PATH}/include}"
+SSL_LIBS="${XQC_SSL_LIBS:-${SSL_PATH}/build/libssl.a;${SSL_PATH}/build/libcrypto.a}"
+TEST_NAME="${XQC_TEST_NAME:-}"
+ARTIFACT_DIR="${XQC_VALIDATION_ARTIFACT_DIR:-${BUILD_DIR}/artifacts}"
+LOG_FILE="${ARTIFACT_DIR}/${VALIDATION_LEVEL}.log"
+CONFIG_HEADER="${ROOT_DIR}/include/xquic/xqc_configure.h"
+CONFIG_HEADER_BACKUP="${BUILD_DIR}/xqc_configure.h.before-validation"
+
+mkdir -p "${BUILD_DIR}" "${ARTIFACT_DIR}"
+: > "${LOG_FILE}"
+
+cp -p "${CONFIG_HEADER}" "${CONFIG_HEADER_BACKUP}"
+
+restore_config_header()
+{
+    cp -p "${CONFIG_HEADER_BACKUP}" "${CONFIG_HEADER}"
+}
+
+trap restore_config_header EXIT HUP INT TERM
+
+log_line()
+{
+    printf '%s\n' "$*" | tee -a "${LOG_FILE}"
+}
+
+run_command()
+{
+    {
+        printf '+'
+        printf ' %q' "$@"
+        printf '\n'
+    } | tee -a "${LOG_FILE}"
+
+    "$@" 2>&1 | tee -a "${LOG_FILE}"
+}
+
+write_environment()
+{
+    {
+        echo "commit=$(git -C "${ROOT_DIR}" rev-parse HEAD)"
+        echo "branch=$(git -C "${ROOT_DIR}" branch --show-current)"
+        echo "platform=$(uname -srm)"
+        echo "compiler=$(cc --version | sed -n '1p')"
+        echo "cmake=$(cmake --version | sed -n '1p')"
+        echo "level=${VALIDATION_LEVEL}"
+        echo "build_dir=${BUILD_DIR}"
+        echo "build_type=${BUILD_TYPE}"
+        echo "build_jobs=${BUILD_JOBS}"
+        echo "ssl_type=${SSL_TYPE}"
+        echo "ssl_path=${SSL_PATH}"
+        echo "test_name=${TEST_NAME}"
+    } > "${ARTIFACT_DIR}/environment.txt"
+}
+
+configure_project()
+{
+    local cmake_args=(
+        "-DCMAKE_BUILD_TYPE=${BUILD_TYPE}"
+        "-DXQC_ENABLE_TESTING=ON"
+        "-DXQC_ENABLE_MOQ=OFF"
+        "-DXQC_ENABLE_BBR2=ON"
+        "-DXQC_ENABLE_COPA=ON"
+        "-DXQC_ENABLE_RENO=ON"
+        "-DXQC_ENABLE_UNLIMITED=ON"
+        "-DXQC_ENABLE_MP_INTEROP=OFF"
+        "-DXQC_NO_PID_PACKET_PROCESS=OFF"
+        "-DXQC_PROTECT_POOL_MEM=OFF"
+        "-DXQC_COMPAT_DUPLICATE=ON"
+        "-DXQC_ENABLE_FEC=OFF"
+        "-DXQC_ENABLE_XOR=OFF"
+        "-DXQC_ENABLE_RSC=OFF"
+        "-DXQC_ENABLE_PKM=OFF"
+        "-DXQC_PRINT_SECRET=ON"
+        "-DXQC_ENABLE_EVENT_LOG=ON"
+        "-DSSL_TYPE=${SSL_TYPE}"
+        "-DSSL_PATH=${SSL_PATH}"
+        "-DSSL_INC_PATH=${SSL_INCLUDE}"
+        "-DSSL_LIB_PATH=${SSL_LIBS}"
+    )
+
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        cmake_args+=("-DPLATFORM=mac")
+
+    elif [[ "$(uname -s)" == "Linux" ]]; then
+        cmake_args+=("-DXQC_SUPPORT_SENDMMSG_BUILD=ON")
+    fi
+
+    run_command cmake -S "${ROOT_DIR}" -B "${BUILD_DIR}" \
+        "${cmake_args[@]}"
+}
+
+build_project()
+{
+    run_command env "CMAKE_BUILD_PARALLEL_LEVEL=${BUILD_JOBS}" \
+        cmake --build "${BUILD_DIR}"
+}
+
+ensure_test_certificate()
+{
+    if [[ ! -f "${BUILD_DIR}/server.key"
+        || ! -f "${BUILD_DIR}/server.crt" ]]
+    then
+        run_command openssl req -newkey rsa:2048 -x509 -nodes \
+            -keyout "${BUILD_DIR}/server.key" \
+            -out "${BUILD_DIR}/server.crt" \
+            -subj "/CN=test.xquic.com" \
+            -days 1
+    fi
+}
+
+run_unit_tests()
+{
+    local discovery_output
+
+    ensure_test_certificate
+    discovery_output="$(ctest --test-dir "${BUILD_DIR}/tests" --show-only)"
+    log_line "${discovery_output}"
+
+    if [[ ! "${discovery_output}" =~ Total\ Tests:\ [1-9][0-9]* ]]; then
+        log_line "no unit tests were discovered"
+        return 1
+    fi
+
+    if [[ -n "${TEST_NAME}" ]]; then
+        (
+            cd "${BUILD_DIR}"
+            run_command "${BUILD_DIR}/tests/run_tests" "${TEST_NAME}"
+        )
+
+    else
+        run_command ctest --test-dir "${BUILD_DIR}/tests" --output-on-failure
+    fi
+}
+
+run_integration_tests()
+{
+    (
+        cd "${BUILD_DIR}"
+        "${ROOT_DIR}/scripts/case_test.sh"
+    ) 2>&1 | tee -a "${LOG_FILE}"
+}
+
+write_environment
+configure_project
+build_project
+
+if [[ "${VALIDATION_LEVEL}" == "test"
+    || "${VALIDATION_LEVEL}" == "full" ]]
+then
+    run_unit_tests
+fi
+
+if [[ "${VALIDATION_LEVEL}" == "full" ]]; then
+    run_integration_tests
+fi
+
+log_line "validation level '${VALIDATION_LEVEL}' passed"

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -49,11 +49,17 @@
 static int xqc_init_suite(void) { return 0; }
 static int xqc_clean_suite(void) { return 0; }
 
-int 
-main()
+int
+main(int argc, char *argv[])
 {
     CU_pSuite pSuite = NULL;
+    CU_pTest pTest = NULL;
     unsigned int failed_tests_count;
+
+    if (argc > 2) {
+        fprintf(stderr, "usage: %s [test-name]\n", argv[0]);
+        return 2;
+    }
 
     if (CU_initialize_registry() != CUE_SUCCESS) {
         printf("CU_initialize error\n");
@@ -249,7 +255,20 @@ main()
     }
 
     CU_basic_set_mode(CU_BRM_VERBOSE);
-    CU_basic_run_tests();
+    if (argc == 2) {
+        pTest = CU_get_test_by_name(argv[1], pSuite);
+        if (pTest == NULL) {
+            fprintf(stderr, "unknown test: %s\n", argv[1]);
+            CU_cleanup_registry();
+            return 2;
+        }
+
+        CU_basic_run_test(pSuite, pTest);
+
+    } else {
+        CU_basic_run_tests();
+    }
+
     failed_tests_count = CU_get_number_of_tests_failed();
 
     CU_cleanup_registry();


### PR DESCRIPTION
### Summary

Add a tool-neutral development harness that keeps project specifications,
ordered pipelines, reusable skills, and validation evidence contracts in one
canonical repository directory.

The harness spec and skills are co-authored-by @cherylsy.

### Changes

- add a concise root `AGENTS.md` map and require every code task to read the
  development pipeline before planning or implementation;
- make the first task in a fresh checkout run `scripts/setup_harness.sh` once
  only when the active skill or pipeline discovery targets lack their
  adapters, while keeping pre-push hook installation opt-in;
- organize portable project instructions, architecture, validation, and
  pull-request contracts under `harness/spec/`;
- document separate HTTP/3 and MoQ logical protocol stacks, published RFC
  mappings, and active Multipath QUIC and MoQT draft links;
- add an issue-fix requirement-analysis branch that runs `issue-check`, gates
  implementation on `check_result: true`, and uses its ignored task report as
  an acceptance-criteria and implementation input;
- add portable `issue-check`, `issue-submit`, `validate`, and
  `xquic-pr-formatting` skills under `harness/skills/`;
- add `scripts/setup_harness.sh` for idempotent skill and pipeline
  registration plus an optional pre-push validation hook;
- add independent happy-path, idempotency, collision, and hook-failure tests
  for the harness setup tooling;
- add an issue-independent `scripts/validate.sh` entry point that preserves
  the tracked `include/xquic/xqc_configure.h`; and
- make `.github/pull_request_template.md` enforce the repository contribution
  requirements before collecting harness-specific current-head validation,
  unit-test, and client-to-server case evidence.

### Related Issue

Not applicable. This harness is intentionally independent of a feature or
issue.

### Specification

No product protocol behavior changes. Published RFCs and active drafts are
indexed in `harness/spec/architecture.md`.

### CONTRIBUTING.md Checklist

- [ ] The branch uses the documented `dev/`, `fix/`, `perf/`, or `doc/`
      prefix.
      Current branch `feat/project-spec` was created before this checklist and
      does not use a documented prefix.
- [x] Commit messages follow `[<type>]: <subject>` using `+`, `-`, `=`, or
      `~`.
- [x] The change follows the Nginx-derived XQUIC code style, or is
      documentation-only.
- [x] The full test suite and sufficient relevant tests have passed, with
      exact evidence recorded below, or a documentation/tooling exemption is
      explained.
- [ ] Required continuous-integration checks pass before merge.
- [x] The branch is rebased on its current base branch, and review-fix commits
      will be squashed before merge.
- [x] The Contributor License Agreement is signed or will be completed before
      merge.

### Validation

- Validation applicability: harness documentation and validation tooling.
- Runtime-coverage exemption: no XQUIC client/server production behavior
  changes. Product happy-path and abnormal-path case tests are not applicable;
  deterministic tooling tests cover successful and rejected registration plus
  successful and failed hook validation paths.
- [x] Tested commit SHA:
  `0490f0297c367373d605bbac07b6852f7f82a73d`
- [x] Complete local unit suite:
  - Command: `env -u XQC_TEST_NAME ./scripts/validate.sh test`
  - Result: CTest 1/1 passed, 0 failures.
- [x] Tooling happy paths:
  - `./scripts/tests/setup_harness_test.sh`
  - Explicit four-skill, one-pipeline, and one-hook contract passed.
  - Repeat registration passed.
  - `./scripts/tests/pre_push_hook_test.sh`
  - Successful full-validation hook path passed.
- [x] Tooling abnormal paths:
  - Existing-path collision was rejected without modification.
  - Unexpected setup entry counts are rejected.
  - Hook command failure, `[ FAIL ]`, and `>>>>>>>> pass:0` were rejected.
- [x] Static validation:
  - `bash -n scripts/setup_harness.sh scripts/hooks/pre-push
    scripts/tests/setup_harness_test.sh scripts/tests/pre_push_hook_test.sh
    scripts/validate.sh`
  - all four `harness/skills/*/SKILL.md` directories passed the standard skill
    validator.
  - 69 relative links across 12 Markdown files resolve.
  - `git diff --check HEAD` passed.
  - `include/xquic/xqc_configure.h` and the temporary retrospective have no
    diff.

### Risk and Scope

- Generated `.agents/` adapters are ignored; `harness/` remains canonical.
- Existing skill, pipeline, and Git hook paths are never overwritten.
- The optional hook is an early signal and does not replace PR evidence.
- `.codex/`, `reports/`, generated headers, and temporary validation artifacts
  are outside this change.
