### PR TITLE
[+]: Optimize harness working branch flow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,8 +23,9 @@ previous wire behavior. Otherwise write `Not applicable`. -->
 <!-- These checks come from CONTRIBUTING.md and apply in addition to the
 harness validation evidence below. -->
 
-- [ ] The branch uses the documented `dev/`, `fix/`, `perf/`, or `doc/`
-      prefix.
+- [ ] The branch prefix matches the task type: `dev/` for a new feature,
+      `fix/` for a bug fix, `perf/` for a performance optimization or other
+      enhancement, or `doc/` for documentation.
 - [ ] Commit messages follow `[<type>]: <subject>` using `+`, `-`, `=`, or
       `~`.
 - [ ] The change follows the Nginx-derived XQUIC code style, or is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,8 @@ build script, validation tool, or repository automation, read the
 [development pipeline](harness/pipelines/dev-pipeline.md) in full. Apply this
 gate at the start of every code task, including a new task in an existing
 session. Do not begin implementation until the requirement and acceptance
-criteria stages have been completed.
+criteria stages have been completed and the task is on a conforming working
+branch.
 
 ## Start Here
 

--- a/harness/pipelines/dev-pipeline.md
+++ b/harness/pipelines/dev-pipeline.md
@@ -9,8 +9,9 @@ it before planning, inspecting implementation paths, or editing source,
 tests, build scripts, validation tooling, or repository automation.
 
 ```text
-Requirement analysis -> Acceptance criteria -> Implementation
-                     -> Validation -> Review and PR evidence
+Requirement analysis -> Acceptance criteria -> Working branch
+                     -> Implementation -> Validation
+                     -> Review and PR evidence
 ```
 
 ## Stage 1: Requirement Analysis
@@ -58,7 +59,38 @@ blocking evidence must be explicit.
 Exit when the criteria can distinguish the intended behavior from the
 pre-change behavior.
 
-## Stage 3: Implementation
+## Stage 3: Working Branch
+
+1. Classify the accepted task and select the exact branch pattern from
+   [`CONTRIBUTING.md`](../../CONTRIBUTING.md#working-branch):
+
+   - New feature: `dev/${feature_name}`
+   - Bug fix: `fix/${function_or_module_name}`
+   - Performance optimization or other enhancement:
+     `perf/${optimization_item}`
+   - Documentation: `doc/${documentation_name}`
+
+2. Treat the `${...}` values as descriptive placeholders. The contribution
+   guide does not require underscores or define a stricter character set for
+   the expanded suffix.
+3. Create the working branch from its intended base, normally `main`, before
+   editing implementation files:
+
+   ```bash
+   git checkout -b <branch-name> main
+   ```
+
+4. Verify the result with `git branch --show-current`. The prefix must match
+   the accepted task type; the four prefixes are not interchangeable, and an
+   unlisted prefix such as `feat/` does not satisfy the contribution guide.
+5. If the current branch contains unrelated local changes, preserve them and
+   isolate the task in a separate worktree or clean checkout instead of
+   moving or mixing them into the new branch.
+
+Exit when the current branch was created from the intended base, contains
+only the scoped task, and its name matches the task-type mapping above.
+
+## Stage 4: Implementation
 
 1. For an issue fix, read
    `build/harness/<task-id>/issue-check.md` before editing production code.
@@ -76,7 +108,7 @@ pre-change behavior.
 
 Exit when the implementation, tests, and durable documentation agree.
 
-## Stage 4: Validation
+## Stage 5: Validation
 
 Follow the [`validate` skill](../skills/validate/SKILL.md). Before a production
 code pull request, run the complete local unit suite with `XQC_TEST_NAME`
@@ -93,7 +125,7 @@ and results. Keep the pull request in draft after a missing or failed gate.
 
 Exit only when the complete unit suite and both relevant case tests pass.
 
-## Stage 5: Review and PR Evidence
+## Stage 6: Review and PR Evidence
 
 1. Review staged and unstaged diffs separately and verify the final scope.
 2. Confirm generated headers, validation artifacts, and task-scoped

--- a/harness/skills/xquic-pr-formatting/SKILL.md
+++ b/harness/skills/xquic-pr-formatting/SKILL.md
@@ -14,9 +14,10 @@ description: Format and update XQUIC pull request descriptions, comments, and re
 3. Treat that template as the canonical PR body structure. Preserve its
    contribution checklist and harness validation sections rather than
    replacing them with a shorter body.
-4. Check the branch prefix, commit format, CLA state, rebase and squash state,
-   code style, full-suite result, relevant tests, CI state, and issue-closing
-   syntax against `CONTRIBUTING.md`.
+4. Check the branch name against the task-to-prefix mapping in
+   `CONTRIBUTING.md`, then check commit format, CLA state, rebase and squash
+   state, code style, full-suite result, relevant tests, CI state, and
+   issue-closing syntax.
 5. For a production behavior change, require the PR body to name paired
    happy-path and abnormal-path unit tests plus paired client-to-server case
    tests.
@@ -48,6 +49,8 @@ branch, commit, command, result, or contributor state supports it.
   test or case name, result, and current-head evidence.
 - Do not mark a `CONTRIBUTING.md` checkbox complete when the branch, commits,
   CLA, rebase state, style, tests, CI, or issue syntax do not support it.
+- Do not accept an allowed branch prefix when it belongs to a different task
+  type.
 - Do not include internal agent names, temporary artifacts, or process
   chatter in contributor-facing content.
 - Preserve the distinction between issue-independent harness work and a

--- a/harness/spec/PROJECT_INSTRUCTIONS.md
+++ b/harness/spec/PROJECT_INSTRUCTIONS.md
@@ -63,7 +63,11 @@ tests, build scripts, validation tooling, or repository automation.
 ## Git and Scope
 
 - Never push directly to a remote `main` or `master` branch.
-- Use a scoped feature branch and submit changes through a pull request.
+- After acceptance criteria and before implementation, follow the
+  [working-branch stage](../pipelines/dev-pipeline.md#stage-3-working-branch).
+- Match the accepted task to its exact `CONTRIBUTING.md` branch pattern;
+  `dev/`, `fix/`, `perf/`, and `doc/` are not interchangeable.
+- Use a scoped working branch and submit changes through a pull request.
 - Preserve unrelated user changes, staged state, and untracked files.
 - Do not edit vendored content under `third_party/`.
 - Keep generated headers, validation logs, and temporary evidence out of

--- a/harness/spec/pull-requests.md
+++ b/harness/spec/pull-requests.md
@@ -20,7 +20,9 @@ The repository [contribution guide](../../CONTRIBUTING.md) remains the
 authoritative contribution contract. Harness evidence extends it and does not
 replace it. Before review, confirm:
 
-- the branch uses the documented `dev/`, `fix/`, `perf/`, or `doc/` prefix;
+- the branch uses the documented pattern for its task type: `dev/` for a new
+  feature, `fix/` for a bug fix, `perf/` for a performance optimization or
+  other enhancement, or `doc/` for documentation;
 - every commit header follows `[<type>]: <subject>` with an allowed `+`, `-`,
   `=`, or `~` type;
 - the contributor has signed or will complete the CLA before merge;


### PR DESCRIPTION
### Summary

This is an issue-independent harness workflow optimization. The development
pipeline checked branch prefixes only during pull-request review and did not
define when a conforming working branch must be created. This could allow
implementation to start on `main`, on an unrelated dirty branch, or under a
prefix that does not match the task type.

Acceptance criteria:

- add a working-branch gate after acceptance criteria and before
  implementation;
- preserve the exact task-to-prefix mapping from `CONTRIBUTING.md`;
- avoid inventing suffix constraints that the contribution guide does not
  define; and
- apply the same task-type check at project-entry and pull-request gates.

### Changes

- add `Stage 3: Working Branch` to the development pipeline and renumber the
  downstream stages;
- require `dev/` for new features, `fix/` for bug fixes, `perf/` for
  performance work or other enhancements, and `doc/` for documentation;
- clarify that `${...}` suffixes are descriptive placeholders rather than a
  mandatory underscore convention;
- require unrelated dirty work to remain isolated instead of being moved or
  mixed into a new branch; and
- align `AGENTS.md`, project instructions, pull-request evidence, the PR
  template, and the PR-formatting skill with the new gate.

### Related Issue

Not applicable. This pull request optimizes the issue-independent harness
workflow and is separate from product issue fixes.

### Specification

Not applicable. No product protocol or wire behavior changes.

### CONTRIBUTING.md Checklist

- [x] The branch prefix matches the task type: `doc/` for this documentation
      change.
- [x] Commit messages follow `[<type>]: <subject>` using `+`, `-`, `=`, or
      `~`.
- [x] The change follows the Nginx-derived XQUIC code style, or is
      documentation-only.
- [x] The full test suite and sufficient relevant tests have passed, with
      exact evidence recorded below, or a documentation/tooling exemption is
      explained.
- [ ] Required continuous-integration checks pass before merge.
- [x] The branch is rebased on its current base branch, and review-fix commits
      will be squashed before merge.
- [x] The Contributor License Agreement is signed or will be completed before
      merge.

### Validation

- Validation applicability: documentation and one Markdown skill.
- Runtime-coverage exemption: no XQUIC production behavior, build script, or
  test implementation changes. The documentation-only exemption in
  `harness/spec/pull-requests.md` applies.
- [x] Tested commit SHA:
  `b79afcf64c3d122d5391b50336848c23552bd86c`
- [x] Documentation and format checks:
  - `git show --check --oneline --stat HEAD`
  - Result: passed with no whitespace errors.
  - Relative-link validation across `AGENTS.md`, `harness/`, and `.github/`
    resolved 71 relative links across 12 Markdown files.
- [x] Branch-rule checks:
  - `git branch --show-current | rg '^doc/'`
  - Result: `doc/harness-branch-naming`.
  - All four branch patterns were found identically in `CONTRIBUTING.md` and
    `harness/pipelines/dev-pipeline.md`.
  - The `working-branch` and `stage-3-working-branch` targets exist.
- [x] Skill validation:
  - `python3 /Users/miaoji/.codex/skills/.system/skill-creator/scripts/quick_validate.py harness/skills/xquic-pr-formatting`
  - Result: `Skill is valid!`
- [x] Complete local unit suite: not applicable under the documentation-only
      exemption.
- [x] Happy-path unit test: not applicable; no production behavior changes.
- [x] Abnormal-path unit test: not applicable; no production behavior changes.
- [x] Happy-path client-to-server case: not applicable; no wire behavior
      changes.
- [x] Abnormal-path client-to-server case: not applicable; no wire behavior
      changes.

### Risk and Scope

- Runtime and protocol behavior are unchanged.
- The change affects only branch routing and review guidance.
- Product source, generated headers, test files, and temporary evidence are
  absent from the diff.
