### PR TITLE
[~]: Fix HTTP/3 push stream error code

### DIFF
--- a/harness/spec/validation.md
+++ b/harness/spec/validation.md
@@ -76,7 +76,7 @@ its case is retired so later changes cannot reuse it.
 | `[705, 799]` | QUIC Transport core | None |
 | `[800, 899]` | Recovery and congestion control | None |
 | `[900, 999]` | QUIC-TLS | None |
-| `[1000, 1099]` | HTTP/3 framing, streams, and settings | None |
+| `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1001` |
 | `[1100, 1149]` | QPACK | None |
 | `[1150, 1199]` | HTTP priority | None |
 | `[1200, 1299]` | QUIC DATAGRAM | None |

--- a/scripts/case_test.sh
+++ b/scripts/case_test.sh
@@ -5267,4 +5267,47 @@ else
 fi
 rm -f test_session xqc_token tp_localhost
 
+## RFC 9114 Section 6.2 unidirectional stream handling
+
+killall test_server 2> /dev/null
+clear_log
+rm -f test_session xqc_token tp_localhost
+${SERVER_BIN} -l d -e > /dev/null &
+sleep 1
+echo -e "HTTP/3 reserved unidirectional stream remains usable ...\c"
+${CLIENT_BIN} -s 1024 -l d -t 1 -E -x 1000 > stdlog
+sent=`grep "\\[h3-uni-stream-test\\]|type:0x21|ret:0|" stdlog`
+received=`grep "|remote|stream_id:.*|stream_type:33|" slog`
+result=`grep ">>>>>>>> pass:1" stdlog`
+conn_err_zero=`grep -E "conn_err:0[^0-9]" stdlog`
+if [ -n "$sent" ] && [ -n "$received" ] && [ -n "$result" ] \
+    && [ -n "$conn_err_zero" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "h3_reserved_uni_stream_survives" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "h3_reserved_uni_stream_survives" "fail"
+fi
+
+killall test_server 2> /dev/null
+clear_log
+rm -f test_session xqc_token tp_localhost
+${SERVER_BIN} -l d -e > /dev/null &
+sleep 1
+echo -e "HTTP/3 client push stream gets stream creation error ...\c"
+${CLIENT_BIN} -s 1024 -l d -t 1 -E -x 1001 > stdlog
+sent=`grep "\\[h3-uni-stream-test\\]|type:0x1|ret:0|" stdlog`
+received=`grep "|remote|stream_id:.*|stream_type:1|" slog`
+server_err=`grep "err:0x103" slog`
+client_err=`grep -E "(conn errno:259|conn_err:259)" stdlog`
+if [ -n "$sent" ] && [ -n "$received" ] && [ -n "$server_err" ] \
+    && [ -n "$client_err" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "h3_client_push_stream_creation_error" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "h3_client_push_stream_creation_error" "fail"
+fi
+killall test_server 2> /dev/null
+
 cd -

--- a/src/http3/xqc_h3_conn.c
+++ b/src/http3/xqc_h3_conn.c
@@ -587,11 +587,24 @@ xqc_h3_conn_on_uni_stream_created(xqc_h3_conn_t *h3c, uint64_t stype)
         break;
 
     case XQC_H3_STREAM_TYPE_PUSH:
-        /* xquic does not implement server push, reject with H3_ID_ERROR */
         xqc_log(h3c->log, XQC_LOG_ERROR,
-                "|h3 push stream not supported|type:%ui|", stype);
+                "|peer push stream rejected|type:%ui|", stype);
 
-        XQC_H3_CONN_ERR(h3c, H3_ID_ERROR, -XQC_H3_INVALID_STREAM);
+        /*
+         * RFC 9114 Section 6.2.2 requires H3_STREAM_CREATION_ERROR when a
+         * server receives a client-initiated push stream. Section 4.6
+         * requires a client that has not sent MAX_PUSH_ID to close the
+         * connection with H3_ID_ERROR upon receiving any push stream.
+         * XQUIC has no production path that sends MAX_PUSH_ID.
+         */
+        if (h3c->conn->conn_type == XQC_CONN_TYPE_SERVER) {
+            XQC_H3_CONN_ERR(h3c, H3_STREAM_CREATION_ERROR,
+                            -XQC_H3_INVALID_STREAM);
+
+        } else {
+            XQC_H3_CONN_ERR(h3c, H3_ID_ERROR, -XQC_H3_INVALID_STREAM);
+        }
+
         return -XQC_H3_INVALID_STREAM;
 
     case XQC_H3_STREAM_TYPE_REQUEST:
@@ -925,4 +938,3 @@ const xqc_conn_callbacks_t h3_conn_callbacks = {
     .conn_handshake_finished    = xqc_h3_conn_handshake_finished,
     .conn_ping_acked            = xqc_h3_conn_ping_acked_notify,
 };
-

--- a/src/http3/xqc_h3_conn.h
+++ b/src/http3/xqc_h3_conn.h
@@ -114,6 +114,8 @@ extern const xqc_conn_callbacks_t  h3_conn_callbacks;
  */
 xqc_h3_conn_t *xqc_h3_conn_create(xqc_connection_t *conn, void *user_data);
 void xqc_h3_conn_destroy(xqc_h3_conn_t *h3c);
+xqc_h3_stream_t *xqc_h3_conn_create_uni_stream(xqc_h3_conn_t *h3c,
+    xqc_h3_stream_type_t h3s_type);
 
 /**
  * validate the uni stream creation event

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -16,6 +16,7 @@
 #include <xquic/xquic.h>
 #include <xquic/xquic_typedef.h>
 #include <xquic/xqc_http3.h>
+#include "src/http3/xqc_h3_conn.h"
 #include "platform.h"
 #ifndef XQC_SYS_WINDOWS
 #include <unistd.h>
@@ -64,7 +65,13 @@ printf_null(const char *format, ...)
 
 #define XQC_MAX_LOG_LEN 2048
 
+#define XQC_TEST_CASE_H3_RESERVED_UNI_STREAM 1000
+#define XQC_TEST_CASE_H3_CLIENT_PUSH_STREAM 1001
+
 typedef struct user_conn_s user_conn_t;
+
+static void xqc_client_send_test_uni_stream(xqc_h3_conn_t *h3_conn,
+    xqc_h3_stream_type_t stream_type);
 
 
 #define XQC_TEST_DGRAM_BATCH_SZ 32
@@ -1919,6 +1926,15 @@ xqc_client_h3_conn_handshake_finished(xqc_h3_conn_t *h3_conn, void *user_data)
         printf("[initial-salt-test] handshake ok, conn_err:%d\n", stats.conn_err);
     }
 
+    if (g_test_case == XQC_TEST_CASE_H3_RESERVED_UNI_STREAM) {
+        xqc_client_send_test_uni_stream(h3_conn,
+                (xqc_h3_stream_type_t)0x21);
+
+    } else if (g_test_case == XQC_TEST_CASE_H3_CLIENT_PUSH_STREAM) {
+        xqc_client_send_test_uni_stream(h3_conn,
+                XQC_H3_STREAM_TYPE_PUSH);
+    }
+
     if (g_test_case == 200 || g_test_case == 201) {
         printf("[h3-dgram-200]|1RTT|updated_mss:%zu|\n", user_conn->dgram_mss);
     }
@@ -1927,6 +1943,25 @@ xqc_client_h3_conn_handshake_finished(xqc_h3_conn_t *h3_conn, void *user_data)
         xqc_client_h3_ext_datagram_send(user_conn);
     }
 }
+
+
+static void
+xqc_client_send_test_uni_stream(xqc_h3_conn_t *h3_conn,
+    xqc_h3_stream_type_t stream_type)
+{
+    xqc_h3_stream_t *h3_stream =
+        xqc_h3_conn_create_uni_stream(h3_conn, stream_type);
+    if (h3_stream == NULL) {
+        printf("[h3-uni-stream-test]|type:0x%" PRIx64 "|create_failed|\n",
+               (uint64_t)stream_type);
+        return;
+    }
+
+    xqc_int_t ret = xqc_h3_stream_send_finish(h3_stream);
+    printf("[h3-uni-stream-test]|type:0x%" PRIx64 "|ret:%d|\n",
+           (uint64_t)stream_type, ret);
+}
+
 
 void
 xqc_client_h3_conn_ping_acked_notify(xqc_h3_conn_t *conn, const xqc_cid_t *cid, void *ping_user_data, void *user_data)

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -139,6 +139,10 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite, "xqc_test_h3_stream", xqc_test_stream)
         || !CU_add_test(pSuite, "xqc_test_h3_critical_stream_close", xqc_test_h3_critical_stream_close)
         || !CU_add_test(pSuite, "xqc_test_h3_second_control_stream_rejected", xqc_test_h3_second_control_stream_rejected)
+        || !CU_add_test(pSuite, "xqc_test_h3_reserved_uni_stream_accepted",
+                        xqc_test_h3_reserved_uni_stream_accepted)
+        || !CU_add_test(pSuite, "xqc_test_h3_push_stream_error_codes",
+                        xqc_test_h3_push_stream_error_codes)
         /* RFC 9114 §4.2.2 field-section-size 32B overhead (issue 751) */
         || !CU_add_test(pSuite, "xqc_test_h3_uncompressed_fields_size", xqc_test_h3_uncompressed_fields_size)
         || !CU_add_test(pSuite, "xqc_test_h3_recv_header_field_section_size", xqc_test_h3_recv_header_field_section_size)

--- a/tests/unittest/xqc_h3_test.c
+++ b/tests/unittest/xqc_h3_test.c
@@ -623,7 +623,6 @@ xqc_test_h3_critical_stream_close()
  * xqc_h3_conn_on_uni_stream_created must:
  *   - Accept first CONTROL/QPACK_ENCODER/QPACK_DECODER (set creation flag)
  *   - Reject second instance with H3_STREAM_CREATION_ERROR (0x103)
- *   - Reject PUSH with H3_ID_ERROR (0x108) since xquic does not support push
  *
  * Each sub-case uses a fresh test_engine_connect() for state isolation.
  */
@@ -667,10 +666,12 @@ xqc_test_h3_second_stream_one(uint64_t stype, uint64_t expected_err_second)
 }
 
 static void
-xqc_test_h3_push_stream_rejected(void)
+xqc_test_h3_push_stream_rejected(xqc_conn_type_t conn_type,
+    uint64_t expected_err)
 {
     xqc_connection_t *conn = test_engine_connect();
     CU_ASSERT_FATAL(conn != NULL);
+    conn->conn_type = conn_type;
 
     if (conn->alpn) {
         xqc_free(conn->alpn);
@@ -684,16 +685,10 @@ xqc_test_h3_push_stream_rejected(void)
 
     CU_ASSERT(conn->conn_err == 0);
 
-    /*
-     * PUSH stream: xquic does not support server push, so even the first
-     * push stream must be rejected with H3_ID_ERROR (0x108).
-     * RFC 9114 Section 4.6 / Section 6.2.2
-     */
     xqc_int_t ret = xqc_h3_conn_on_uni_stream_created(h3c,
             XQC_H3_STREAM_TYPE_PUSH);
     CU_ASSERT(ret == -XQC_H3_INVALID_STREAM);
-    CU_ASSERT(conn->conn_err == H3_ID_ERROR);
-    CU_ASSERT(conn->conn_err == 0x108);  /* literal H3_ID_ERROR */
+    CU_ASSERT(conn->conn_err == expected_err);
     CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
 
     xqc_h3_conn_destroy(h3c);
@@ -719,10 +714,55 @@ xqc_test_h3_second_control_stream_rejected()
      * per RFC 9204 Section 4.2 */
     xqc_test_h3_second_stream_one(XQC_H3_STREAM_TYPE_QPACK_DECODER,
             H3_STREAM_CREATION_ERROR);
+}
 
-    /* Case 4: PUSH stream (unsupported) -> H3_ID_ERROR
-     * per RFC 9114 Section 4.6 / 6.2.2 */
-    xqc_test_h3_push_stream_rejected();
+
+void
+xqc_test_h3_reserved_uni_stream_accepted()
+{
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_FATAL(conn != NULL);
+    conn->conn_type = XQC_CONN_TYPE_SERVER;
+
+    if (conn->alpn) {
+        xqc_free(conn->alpn);
+    }
+    conn->alpn_len = strlen(XQC_ALPN_H3);
+    conn->alpn = xqc_calloc(1, conn->alpn_len + 1);
+    xqc_memcpy(conn->alpn, XQC_ALPN_H3, conn->alpn_len);
+
+    xqc_h3_conn_t *h3c = xqc_h3_conn_create(conn, NULL);
+    CU_ASSERT_FATAL(h3c != NULL);
+
+    /* RFC 9114 Section 6.2.3 requires reserved stream types to be ignored. */
+    xqc_int_t ret = xqc_h3_conn_on_uni_stream_created(h3c, 0x21);
+    CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(conn->conn_err == 0);
+    CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) == 0);
+
+    xqc_h3_conn_destroy(h3c);
+    if (conn->alpn) {
+        xqc_free(conn->alpn);
+    }
+}
+
+
+void
+xqc_test_h3_push_stream_error_codes()
+{
+    /*
+     * RFC 9114 Section 4.6: a client that has not sent MAX_PUSH_ID must
+     * close the connection with H3_ID_ERROR upon receiving any push stream.
+     * XQUIC has no production path that sends MAX_PUSH_ID.
+     */
+    xqc_test_h3_push_stream_rejected(XQC_CONN_TYPE_CLIENT, H3_ID_ERROR);
+
+    /*
+     * RFC 9114 Section 6.2.2: a server rejects a client-initiated push
+     * stream with H3_STREAM_CREATION_ERROR.
+     */
+    xqc_test_h3_push_stream_rejected(XQC_CONN_TYPE_SERVER,
+            H3_STREAM_CREATION_ERROR);
 }
 
 

--- a/tests/unittest/xqc_h3_test.h
+++ b/tests/unittest/xqc_h3_test.h
@@ -11,6 +11,8 @@ void xqc_test_ins();
 void xqc_test_rep();
 void xqc_test_h3_critical_stream_close();
 void xqc_test_h3_second_control_stream_rejected();
+void xqc_test_h3_reserved_uni_stream_accepted();
+void xqc_test_h3_push_stream_error_codes();
 void xqc_test_h3_uncompressed_fields_size();
 void xqc_test_h3_recv_header_field_section_size();
 


### PR DESCRIPTION
### Summary

XQUIC unconditionally used `H3_ID_ERROR` when a peer-created HTTP/3 push
stream was identified. This produced the wrong wire-visible connection error
when the receiver was a server.

This change makes the rejection role-aware:

- a server receiving a client-initiated push stream closes the connection
  with `H3_STREAM_CREATION_ERROR`;
- a client that has not sent `MAX_PUSH_ID` closes the connection with
  `H3_ID_ERROR` upon receiving any push stream; and
- reserved unidirectional stream types continue to be accepted and ignored.

The observable acceptance criteria are that the server emits error `0x103`
for a client-created push stream while an unrelated reserved stream remains
usable by a normal HTTP/3 request.

### Changes

- Select the push-stream connection error from the receiving endpoint role.
- Add happy-path coverage for a reserved peer unidirectional stream.
- Add role-specific unit coverage for client and server push-stream
  rejection.
- Extend the test client with generic reserved and push unidirectional stream
  cases.
- Add paired client-to-server case tests for normal reserved-stream handling
  and the required push-stream rejection.
- Allocate and register distinct HTTP/3 case IDs `1000` and `1001`.

### Related Issue

Fixes: #851

### Specification

[RFC 9114 Section 6.2.2](https://www.rfc-editor.org/rfc/rfc9114.html#section-6.2.2)
normatively requires a server that receives a client-initiated push stream to
treat it as an `H3_STREAM_CREATION_ERROR` connection error.

[RFC 9114 Section 4.6](https://www.rfc-editor.org/rfc/rfc9114.html#section-4.6)
normatively requires a client that has not sent `MAX_PUSH_ID` to treat receipt
of any push stream as an `H3_ID_ERROR` connection error. XQUIC has no
production path that sends `MAX_PUSH_ID`; HTTP/3 defines no separate
"server push unsupported" error code.

Before this change, XQUIC emitted `H3_ID_ERROR` (`0x108`) for both endpoint
roles. After this change, the server path emits
`H3_STREAM_CREATION_ERROR` (`0x103`), while the client path retains
the RFC-required `H3_ID_ERROR`.

### CONTRIBUTING.md Checklist

- [x] The branch prefix matches the task type: `dev/` for a new feature,
      `fix/` for a bug fix, `perf/` for a performance optimization or other
      enhancement, or `doc/` for documentation.
- [x] Commit messages follow `[<type>]: <subject>` using `+`, `-`, `=`, or
      `~`.
- [x] The change follows the Nginx-derived XQUIC code style, or is
      documentation-only.
- [ ] The full test suite and sufficient relevant tests have passed, with
      exact evidence recorded below, or a documentation/tooling exemption is
      explained.
- [ ] Required continuous-integration checks pass before merge.
- [x] The branch is rebased on its current base branch, and review-fix commits
      will be squashed before merge.
- [x] The Contributor License Agreement is signed or will be completed before
      merge.

### Validation

- Validation applicability: `production behavior`
- Runtime-coverage exemption, if applicable: `Not applicable`
- [x] Tested commit SHA:
      `52a4e767823a85e26b4e8ac00fa5e20d32eb7e61`
- [x] Complete local unit suite:
  - Command: `env -u XQC_TEST_NAME ./scripts/validate.sh test`
  - Result: `134/134 CUnit tests, Failed=0`
- [x] Happy-path unit test:
      `xqc_test_h3_reserved_uni_stream_accepted` passed in the complete suite
- [x] Abnormal-path unit test:
      `xqc_test_h3_push_stream_error_codes` passed in the complete suite
- [x] Happy-path client-to-server case:
  - Case ID and namespace:
    `1000; [1000, 1099] HTTP/3 framing, streams, and settings`
  - Case name: `h3_reserved_uni_stream_survives`
  - Server command:
    `cd build && ./tests/test_server -l d -e`
  - Client command:
    `cd build && ./tests/test_client -s 1024 -l d -t 1 -E -x 1000`
  - Result: passed; the client sent type `0x21`, the server observed
    `stream_type:33`, the normal request reported `pass:1`, and the final
    connection error was zero
- [x] Abnormal-path client-to-server case:
  - Case ID and namespace:
    `1001; [1000, 1099] HTTP/3 framing, streams, and settings`
  - Case name: `h3_client_push_stream_creation_error`
  - Server command:
    `cd build && ./tests/test_server -l d -e`
  - Client command:
    `cd build && ./tests/test_client -s 1024 -l d -t 1 -E -x 1001`
  - Result: passed; the server observed push stream type `0x01` and emitted
    `err:0x103`, while the client observed connection error `259`

The conservative command was attempted before the rebase:
`env -u XQC_TEST_NAME XQC_BUILD_DIR=build ./scripts/validate.sh full` did not
complete successfully. The existing `cert_verify` case failed with
certificate verification error 62, and the run later stopped making progress
in the existing `massive_requests_with_massive_header` case. A current-head
full-suite result is therefore not available; this remains an explicit review
limitation while CI completes.

Additional deterministic checks:

- `git diff HEAD^ --check`: passed
- `bash -n scripts/case_test.sh`: passed
- Candidate ID `1000`: no pre-allocation match in the current tree or
  `git log --all -G`
- Candidate ID `1001`: no pre-allocation match in the current tree or
  `git log --all -G`
- Registry: `[1000, 1099] HTTP/3 framing, streams, and settings` records
  `1000-1001`

### Risk and Scope

The production change is limited to HTTP/3 peer unidirectional stream
validation. It changes only the server-side error for a client-created push
stream and deliberately preserves client-side behavior.

The paired cases cover the wire-visible success and rejection paths with the
real test client and server. Alternate TLS backends, non-macOS platforms, and
the complete integration suite remain unverified locally. CI is not yet
complete; the CLA check has passed.

The validation case-ID registry was updated as required; no user-facing
documentation changed. Generated configuration and diagnostic artifacts are
absent from the commit, and the pull request contains one cohesive issue fix.
