### PR TITLE
[~]: Reject client PUSH_PROMISE on HTTP/3 server

### DIFF
--- a/harness/spec/validation.md
+++ b/harness/spec/validation.md
@@ -76,7 +76,7 @@ its case is retired so later changes cannot reuse it.
 | `[705, 799]` | QUIC Transport core | None |
 | `[800, 899]` | Recovery and congestion control | None |
 | `[900, 999]` | QUIC-TLS | None |
-| `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1001` |
+| `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1003` |
 | `[1100, 1149]` | QPACK | None |
 | `[1150, 1199]` | HTTP priority | None |
 | `[1200, 1299]` | QUIC DATAGRAM | None |

--- a/scripts/case_test.sh
+++ b/scripts/case_test.sh
@@ -5310,4 +5310,51 @@ else
 fi
 killall test_server 2> /dev/null
 
+
+## RFC 9114 Sections 7.2.5 and 9 request-stream frame handling
+
+clear_log
+rm -f test_session xqc_token tp_localhost h3_request_frame_server.log
+${SERVER_BIN} -l d -e -x 1002 > h3_request_frame_server.log &
+sleep 1
+echo -e "HTTP/3 reserved request frame remains usable ...\c"
+${CLIENT_BIN} -s 1024 -l d -t 1 -E -x 1002 > stdlog
+sent=`grep "\\[h3-request-frame-test\\]|type:0x21|ret:0|" stdlog`
+received=`grep "parse frame type success|frame_type:21|" slog`
+server_ok=`grep "\\[h3-request-frame-test\\]|reserved-frame|conn_err:0|" \
+    h3_request_frame_server.log`
+client_ok=`grep "conn errno:256" stdlog`
+if [ -n "$sent" ] && [ -n "$received" ] && [ -n "$server_ok" ] \
+    && [ -n "$client_ok" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "h3_reserved_request_frame_accepted" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "h3_reserved_request_frame_accepted" "fail"
+fi
+
+killall test_server 2> /dev/null
+clear_log
+rm -f test_session xqc_token tp_localhost h3_request_frame_server.log
+${SERVER_BIN} -l d -e -x 1003 > h3_request_frame_server.log &
+sleep 1
+echo -e "HTTP/3 client PUSH_PROMISE gets frame unexpected ...\c"
+${CLIENT_BIN} -s 1024 -l d -t 1 -E -x 1003 > stdlog
+sent=`grep "\\[h3-request-frame-test\\]|type:0x5|ret:0|" stdlog`
+server_err=`grep "\\[h3-request-frame-test\\]|push-promise|conn_err:261|" \
+    h3_request_frame_server.log`
+wire_err=`grep "err:0x105" slog`
+client_err=`grep -E "(conn errno:261|conn_err:261)" stdlog`
+if [ -n "$sent" ] && [ -n "$server_err" ] && [ -n "$wire_err" ] \
+    && [ -n "$client_err" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "h3_client_push_promise_rejected" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "h3_client_push_promise_rejected" "fail"
+fi
+killall test_server 2> /dev/null
+rm -f h3_request_frame_server.log
+
+
 cd -

--- a/src/http3/xqc_h3_stream.c
+++ b/src/http3/xqc_h3_stream.c
@@ -1060,7 +1060,18 @@ xqc_h3_stream_process_request(xqc_h3_stream_t *h3s, unsigned char *data, size_t 
                 break;
 
             case XQC_H3_FRM_PUSH_PROMISE:
-                /* PUSH related is not implemented yet */
+                /*
+                 * RFC 9114 Section 7.2.5: clients cannot send PUSH_PROMISE.
+                 * Servers must reject one with H3_FRAME_UNEXPECTED.
+                 */
+                if (h3s->h3c->conn->conn_type == XQC_CONN_TYPE_SERVER) {
+                    xqc_log(h3s->log, XQC_LOG_ERROR,
+                            "|client PUSH_PROMISE on request stream|");
+                    xqc_h3_frm_reset_pctx(pctx);
+                    XQC_H3_CONN_ERR(h3s->h3c, H3_FRAME_UNEXPECTED,
+                                    -XQC_H3_REQUEST_FRAME_UNEXPECTED);
+                    return -XQC_H3_REQUEST_FRAME_UNEXPECTED;
+                }
                 break;
 
             /* RFC 9114 §7.2.4/§7.2.3/§7.2.6/§7.2.7: control-only frames on request stream */
@@ -1397,6 +1408,22 @@ xqc_h3_stream_process_bidi_type_unknown(xqc_h3_stream_t *h3s,
         /* the type of the 1st frame is determined */
         xqc_log(h3s->log, XQC_LOG_DEBUG, "|parse frame type success|frame_type:%xL|read:%z|",
                 pctx->frame.type, read);
+
+        /*
+         * RFC 9114 Section 7.2.5: reject a client PUSH_PROMISE even
+         * when it is the first frame and this stream's type is not
+         * determined yet.
+         */
+        if (pctx->frame.type == XQC_H3_FRM_PUSH_PROMISE
+            && h3s->h3c->conn->conn_type == XQC_CONN_TYPE_SERVER)
+        {
+            xqc_log(h3s->log, XQC_LOG_ERROR,
+                    "|client PUSH_PROMISE on unknown bidi stream|");
+            xqc_h3_frm_reset_pctx(pctx);
+            XQC_H3_CONN_ERR(h3s->h3c, H3_FRAME_UNEXPECTED,
+                            -XQC_H3_REQUEST_FRAME_UNEXPECTED);
+            return -XQC_H3_REQUEST_FRAME_UNEXPECTED;
+        }
         
         if (pctx->frame.type != XQC_H3_EXT_FRM_BIDI_STREAM_TYPE) {
             /* the first frame is not BIDI_STREAM_TYPE */

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -17,6 +17,7 @@
 #include <xquic/xquic_typedef.h>
 #include <xquic/xqc_http3.h>
 #include "src/http3/xqc_h3_conn.h"
+#include "src/http3/xqc_h3_request.h"
 #include "platform.h"
 #ifndef XQC_SYS_WINDOWS
 #include <unistd.h>
@@ -67,11 +68,15 @@ printf_null(const char *format, ...)
 
 #define XQC_TEST_CASE_H3_RESERVED_UNI_STREAM 1000
 #define XQC_TEST_CASE_H3_CLIENT_PUSH_STREAM 1001
+#define XQC_TEST_CASE_H3_RESERVED_REQUEST_FRAME 1002
+#define XQC_TEST_CASE_H3_CLIENT_PUSH_PROMISE 1003
 
 typedef struct user_conn_s user_conn_t;
 
 static void xqc_client_send_test_uni_stream(xqc_h3_conn_t *h3_conn,
     xqc_h3_stream_type_t stream_type);
+static xqc_int_t xqc_client_send_test_request_frame(
+    xqc_h3_request_t *h3_request, uint64_t frame_type);
 
 
 #define XQC_TEST_DGRAM_BATCH_SZ 32
@@ -116,6 +121,7 @@ typedef struct user_stream_s {
     xqc_usec_t               last_read_time;
     int                      abnormal_count;
     int                      body_read_notify_cnt;
+    int                      h3_test_frame_queued;
     xqc_usec_t               last_recv_log_time;
     uint64_t                 recv_log_bytes;
 
@@ -1963,6 +1969,45 @@ xqc_client_send_test_uni_stream(xqc_h3_conn_t *h3_conn,
 }
 
 
+static xqc_int_t
+xqc_client_send_test_request_frame(xqc_h3_request_t *h3_request,
+    uint64_t frame_type)
+{
+    xqc_h3_stream_t *h3_stream = h3_request->h3_stream;
+    xqc_var_buf_t *buf = xqc_var_buf_create(2);
+    if (buf == NULL) {
+        return -XQC_EMALLOC;
+    }
+
+    xqc_int_t ret;
+    if (frame_type == XQC_H3_FRM_PUSH_PROMISE) {
+        ret = xqc_h3_frm_write_push_promise(&h3_stream->send_buf, 0, buf,
+                                            XQC_FALSE);
+
+    } else {
+        unsigned char frame[] = { 0x21, 0x00 };
+        ret = xqc_var_buf_save_data(buf, frame, sizeof(frame));
+        if (ret == XQC_OK) {
+            ret = xqc_list_buf_to_tail(&h3_stream->send_buf, buf);
+        }
+    }
+
+    if (ret != XQC_OK) {
+        xqc_var_buf_free(buf);
+        return ret;
+    }
+
+    ret = xqc_h3_stream_send_buffer(h3_stream);
+    if (ret == -XQC_EAGAIN) {
+        ret = XQC_OK;
+    }
+
+    printf("[h3-request-frame-test]|type:0x%" PRIx64 "|ret:%d|\n",
+           frame_type, ret);
+    return ret;
+}
+
+
 void
 xqc_client_h3_conn_ping_acked_notify(xqc_h3_conn_t *conn, const xqc_cid_t *cid, void *ping_user_data, void *user_data)
 {
@@ -2436,6 +2481,27 @@ xqc_client_request_send(xqc_h3_request_t *h3_request, user_stream_t *user_stream
     }
     ssize_t ret = 0;
     char content_len[10];
+
+    if (!user_stream->h3_test_frame_queued
+        && (g_test_case == XQC_TEST_CASE_H3_RESERVED_REQUEST_FRAME
+            || g_test_case == XQC_TEST_CASE_H3_CLIENT_PUSH_PROMISE))
+    {
+        uint64_t frame_type =
+            g_test_case == XQC_TEST_CASE_H3_CLIENT_PUSH_PROMISE
+            ? XQC_H3_FRM_PUSH_PROMISE
+            : 0x21;
+        ret = xqc_client_send_test_request_frame(h3_request, frame_type);
+        if (ret != XQC_OK) {
+            return ret;
+        }
+        user_stream->h3_test_frame_queued = 1;
+    }
+
+    if (g_test_case == XQC_TEST_CASE_H3_RESERVED_REQUEST_FRAME
+        || g_test_case == XQC_TEST_CASE_H3_CLIENT_PUSH_PROMISE)
+    {
+        return XQC_OK;
+    }
 
     if (user_stream->send_body == NULL && !g_is_get /* POST */) {
         user_stream->send_body_max = MAX_BUF_SIZE;

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -53,6 +53,9 @@ printf_null(const char *format, ...)
 
 #define XQC_TEST_DGRAM_BATCH_SZ 32
 
+#define XQC_TEST_CASE_H3_RESERVED_REQUEST_FRAME 1002
+#define XQC_TEST_CASE_H3_CLIENT_PUSH_PROMISE 1003
+
 extern long xqc_random(void);
 extern xqc_usec_t xqc_now();
 
@@ -961,6 +964,17 @@ xqc_server_h3_conn_close_notify(xqc_h3_conn_t *h3_conn, const xqc_cid_t *cid, vo
     xqc_conn_stats_t stats = xqc_conn_get_stats(ctx.engine, cid);
     printf("send_count:%u, lost_count:%u, tlp_count:%u, recv_count:%u, srtt:%"PRIu64" early_data_flag:%d, conn_err:%d, ack_info:%s, conn_info:%s, alpn:%s\n",
            stats.send_count, stats.lost_count, stats.tlp_count, stats.recv_count, stats.srtt, stats.early_data_flag, stats.conn_err, stats.ack_info, stats.conn_info, stats.alpn);
+
+    if (g_test_case == XQC_TEST_CASE_H3_RESERVED_REQUEST_FRAME) {
+        printf("[h3-request-frame-test]|reserved-frame|conn_err:%d|\n",
+               stats.conn_err);
+        fflush(stdout);
+
+    } else if (g_test_case == XQC_TEST_CASE_H3_CLIENT_PUSH_PROMISE) {
+        printf("[h3-request-frame-test]|push-promise|conn_err:%d|\n",
+               stats.conn_err);
+        fflush(stdout);
+    }
 
     printf("[h3-dgram]|recv_dgram_bytes:%zu|sent_dgram_bytes:%zu|lost_dgram_bytes:%zu|lost_cnt:%zu|\n", 
            user_conn->dgram_blk->data_recv, user_conn->dgram_blk->data_sent,

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -156,6 +156,12 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite, "xqc_test_h3_control_frame_unexpected", xqc_test_h3_control_frame_unexpected)
         || !CU_add_test(pSuite, "xqc_test_h3_missing_settings", xqc_test_h3_missing_settings)
         || !CU_add_test(pSuite, "xqc_test_h3_request_frame_unexpected", xqc_test_h3_request_frame_unexpected)
+        || !CU_add_test(pSuite,
+                        "xqc_test_h3_server_reserved_request_frame_accepted",
+                        xqc_test_h3_server_reserved_request_frame_accepted)
+        || !CU_add_test(pSuite,
+                        "xqc_test_h3_server_push_promise_rejected",
+                        xqc_test_h3_server_push_promise_rejected)
         /* issue #746: RFC 9114 §4.2 forbidden connection-specific headers */
         || !CU_add_test(pSuite, "xqc_test_h3_message_error_enum", xqc_test_h3_message_error_enum)
         || !CU_add_test(pSuite, "xqc_test_h3_forbidden_headers_rejected", xqc_test_h3_forbidden_headers_rejected)

--- a/tests/unittest/xqc_h3_test.c
+++ b/tests/unittest/xqc_h3_test.c
@@ -1762,6 +1762,81 @@ xqc_test_h3_request_frame_unexpected()
 
 
 void
+xqc_test_h3_server_reserved_request_frame_accepted()
+{
+    xqc_connection_t *conn = NULL;
+    xqc_h3_conn_t *h3c = NULL;
+    xqc_h3_stream_t *h3s = xqc_h3_msgerr_setup(&conn, &h3c);
+    CU_ASSERT_FATAL(h3s != NULL);
+    conn->conn_type = XQC_CONN_TYPE_SERVER;
+
+    /*
+     * RFC 9114 Section 9 requires unknown frame types, including the
+     * reserved type 0x21, to be ignored.
+     */
+    unsigned char reserved_frame[] = { 0x21, 0x00 };
+    ssize_t processed = xqc_h3_stream_process_request(h3s, reserved_frame,
+            sizeof(reserved_frame), XQC_FALSE);
+
+    CU_ASSERT(processed == sizeof(reserved_frame));
+    CU_ASSERT(conn->conn_err == 0);
+    CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) == 0);
+
+    xqc_h3_msgerr_teardown(h3s, h3c, conn);
+}
+
+
+void
+xqc_test_h3_server_push_promise_rejected()
+{
+    xqc_connection_t *conn = NULL;
+    xqc_h3_conn_t *h3c = NULL;
+    xqc_h3_stream_t *h3s = xqc_h3_msgerr_setup(&conn, &h3c);
+    CU_ASSERT_FATAL(h3s != NULL);
+    conn->conn_type = XQC_CONN_TYPE_SERVER;
+
+    /*
+     * RFC 9114 Section 7.2.5: a server that receives PUSH_PROMISE from a
+     * client must close the connection with H3_FRAME_UNEXPECTED.
+     */
+    unsigned char push_promise[] = { 0x05, 0x02, 0x00, 0x00 };
+    ssize_t processed = xqc_h3_stream_process_request(h3s, push_promise,
+            sizeof(push_promise), XQC_FALSE);
+
+    CU_ASSERT(processed == -XQC_H3_REQUEST_FRAME_UNEXPECTED);
+    CU_ASSERT(conn->conn_err == H3_FRAME_UNEXPECTED);
+    CU_ASSERT(conn->conn_err == 0x0105);
+    CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
+
+    xqc_h3_msgerr_teardown(h3s, h3c, conn);
+
+    /*
+     * Cover a PUSH_PROMISE as the first frame on a peer-created bidi
+     * stream. The unknown-type dispatcher parses that first frame before
+     * request-stream processing, so it must enforce the same rule.
+     */
+    conn = NULL;
+    h3c = NULL;
+    h3s = xqc_h3_msgerr_setup(&conn, &h3c);
+    CU_ASSERT_FATAL(h3s != NULL);
+    conn->conn_type = XQC_CONN_TYPE_SERVER;
+    xqc_h3_request_destroy(h3s->h3r);
+    h3s->h3r = NULL;
+    h3s->type = XQC_H3_STREAM_TYPE_UNKNOWN;
+
+    processed = xqc_h3_stream_process_in(h3s, push_promise,
+            sizeof(push_promise), XQC_FALSE);
+
+    CU_ASSERT(processed == -XQC_H3_EPROC_REQUEST);
+    CU_ASSERT(conn->conn_err == H3_FRAME_UNEXPECTED);
+    CU_ASSERT(conn->conn_err == 0x0105);
+    CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
+
+    xqc_h3_msgerr_teardown(h3s, h3c, conn);
+}
+
+
+void
 xqc_test_h3_allowed_headers_pass()
 {
     /* content-type: normal header, never forbidden */

--- a/tests/unittest/xqc_h3_test.h
+++ b/tests/unittest/xqc_h3_test.h
@@ -28,6 +28,10 @@ void xqc_test_h3_missing_settings();
 /* issue #609: RFC 9114 §7.2 control-only frames on request stream */
 void xqc_test_h3_request_frame_unexpected();
 
+/* issue #849: RFC 9114 §7.2.5 PUSH_PROMISE sender role */
+void xqc_test_h3_server_reserved_request_frame_accepted();
+void xqc_test_h3_server_push_promise_rejected();
+
 /* issue #746: RFC 9114 §4.2 forbidden connection-specific headers */
 void xqc_test_h3_message_error_enum();
 void xqc_test_h3_forbidden_headers_rejected();


### PR DESCRIPTION
### Summary

HTTP/3 servers currently ignore a client-sent `PUSH_PROMISE` frame on a
request stream. This violates the sender-role requirement in RFC 9114
Section 7.2.5 and allows the connection to continue instead of closing with
`H3_FRAME_UNEXPECTED`.

This change rejects the frame on both an established request stream and the
first-frame path where an incoming bidirectional stream has not yet been
classified.

Acceptance criteria:

- A server receiving a client `PUSH_PROMISE` closes the connection with
  `H3_FRAME_UNEXPECTED` (`0x105`).
- The local internal error remains `XQC_H3_REQUEST_FRAME_UNEXPECTED`.
- Client-side receipt of a server `PUSH_PROMISE` is not rejected by the new
  role check.
- Reserved request-stream frames remain accepted.

### Changes

- Add a server-role check for `PUSH_PROMISE` in request-stream processing.
- Apply the same check while classifying the first frame of an incoming
  bidirectional stream.
- Add paired happy-path and abnormal-path CUnit coverage.
- Allocate HTTP/3 case IDs 1002 and 1003 and add matching client-to-server
  cases with client and server assertions.
- Update the case-ID namespace registry.

### Related Issue

Fixes: #849

### Specification

RFC 9114 Section 7.2.5 contains a normative requirement: a client MUST NOT
send `PUSH_PROMISE`, and a server that receives one MUST treat it as a
connection error of type `H3_FRAME_UNEXPECTED`.

Previous wire behavior: the server ignored the frame and kept the connection
open.

New wire behavior: the server closes the connection with
`H3_FRAME_UNEXPECTED` (`0x105`). The lowest-level regression test is
`xqc_test_h3_server_push_promise_rejected`.

### CONTRIBUTING.md Checklist

- [x] The branch prefix matches the task type: `fix/`.
- [x] Commit messages follow `[<type>]: <subject>`.
- [x] The change follows the Nginx-derived XQUIC code style.
- [ ] The aggregate client-to-server suite is fully green; see Notes.
- [ ] Required continuous-integration checks pass before merge.
- [x] The branch is based on the current `origin/main`, and review-fix
      commits will be squashed before merge.
- [ ] The Contributor License Agreement is signed or will be completed before
      merge.

### Validation

- Validation applicability: `production behavior`
- Runtime-coverage exemption: `Not applicable`
- [x] Tested commit SHA:
  `559634d6476b331cbf866ef1f28c230a7879ee93`
- [x] Complete local unit suite:
  - Command:
    `unset XQC_TEST_NAME; XQC_SSL_PATH="$PWD/third_party/boringssl" XQC_BUILD_DIR=build ./scripts/validate.sh test`
  - Result: `136/136 CUnit tests, Failed=0`
- [x] Happy-path unit test:
  `xqc_test_h3_server_reserved_request_frame_accepted` — passed
- [x] Abnormal-path unit test:
  `xqc_test_h3_server_push_promise_rejected` — passed, including the
  established request-stream and first-frame unknown-stream paths
- [x] Happy-path client-to-server case:
  - Case ID and namespace: `1002; [1000, 1099] HTTP/3 framing, streams, and settings`
  - Case name: `h3_reserved_request_frame_accepted`
  - Commands:
    ```bash
    cd build
    tests/test_server -l d -e -x 1002 > h3_request_frame_server.log &
    tests/test_client -s 1024 -l d -t 1 -E -x 1002 > stdlog
    ```
  - Result: `[       OK ] xquic_case_test.h3_reserved_request_frame_accepted`
- [x] Abnormal-path client-to-server case:
  - Case ID and namespace: `1003; [1000, 1099] HTTP/3 framing, streams, and settings`
  - Case name: `h3_client_push_promise_rejected`
  - Commands:
    ```bash
    cd build
    tests/test_server -l d -e -x 1003 > h3_request_frame_server.log &
    tests/test_client -s 1024 -l d -t 1 -E -x 1003 > stdlog
    ```
  - Result: `[       OK ] xquic_case_test.h3_client_push_promise_rejected`
  - Observed wire/application error: `0x105` / `261`

### Risk and Scope

The production change is limited to HTTP/3 request-stream frame dispatch and
is gated on the local endpoint being a server. Client handling of legitimate
server push promises is unchanged.

Local validation used a Debug build with BoringSSL on macOS. Linux and other
TLS backends were not run locally and remain covered by CI. Generated,
temporary, and issue-check artifacts are absent from the source diff.

No durable user-facing documentation changes are required.

### Notes

The complete CUnit suite and both issue-specific client-to-server cases pass.
An aggregate `XQC_BUILD_DIR=build ./scripts/validate.sh full` attempt reached
unrelated pre-existing case failures (including pure-fin, illegal-packet, and
wrong-CID cases) and was later terminated by the local command runner's
five-minute limit before the entire case file completed. This PR therefore
remains Draft pending CI and/or a clean aggregate case-suite run.
