### PR TITLE
[~] Fix HTTP/3 push stream error code

### DIFF
--- a/src/http3/xqc_h3_conn.c
+++ b/src/http3/xqc_h3_conn.c
@@ -587,11 +587,22 @@ xqc_h3_conn_on_uni_stream_created(xqc_h3_conn_t *h3c, uint64_t stype)
         break;
 
     case XQC_H3_STREAM_TYPE_PUSH:
-        /* xquic does not implement server push, reject with H3_ID_ERROR */
         xqc_log(h3c->log, XQC_LOG_ERROR,
                 "|h3 push stream not supported|type:%ui|", stype);
 
-        XQC_H3_CONN_ERR(h3c, H3_ID_ERROR, -XQC_H3_INVALID_STREAM);
+        /*
+         * RFC 9114 Section 6.2.2 requires H3_STREAM_CREATION_ERROR when a
+         * server receives a client-initiated push stream. A client uses
+         * H3_ID_ERROR because xquic does not advertise server push support.
+         */
+        if (h3c->conn->conn_type == XQC_CONN_TYPE_SERVER) {
+            XQC_H3_CONN_ERR(h3c, H3_STREAM_CREATION_ERROR,
+                            -XQC_H3_INVALID_STREAM);
+
+        } else {
+            XQC_H3_CONN_ERR(h3c, H3_ID_ERROR, -XQC_H3_INVALID_STREAM);
+        }
+
         return -XQC_H3_INVALID_STREAM;
 
     case XQC_H3_STREAM_TYPE_REQUEST:

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -133,6 +133,8 @@ main()
         || !CU_add_test(pSuite, "xqc_test_h3_stream", xqc_test_stream)
         || !CU_add_test(pSuite, "xqc_test_h3_critical_stream_close", xqc_test_h3_critical_stream_close)
         || !CU_add_test(pSuite, "xqc_test_h3_second_control_stream_rejected", xqc_test_h3_second_control_stream_rejected)
+        || !CU_add_test(pSuite, "xqc_test_h3_push_stream_error_codes",
+                        xqc_test_h3_push_stream_error_codes)
         /* RFC 9114 §4.2.2 field-section-size 32B overhead (issue 751) */
         || !CU_add_test(pSuite, "xqc_test_h3_uncompressed_fields_size", xqc_test_h3_uncompressed_fields_size)
         || !CU_add_test(pSuite, "xqc_test_h3_recv_header_field_section_size", xqc_test_h3_recv_header_field_section_size)

--- a/tests/unittest/xqc_h3_test.c
+++ b/tests/unittest/xqc_h3_test.c
@@ -623,7 +623,6 @@ xqc_test_h3_critical_stream_close()
  * xqc_h3_conn_on_uni_stream_created must:
  *   - Accept first CONTROL/QPACK_ENCODER/QPACK_DECODER (set creation flag)
  *   - Reject second instance with H3_STREAM_CREATION_ERROR (0x103)
- *   - Reject PUSH with H3_ID_ERROR (0x108) since xquic does not support push
  *
  * Each sub-case uses a fresh test_engine_connect() for state isolation.
  */
@@ -667,10 +666,12 @@ xqc_test_h3_second_stream_one(uint64_t stype, uint64_t expected_err_second)
 }
 
 static void
-xqc_test_h3_push_stream_rejected(void)
+xqc_test_h3_push_stream_rejected(xqc_conn_type_t conn_type,
+    uint64_t expected_err)
 {
     xqc_connection_t *conn = test_engine_connect();
     CU_ASSERT_FATAL(conn != NULL);
+    conn->conn_type = conn_type;
 
     if (conn->alpn) {
         xqc_free(conn->alpn);
@@ -684,16 +685,10 @@ xqc_test_h3_push_stream_rejected(void)
 
     CU_ASSERT(conn->conn_err == 0);
 
-    /*
-     * PUSH stream: xquic does not support server push, so even the first
-     * push stream must be rejected with H3_ID_ERROR (0x108).
-     * RFC 9114 Section 4.6 / Section 6.2.2
-     */
     xqc_int_t ret = xqc_h3_conn_on_uni_stream_created(h3c,
             XQC_H3_STREAM_TYPE_PUSH);
     CU_ASSERT(ret == -XQC_H3_INVALID_STREAM);
-    CU_ASSERT(conn->conn_err == H3_ID_ERROR);
-    CU_ASSERT(conn->conn_err == 0x108);  /* literal H3_ID_ERROR */
+    CU_ASSERT(conn->conn_err == expected_err);
     CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
 
     xqc_h3_conn_destroy(h3c);
@@ -720,9 +715,23 @@ xqc_test_h3_second_control_stream_rejected()
     xqc_test_h3_second_stream_one(XQC_H3_STREAM_TYPE_QPACK_DECODER,
             H3_STREAM_CREATION_ERROR);
 
-    /* Case 4: PUSH stream (unsupported) -> H3_ID_ERROR
-     * per RFC 9114 Section 4.6 / 6.2.2 */
-    xqc_test_h3_push_stream_rejected();
+}
+
+/*
+ * Issue #851 regression for RFC 9114 Section 6.2.2:
+ *   - A client rejects an unsupported push stream with H3_ID_ERROR.
+ *   - A server rejects a client-initiated push stream with
+ *     H3_STREAM_CREATION_ERROR.
+ */
+void
+xqc_test_h3_push_stream_error_codes()
+{
+    /* A client receives an unsupported PUSH stream. */
+    xqc_test_h3_push_stream_rejected(XQC_CONN_TYPE_CLIENT, H3_ID_ERROR);
+
+    /* A server receives a client-initiated PUSH stream. */
+    xqc_test_h3_push_stream_rejected(XQC_CONN_TYPE_SERVER,
+            H3_STREAM_CREATION_ERROR);
 }
 
 

--- a/tests/unittest/xqc_h3_test.h
+++ b/tests/unittest/xqc_h3_test.h
@@ -11,6 +11,7 @@ void xqc_test_ins();
 void xqc_test_rep();
 void xqc_test_h3_critical_stream_close();
 void xqc_test_h3_second_control_stream_rejected();
+void xqc_test_h3_push_stream_error_codes();
 void xqc_test_h3_uncompressed_fields_size();
 void xqc_test_h3_recv_header_field_section_size();
 


### PR DESCRIPTION
## Summary

Use the RFC 9114 error code for a client-initiated push stream received by an
HTTP/3 server, while preserving the existing client-side behavior.

## Problem

XQUIC returned `H3_ID_ERROR` for every push stream. RFC 9114 Section 6.2.2
requires a server that receives a client-initiated push stream to treat it as
an `H3_STREAM_CREATION_ERROR`.

## Acceptance criteria

- a server receiving a client-initiated push stream returns
  `H3_STREAM_CREATION_ERROR`;
- a client receiving a push stream continues to return `H3_ID_ERROR`, because
  XQUIC does not advertise server push support;
- a dedicated unit test covers both connection roles.

## Approach

Select the connection error from the local connection role and split the push
stream checks out of the existing duplicate-unidirectional-stream regression
into `xqc_test_h3_push_stream_error_codes`.

## Validation

- generic Debug/BoringSSL build: `cmake --build build/validation -j 10`
- regression without the implementation fix: 1 test failed, 11/12 assertions
  passed
- regression with the implementation fix: 1 test passed, 12/12 assertions
  passed
- `git diff --check`

An unfiltered CUnit run on the latest `main` did not complete within six
minutes and was stopped. The focused regression and all build targets are
green.

## Specification and risk

The behavior is required by
[RFC 9114 Section 6.2.2](https://www.rfc-editor.org/rfc/rfc9114.html#section-6.2.2).
The change is limited to the push-stream error selected by connection role; no
public API or negotiated behavior changes.

Fixes: #851
