### PR TITLE
[~]: Optimize harness CUnit validation evidence

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -51,14 +51,16 @@ explain why runtime coverage does not apply. -->
 - [ ] Tested commit SHA: `<sha>`
 - [ ] Complete local unit suite:
   - Command: `unset XQC_TEST_NAME && ./scripts/validate.sh test`
-  - Result: `<pass/fail and concise summary>`
+  - Result: `<Ran>/<Total> CUnit tests, Failed=<count>`
 - [ ] Happy-path unit test: `<test name and result>`
 - [ ] Abnormal-path unit test: `<test name and result>`
 - [ ] Happy-path client-to-server case:
+  - Case ID and namespace: `<id; [A, B] module>`
   - Case name: `<case_print_result name>`
   - Command: `<exact command>`
   - Result: `<pass/fail>`
 - [ ] Abnormal-path client-to-server case:
+  - Case ID and namespace: `<different id; [A, B] module>`
   - Case name: `<case_print_result name>`
   - Command: `<exact command>`
   - Result: `<pass/fail>`

--- a/harness/pipelines/dev-pipeline.md
+++ b/harness/pipelines/dev-pipeline.md
@@ -50,9 +50,12 @@ blocking evidence must be explicit.
 4. Identify an abnormal, rejection, boundary, or error-branch unit test.
 5. Identify matching happy-path and abnormal-path client-to-server cases in
    `scripts/case_test.sh`.
-6. Identify broader compatibility or interoperability evidence when the
+6. If either client-to-server case is new, select a distinct, never-used ID
+   for each case from the owning layer or module namespace in the
+   [validation specification](../spec/validation.md#client-to-server-case-id-namespace).
+7. Identify broader compatibility or interoperability evidence when the
    paired tests cannot establish the peer-visible result.
-7. Choose the expected validation level from the
+8. Choose the expected validation level from the
    [validation specification](../spec/validation.md).
 
 Exit when the criteria can distinguish the intended behavior from the
@@ -67,7 +70,8 @@ pre-change behavior.
    issue claim, specification revision, or source path changed.
 2. Add or update paired happy-path and abnormal-path unit tests.
 3. Add or update paired happy-path and abnormal-path client-to-server case
-   tests.
+   tests. Give every new case its allocated ID and update the validation
+   namespace registry in the same change.
 4. Make the smallest production change that satisfies the criteria.
 5. Follow `CONTRIBUTING.md` and adjacent project conventions.
 6. Re-read the modified path and trace affected callers and callees.
@@ -108,7 +112,8 @@ Exit only when the complete unit suite and both relevant case tests pass.
    [pull-request template](../../.github/pull_request_template.md) with
    current-head local validation results. For production behavior changes,
    name the complete unit-suite command and the paired happy-path and
-   abnormal-path unit and client-to-server case tests.
+   abnormal-path unit and client-to-server case tests, including each case ID
+   and namespace.
 
 Complete the loop only when the acceptance criteria, paired unit and case-test
 coverage, validation evidence, scope review, and pull request evidence are
@@ -124,12 +129,14 @@ consistent.
    abnormal-path unit tests.
 4. Every production behavior change requires paired happy-path and
    abnormal-path client-to-server case tests.
-5. A failed build is resolved before tests continue.
-6. The complete local unit suite and relevant case-test pair must pass before
+5. Every new client-to-server case has a distinct, never-used ID from the
+   documented namespace, and active or retired IDs are never reused.
+6. A failed build is resolved before tests continue.
+7. The complete local unit suite and relevant case-test pair must pass before
    review.
-7. Generated and temporary artifacts are never committed as source.
-8. A production code pull request remains draft while any required local
+8. Generated and temporary artifacts are never committed as source.
+9. A production code pull request remains draft while any required local
    result or paired test name is missing from its description.
-9. An issue fix must not enter implementation with a false or inconclusive
+10. An issue fix must not enter implementation with a false or inconclusive
    issue-check gate, and its task-scoped issue-check report must never be
    committed.

--- a/harness/skills/validate/SKILL.md
+++ b/harness/skills/validate/SKILL.md
@@ -19,22 +19,32 @@ diff contains:
 4. A client-to-server happy-path case in `scripts/case_test.sh`.
 5. A client-to-server abnormal-path case that proves the expected rejection,
    error, close, or recovery behavior.
+6. A distinct, never-before-used ID for each new client-to-server case,
+   allocated from the owning layer or module namespace in the
+   [validation specification](../../spec/validation.md#client-to-server-case-id-namespace).
+7. The new IDs recorded in the namespace registry in the same change.
 
 Give the two case tests distinct `case_print_result` names. Assert the
 observable client and server results needed to prove the behavior. Reusing an
-unrelated test or asserting only that the process exited is not sufficient.
+unrelated test or case ID, or asserting only that the process exited, is not
+sufficient. Active and retired case IDs are both permanently unavailable for
+new behavior.
 
 ## Workflow
 
 1. Inspect the changed-file scope and preserve unrelated user changes.
 2. Apply the Coverage Gate before treating validation as complete.
-3. During development, use a focused registered CUnit test for fast feedback:
+3. For every new case ID, check `scripts/case_test.sh`,
+   `tests/test_client.c`, `tests/test_server.c`, and their Git history. Require
+   no previous allocation and confirm the registry range matches the owning
+   protocol layer or module.
+4. During development, use a focused registered CUnit test for fast feedback:
 
    ```bash
    XQC_TEST_NAME=<test-name> ./scripts/validate.sh test
    ```
 
-4. Before creating or updating a code pull request, clear the focused-test
+5. Before creating or updating a code pull request, clear the focused-test
    selector and run the complete unit suite:
 
    ```bash
@@ -42,7 +52,10 @@ unrelated test or asserting only that the process exited is not sufficient.
    ./scripts/validate.sh test
    ```
 
-5. Run both relevant client-to-server case-test blocks, including their setup,
+6. Require the emitted CUnit summary to show `Ran == Total` and `Failed == 0`.
+   Record the result as `<Ran>/<Total> CUnit tests`; `CTest 1/1` alone is not
+   complete-unit-suite evidence.
+7. Run both relevant client-to-server case-test blocks, including their setup,
    cleanup, and assertions. Because `scripts/case_test.sh` has no generic
    name filter, use the following conservative command unless the exact
    standalone commands for both blocks are executed and recorded:
@@ -51,15 +64,16 @@ unrelated test or asserting only that the process exited is not sufficient.
    XQC_BUILD_DIR=build ./scripts/validate.sh full
    ```
 
-6. Require the complete unit suite and both relevant case tests to pass. Check
+8. Require the complete unit suite and both relevant case tests to pass. Check
    the case output for both expected `[       OK ]` names and for any
    `[     FAIL ]` or `>>>>>>>> pass:0` result; do not rely only on the script's
    exit code.
-7. Verify that `include/xquic/xqc_configure.h` and other generated artifacts
+9. Verify that `include/xquic/xqc_configure.h` and other generated artifacts
    did not enter the source diff.
-8. Report the changed scope, paired unit-test names, paired case-test names,
-   exact commands, and pass/fail results.
-9. Put those current-head results in the repository
+10. Report the changed scope, CUnit `<Ran>/<Total>` and failed counts, paired
+    unit-test names, paired case IDs and namespaces, case-test names, exact
+    commands, and results.
+11. Put those current-head results in the repository
    [pull-request template](../../../.github/pull_request_template.md).
    Missing, stale, focused-only, or failed local evidence does not pass the
    PR gate.
@@ -79,8 +93,12 @@ applicable.
   unit test.
 - Do not submit a code pull request with a missing happy-path or abnormal-path
   client-to-server case test.
+- Do not reuse an active or retired case ID, use an ID outside its documented
+  namespace, or give the paired happy and abnormal cases the same ID.
 - Do not use a focused test as pull-request evidence in place of the complete
   local unit suite.
+- Do not use the aggregate `CTest 1/1` result in place of the CUnit
+  `<Ran>/<Total>` and failed counts.
 - Do not treat an environment blocker as a passing gate; keep the pull request
   in draft or resolve the blocker before review.
 - Keep raw logs under the ignored validation artifact directory.

--- a/harness/spec/pull-requests.md
+++ b/harness/spec/pull-requests.md
@@ -70,20 +70,30 @@ Every production behavior change must identify:
 
 - a happy-path unit test;
 - an abnormal, rejection, boundary, or error-branch unit test;
-- a happy-path client-to-server case in `scripts/case_test.sh`; and
-- an abnormal-path client-to-server case in `scripts/case_test.sh`.
+- a happy-path client-to-server case in `scripts/case_test.sh`, including its
+  case ID and documented namespace; and
+- an abnormal-path client-to-server case in `scripts/case_test.sh`, including
+  its different case ID and documented namespace.
+
+New case IDs must be absent from both the current tree and repository history
+before allocation. Active and retired IDs cannot be reused, and every new ID
+must be recorded in the
+[case ID namespace registry](validation.md#client-to-server-case-id-namespace)
+in the same change.
 
 The pull request must show that `XQC_TEST_NAME` was unset when the complete
-local unit suite ran. It must also show that both relevant case tests passed.
-If the case pair cannot run independently, use
+local unit suite ran. Report its result as `<Ran>/<Total> CUnit tests` and
+include the failed count; the aggregate `CTest 1/1` result is not sufficient
+evidence. It must also show that both relevant case tests passed. If the case
+pair cannot run independently, use
 `XQC_BUILD_DIR=build ./scripts/validate.sh full`. Evidence must come from the
 current pull request head and be refreshed after every code revision.
 
 The PR validation gate is not satisfied by a checkbox alone. The description
 must contain the exact complete-suite command and result, both unit-test
-names, both client-to-server case names and commands, and the tested commit
-SHA. Keep a production code pull request in draft when any field is missing,
-failed, stale, or replaced by focused-test output.
+names, both client-to-server case IDs, namespaces, names and commands, and the
+tested commit SHA. Keep a production code pull request in draft when any
+field is missing, failed, stale, or replaced by focused-test output.
 
 Documentation-only changes may replace runtime evidence with link, format, and
 command-syntax checks. Validation-tooling changes use the closest

--- a/harness/spec/validation.md
+++ b/harness/spec/validation.md
@@ -43,6 +43,74 @@ use link, format, and command-syntax checks. Validation-tooling changes require
 the closest deterministic self-checks. The pull request must state why paired
 runtime coverage does not apply.
 
+## Client-to-Server Case ID Namespace
+
+The `-x <id>` value shared by `tests/test_client` and `tests/test_server`
+selects case-specific behavior. A case ID is a permanent behavior identifier,
+not a reusable execution slot.
+
+The following registry records IDs present in the current tree or previously
+used in repository history. Range boundaries are inclusive. ID `0` means the
+normal/default path and must not be allocated. Because the older ranges contain
+cross-layer assignments, the complete `[1, 704]` range is frozen for new IDs,
+including gaps.
+
+| Range | Existing namespace | Permanently reserved IDs |
+|-------|--------------------|--------------------------|
+| `[1, 99]` | Legacy cross-layer QUIC, TLS, HTTP/3, and callback cases | `1-53`, `55-57`, `80`, `99` |
+| `[100, 149]` | Multipath QUIC and path management | `100-110` |
+| `[150, 199]` | HTTP/3 and QPACK settings | `150-153` |
+| `[200, 299]` | QUIC DATAGRAM and HTTP/3 datagram | `200-211` |
+| `[300, 399]` | HTTP/3 extension bytestream | `300-315` |
+| `[400, 499]` | Transport connection settings and extensions | `400`, `450-455` |
+| `[500, 599]` | Frozen legacy cross-layer overflow | `500-502` |
+| `[600, 699]` | Frozen test-runtime and transport mechanics | `600-601` |
+| `[700, 704]` | Frozen protocol-regression overflow | `700-704` |
+
+New cases must allocate from the following layer or module namespace. Update
+the allocated-ID column in the same pull request. An ID remains listed after
+its case is retired so later changes cannot reuse it.
+
+| Range | New-case namespace | Allocated IDs |
+|-------|--------------------|---------------|
+| `[705, 799]` | QUIC Transport core | None |
+| `[800, 899]` | Recovery and congestion control | None |
+| `[900, 999]` | QUIC-TLS | None |
+| `[1000, 1099]` | HTTP/3 framing, streams, and settings | None |
+| `[1100, 1149]` | QPACK | None |
+| `[1150, 1199]` | HTTP priority | None |
+| `[1200, 1299]` | QUIC DATAGRAM | None |
+| `[1300, 1399]` | Multipath QUIC | None |
+| `[1400, 1499]` | MoQT | None |
+| `[1500, 1599]` | LOC and MSF application protocols | None |
+| `[1600, 1699]` | FEC and experimental transport extensions | None |
+| `[1700, 1799]` | Common runtime, public API, and test harness | None |
+
+Apply these allocation rules before running a new case:
+
+1. Give every new `case_print_result` behavior its own unused ID. The paired
+   happy-path and abnormal-path cases must have different IDs.
+2. Do not assign an active or retired ID to a new behavior. An existing case
+   may keep its ID only when its original behavior contract remains intact.
+3. Select the range for the lowest protocol layer or module that owns the
+   behavior. Cross-layer cases use the lowest layer that injects the condition.
+4. Search the current tree and Git history before allocating an ID:
+
+   ```bash
+   case_id=1000  # replace with the candidate ID
+   rg -n -- \
+       "-x[[:space:]]+${case_id}([^0-9]|$)|g_test_case.*${case_id}([^0-9]|$)" \
+       scripts/case_test.sh tests/test_client.c tests/test_server.c
+   git log --all -G \
+       "(-x[[:space:]]+|g_test_case.*)${case_id}([^0-9]|$)" -- \
+       scripts/case_test.sh tests/test_client.c tests/test_server.c
+   ```
+
+   Both commands must return no prior allocation.
+5. Add the allocated ID to this registry, implement the matching client and
+   server selector behavior, and record the ID, namespace, case name, command,
+   and result in the pull request.
+
 ## Levels
 
 ### Build
@@ -65,9 +133,11 @@ pre-PR evidence for a production behavior change.
 
 `./scripts/validate.sh test`
 
-Runs the Build level and then the CTest unit suite with failure output. This is
-the mandatory complete-unit-suite gate for every production code pull request.
-`XQC_TEST_NAME` must be unset for this gate.
+Runs the Build level and then the verbose CTest unit suite. The validator
+extracts and records CUnit's `Total`, `Ran`, `Passed`, and `Failed` counts.
+With `XQC_TEST_NAME` unset, the complete-suite gate requires `Ran == Total`
+and `Failed == 0`. A top-level `CTest 1/1` result alone does not satisfy this
+gate.
 
 ### Full
 
@@ -87,6 +157,8 @@ an issue-specific build.
 Before creating or moving a production code pull request to review:
 
 1. Confirm the paired unit tests and paired client-to-server case tests exist.
+   For new cases, confirm their distinct IDs are registered in the correct
+   namespace and have never appeared in the current tree or Git history.
 2. Run the complete local unit suite with no focused-test selector:
 
    ```bash
@@ -94,16 +166,19 @@ Before creating or moving a production code pull request to review:
    ./scripts/validate.sh test
    ```
 
-3. Run both relevant case-test blocks, including their server/client setup,
+3. Confirm the emitted CUnit summary reports `Ran == Total` and `Failed == 0`.
+   Record the real result as `<Ran>/<Total> CUnit tests`; do not use
+   `CTest 1/1` as the unit-suite evidence or substitute a fixed example count.
+4. Run both relevant case-test blocks, including their server/client setup,
    state cleanup, and assertions.
-4. If the case blocks cannot be invoked independently, run the full suite:
+5. If the case blocks cannot be invoked independently, run the full suite:
 
    ```bash
    unset XQC_TEST_NAME
    XQC_BUILD_DIR=build ./scripts/validate.sh full
    ```
 
-5. Require all unit tests and both relevant cases to pass before submitting
+6. Require all unit tests and both relevant cases to pass before submitting
    the pull request. Confirm both expected `[       OK ]` case names are
    present and no relevant `[     FAIL ]` or `>>>>>>>> pass:0` result exists;
    the legacy case script's process exit code alone is not sufficient.
@@ -114,7 +189,9 @@ The pull request evidence must name:
 - the abnormal-path unit test;
 - the happy-path `case_print_result` case;
 - the abnormal-path `case_print_result` case;
+- each case ID and its documented namespace;
 - the command that ran the complete unit suite; and
+- the `<Ran>/<Total> CUnit tests` result with the failed count; and
 - the commands and results for the relevant case-test pair.
 
 A focused unit test is iteration evidence only. A missing test, failed test,
@@ -183,7 +260,8 @@ them below `build/artifacts/` because it selects `XQC_BUILD_DIR=build`.
 
 - `environment.txt`: commit, branch, platform, compiler, CMake version, and
   selected profile;
-- `<level>.log`: complete command output for the selected validation level.
+- `<level>.log`: complete command output for the selected validation level,
+  including the normalized CUnit summary and gate result.
 
 Pull requests should summarize the result and name the commands run. Raw logs
 are evidence for diagnosis and audit; they are not a substitute for a concise

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -61,6 +61,71 @@ run_command()
     "$@" 2>&1 | tee -a "${LOG_FILE}"
 }
 
+extract_cunit_summary()
+{
+    awk '
+    {
+        line = $0
+        sub(/^[0-9]+:[[:space:]]*/, "", line)
+        sub(/^[[:space:]]+/, "", line)
+        field_count = split(line, fields, /[[:space:]]+/)
+        is_summary = field_count == 6
+        is_summary = is_summary && fields[1] == "tests"
+        is_summary = is_summary && fields[2] ~ /^[0-9]+$/
+        is_summary = is_summary && fields[3] ~ /^[0-9]+$/
+        is_summary = is_summary && fields[4] ~ /^[0-9]+$/
+        is_summary = is_summary && fields[5] ~ /^[0-9]+$/
+
+        if (is_summary) {
+            summary = fields[2] " " fields[3] " " fields[4] " " fields[5]
+        }
+    }
+    END {
+        if (summary != "") {
+            print summary
+        }
+    }
+    ' "${LOG_FILE}"
+}
+
+verify_cunit_summary()
+{
+    local summary
+    local total
+    local ran
+    local passed
+    local failed
+
+    summary="$(extract_cunit_summary)"
+    if [[ -z "${summary}" ]]; then
+        log_line "CUnit gate failed: test summary was not found"
+        return 1
+    fi
+
+    read -r total ran passed failed <<< "${summary}"
+    log_line "CUnit summary: Total=${total} Ran=${ran}" \
+        "Passed=${passed} Failed=${failed}"
+
+    if (( failed != 0 )); then
+        log_line "CUnit gate failed: Failed=${failed}, expected 0"
+        return 1
+    fi
+
+    if [[ -z "${TEST_NAME}" ]]; then
+        if (( ran != total )); then
+            log_line \
+                "CUnit gate failed: Ran=${ran} does not match Total=${total}"
+            return 1
+        fi
+
+        log_line "CUnit result: ${ran}/${total} CUnit tests, Failed=${failed}"
+
+    else
+        log_line "CUnit focused result: ${ran}/${total} CUnit tests selected," \
+            "Failed=${failed}"
+    fi
+}
+
 write_environment()
 {
     {
@@ -138,6 +203,7 @@ ensure_test_certificate()
 run_unit_tests()
 {
     local discovery_output
+    local test_status=0
 
     ensure_test_certificate
     discovery_output="$(ctest --test-dir "${BUILD_DIR}/tests" --show-only)"
@@ -149,13 +215,30 @@ run_unit_tests()
     fi
 
     if [[ -n "${TEST_NAME}" ]]; then
-        (
+        if (
             cd "${BUILD_DIR}"
             run_command "${BUILD_DIR}/tests/run_tests" "${TEST_NAME}"
         )
+        then
+            :
+
+        else
+            test_status=$?
+        fi
 
     else
-        run_command ctest --test-dir "${BUILD_DIR}/tests" --output-on-failure
+        if run_command ctest --test-dir "${BUILD_DIR}/tests" --verbose; then
+            :
+
+        else
+            test_status=$?
+        fi
+    fi
+
+    verify_cunit_summary
+
+    if (( test_status != 0 )); then
+        return "${test_status}"
     fi
 }
 


### PR DESCRIPTION
### Summary

This is an issue-independent harness validation workflow optimization.
`CTest 1/1` only proves that the aggregate `run_tests` process exited
successfully and does not expose whether every registered CUnit test ran.

This change makes the complete-unit-suite gate report CUnit's real
`Total / Ran / Passed / Failed` counts, require `Ran == Total` and
`Failed == 0`, and provide `<Ran>/<Total> CUnit tests` as pull-request
evidence. It also makes client-to-server case IDs permanent and assigns clean
module namespaces for future cases.

### Changes

- run the aggregate unit suite through verbose CTest so successful CUnit
  output is available in the validation log;
- extract and record a normalized CUnit summary and concise PR evidence line;
- fail closed when the CUnit summary is missing, `Ran != Total`, or
  `Failed != 0`;
- preserve focused `XQC_TEST_NAME` feedback without applying the complete
  suite's `Ran == Total` requirement;
- consume only the real development build's `run_tests` output, without
  synthetic CUnit fixtures;
- freeze the historical `[1, 704]` case-ID space, including retired IDs, so
  prior behavior identifiers cannot be reused;
- define new per-layer and per-module allocation ranges `[705, 1799]`;
- require distinct happy-path and abnormal-path IDs, current-tree and Git
  history checks, and registry updates; and
- update the development pipeline, validation specification, validate skill,
  PR evidence contract, and PR template.

### Related Issue

Not applicable. This optimizes the issue-independent harness validation
workflow and is separate from product issue fixes.

### Specification

Not applicable. No product protocol or wire behavior changes.

### CONTRIBUTING.md Checklist

- [x] The branch uses the documented `perf/` prefix for this harness
      enhancement.
- [x] Commit messages follow `[<type>]: <subject>` using `+`, `-`, `=`, or
      `~`.
- [x] The change follows the Nginx-derived XQUIC code style.
- [x] The full test suite and sufficient relevant tests have passed, with
      exact evidence recorded below.
- [ ] Required continuous-integration checks pass before merge.
- [x] The branch is rebased on its current base branch, and review-fix commits
      will be squashed before merge.
- [x] The Contributor License Agreement is signed or will be completed before
      merge.

### Validation

- Validation applicability: harness validation tooling.
- Runtime-coverage exemption: paired product unit and client-to-server cases
  are not applicable because no XQUIC production or wire behavior changes.
  The production validation path was exercised against the real development
  build and complete CUnit suite; no fake CUnit output was used.
- [x] Tested commit SHA:
  `10a32d129b9a2f84f0c40b362274430e2730387d`
- [x] Complete local unit suite:
  - Command:
    `env -u XQC_TEST_NAME XQC_SSL_PATH=/Users/miaoji/Documents/Codex/xquic/third_party/boringssl ./scripts/validate.sh test`
  - Result: `132/132 CUnit tests, Passed=132, Failed=0`.
- [x] Harness regression checks:
  - `./scripts/tests/pre_push_hook_test.sh`
  - `./scripts/tests/setup_harness_test.sh`
  - Result: both passed.
- [x] Case-ID namespace audit:
  - Command: current-tree and `git log --all -G` scans across
    `scripts/case_test.sh`, `tests/test_client.c`, and `tests/test_server.c`.
  - Result: active and retired IDs were registered; candidate HTTP/3 ID
    `1000` has no prior allocation.
- [x] Static checks:
  - `bash -n scripts/validate.sh scripts/tests/pre_push_hook_test.sh
    scripts/tests/setup_harness_test.sh scripts/hooks/pre-push
    scripts/setup_harness.sh`
  - the validate skill passed the standard skill validator;
  - all 72 relative Markdown links resolve; and
  - `git show --check --oneline --stat HEAD` passed.
- [x] Happy-path unit test: the real complete CUnit suite passed through the
      production validation path.
- [x] Abnormal-path unit test: not applicable to product behavior; the
      fail-closed gate is implemented in the validation script without
      synthetic result injection.
- [x] Happy-path client-to-server case: not applicable; no wire behavior
      changes.
- [x] Abnormal-path client-to-server case: not applicable; no wire behavior
      changes.

### Risk and Scope

- Parsing depends on the stable CUnit Basic run-summary format and accepts
  both direct and CTest-prefixed output.
- Missing or malformed summaries fail closed.
- Verbose CTest increases successful-test log volume so the underlying CUnit
  evidence remains auditable.
- No fake test binary, stubbed CTest process, or synthetic CUnit summary is
  included in this change.
- The case-ID registry is intentionally append-only; the current-tree and Git
  history checks protect against manual registry drift.
- No current client or server selector behavior or case-test block changes;
  the new namespace begins immediately after the current maximum at ID `705`.
- Per-case CTest registration and JUnit output are intentionally out of
  scope.
- Product source, generated headers, case tests, and temporary artifacts are
  absent from the diff.
