### PR TITLE
[~]: Enforce PR submission gates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,73 +1,25 @@
-### Summary
+### Mechanism
 
-<!-- Describe the current behavior or need, its impact, the observable
-acceptance criteria, and the implementation approach. -->
+<!-- Explain the changed mechanism concisely. For protocol behavior, cite the
+exact RFC or draft section. Otherwise write `Not applicable`. When the change
+closes an issue, add the exact standalone line `Fixes: #123`. -->
 
-### Changes
+- RFC or draft: `<RFC/draft section, or Not applicable>`
 
-<!-- List the concrete code, test, documentation, or tooling changes. -->
+### Validation Cases
 
-### Related Issue
+<!-- List only each case ID and its concise behavior. Do not repeat commands,
+test function names, logs, namespace ranges, or reservation snapshots. For a
+documentation/tooling-only change, write `Not applicable` with a reason. -->
 
-<!-- Add the exact line `Fixes: #123` when this PR resolves an issue.
-Otherwise write `Not applicable`. -->
+- `<case ID>` — `<concise happy-path or abnormal-path behavior>`
 
-### Specification
+### CONTRIBUTING.md
 
-<!-- For protocol behavior, cite the exact RFC or draft revision and section,
-state whether the requirement is normative, and describe the expected and
-previous wire behavior. Otherwise write `Not applicable`. -->
+<!-- Check every CONTRIBUTING.md requirement internally, but publish only the
+aggregate result. If local or CI validation is incomplete, name only the
+failing case ID and meaning or the incomplete CI check. -->
 
-### CONTRIBUTING.md Checklist
-
-<!-- These checks come from CONTRIBUTING.md and apply in addition to the
-harness validation evidence below. -->
-
-- [ ] The branch prefix matches the task type: `dev/` for a new feature,
-      `fix/` for a bug fix, `perf/` for a performance optimization or other
-      enhancement, or `doc/` for documentation.
-- [ ] Commit messages follow `[<type>]: <subject>` using `+`, `-`, `=`, or
-      `~`.
-- [ ] The change follows the Nginx-derived XQUIC code style, or is
-      documentation-only.
-- [ ] The full test suite and sufficient relevant tests have passed, with
-      exact evidence recorded below, or a documentation/tooling exemption is
-      explained.
-- [ ] Required continuous-integration checks pass before merge.
-- [ ] The branch is rebased on its current base branch, and review-fix commits
-      will be squashed before merge.
-- [ ] The Contributor License Agreement is signed or will be completed before
-      merge.
-
-### Validation
-
-<!-- Production behavior changes must complete every field below with results
-from the current PR head. A checked box without the command, name, result, and
-tested commit SHA does not pass the gate. Documentation-only or validation-
-tooling changes must replace runtime evidence with deterministic checks and
-explain why runtime coverage does not apply. -->
-
-- Validation applicability: `<production behavior / documentation / tooling>`
-- Runtime-coverage exemption, if applicable: `<reason and deterministic checks>`
-- [ ] Tested commit SHA: `<sha>`
-- [ ] Complete local unit suite:
-  - Command: `unset XQC_TEST_NAME && ./scripts/validate.sh test`
-  - Result: `<Ran>/<Total> CUnit tests, Failed=<count>`
-- [ ] Happy-path unit test: `<test name and result>`
-- [ ] Abnormal-path unit test: `<test name and result>`
-- [ ] Happy-path client-to-server case:
-  - Case ID and namespace: `<id; [A, B] module>`
-  - Case name: `<case_print_result name>`
-  - Command: `<exact command>`
-  - Result: `<pass/fail>`
-- [ ] Abnormal-path client-to-server case:
-  - Case ID and namespace: `<different id; [A, B] module>`
-  - Case name: `<case_print_result name>`
-  - Command: `<exact command>`
-  - Result: `<pass/fail>`
-
-### Risk and Scope
-
-<!-- Name affected layers, compatibility risks, untested configurations, and
-documentation impact. Confirm generated or temporary artifacts are absent and
-that the PR contains one cohesive contribution. -->
+- Overall: `<Passed / Pending / Not passed>`
+- Local regression: `<Complete / Incomplete — concise failed cases>`
+- CI: `<Complete / Pending / Failed — concise incomplete checks>`

--- a/harness/pipelines/dev-pipeline.md
+++ b/harness/pipelines/dev-pipeline.md
@@ -11,7 +11,7 @@ tests, build scripts, validation tooling, or repository automation.
 ```text
 Requirement analysis -> Acceptance criteria -> Working branch
                      -> Implementation -> Validation
-                     -> Review and PR evidence
+                     -> Review and PR submission
 ```
 
 ## Stage 1: Requirement Analysis
@@ -54,13 +54,17 @@ blocking evidence must be explicit.
 6. If either client-to-server case is new, select a distinct, never-used ID
    for each case from the owning layer or module namespace in the
    [validation specification](../spec/validation.md#client-to-server-case-id-namespace).
+   Refresh the base, search repository history, then inspect the published head
+   SHA of every open pull request targeting `main`; do not select an ID already
+   reserved in another PR's case selectors.
 7. Identify broader compatibility or interoperability evidence when the
    paired tests cannot establish the peer-visible result.
 8. Choose the expected validation level from the
    [validation specification](../spec/validation.md).
 
 Exit when the criteria can distinguish the intended behavior from the
-pre-change behavior.
+pre-change behavior and every proposed case ID has a complete, conflict-free
+allocation snapshot.
 
 ## Stage 3: Working Branch
 
@@ -125,11 +129,19 @@ unset XQC_TEST_NAME
 
 Use `XQC_BUILD_DIR=build ./scripts/validate.sh full` when the paired case-test
 blocks cannot be run independently. Record exact commands, paired test names,
-and results. Keep the pull request in draft after a missing or failed gate.
+and results in ignored local validation artifacts. Do not submit a new pull
+request or move an existing pull request to review after a missing or failed
+gate.
 
-Exit only when the complete unit suite and both relevant case tests pass.
+For every new case ID, repeat the open-PR reservation scan after the tests pass
+and immediately before Stage 6. Record the candidate IDs, query time, number of
+published PR heads inspected, current PR exclusion, and result. Fail closed if
+the open-PR query, fetch, or head-SHA verification is incomplete.
 
-## Stage 6: Review and PR Evidence
+Exit only when the complete unit suite and both relevant case tests pass and
+the final reservation snapshot is complete and conflict-free.
+
+## Stage 6: Review and PR Submission
 
 1. Review staged and unstaged diffs separately and verify the final scope.
 2. Confirm generated headers, validation artifacts, and task-scoped
@@ -137,18 +149,36 @@ Exit only when the complete unit suite and both relevant case tests pass.
 3. Check that documentation links and referenced commands still resolve.
 4. Assemble the evidence required by the
    [pull-request specification](../spec/pull-requests.md).
-5. Use the
-   [`xquic-pr-formatting` skill](../skills/xquic-pr-formatting/SKILL.md)
-   when drafting or updating the pull request.
-6. Complete the repository
-   [pull-request template](../../.github/pull_request_template.md) with
-   current-head local validation results. For production behavior changes,
-   name the complete unit-suite command and the paired happy-path and
-   abnormal-path unit and client-to-server case tests, including each case ID
-   and namespace.
+5. Complete the repository
+   [pull-request template](../../.github/pull_request_template.md) as a concise
+   review summary:
+   - explain the changed mechanism and cite the exact RFC or draft section
+     when protocol behavior changes;
+   - list each client-to-server case as only `<ID> — <concise behavior>`;
+   - report one aggregate `CONTRIBUTING.md` result; and
+   - mark local regression and CI `Complete`, or name only incomplete checks
+     and concise failing cases.
+   Do not copy commands, test function names, logs, namespace ranges, tested
+   SHA, or successful reservation snapshots into the PR body.
+6. After Stage 5 passes, invoke the
+   [`xquic-pr-formatting` skill](../skills/xquic-pr-formatting/SKILL.md) to
+   format and submit a new pull request, or update an existing pull request
+   after a follow-up revision, through the available GitHub client. Publish a
+   new-case PR or a head that changes case IDs in draft until the
+   post-publication scan passes.
+7. Immediately scan open pull requests again with the published current PR
+   included. If two PRs contain the same case ID, the lower-numbered PR keeps
+   it. Keep or return every later PR to draft, then go back to Stage 2,
+   reallocate the colliding ID, update the selectors and registry, and rerun
+   Stage 5 before publishing another head.
+8. Reflect a post-publication collision as an incomplete local-regression
+   blocker; keep successful scan details in local evidence. Fetch the published
+   pull request and verify its title, concise body, real line breaks, issue and
+   RFC linkage, aggregate gates, draft or review state, and URL. Only then move
+   an otherwise complete PR to review.
 
 Complete the loop only when the acceptance criteria, paired unit and case-test
-coverage, validation evidence, scope review, and pull request evidence are
+coverage, validation evidence, scope review, and published pull request are
 consistent.
 
 ## Enforcement Rules
@@ -162,13 +192,21 @@ consistent.
 4. Every production behavior change requires paired happy-path and
    abnormal-path client-to-server case tests.
 5. Every new client-to-server case has a distinct, never-used ID from the
-   documented namespace, and active or retired IDs are never reused.
+   documented namespace, active or retired IDs are never reused, and an ID
+   reserved by another open pull request is unavailable.
 6. A failed build is resolved before tests continue.
 7. The complete local unit suite and relevant case-test pair must pass before
    review.
 8. Generated and temporary artifacts are never committed as source.
-9. A production code pull request remains draft while any required local
-   result or paired test name is missing from its description.
+9. A production code pull request reports incomplete local or CI gates
+   truthfully and remains draft while required paired coverage or local
+   validation is missing or failed.
 10. An issue fix must not enter implementation with a false or inconclusive
-   issue-check gate, and its task-scoped issue-check report must never be
-   committed.
+    issue-check gate, and its task-scoped issue-check report must never be
+    committed.
+11. A new pull request is submitted only after the Stage 5 validation gate
+    passes, and every submission or follow-up update uses
+    `xquic-pr-formatting` and verifies the published result.
+12. Case-ID allocation fails closed unless the base, repository history, and
+    all open PR heads were checked. A post-publication collision is resolved in
+    favor of the lowest PR number; a later PR must reallocate and revalidate.

--- a/harness/skills/validate/SKILL.md
+++ b/harness/skills/validate/SKILL.md
@@ -19,8 +19,9 @@ diff contains:
 4. A client-to-server happy-path case in `scripts/case_test.sh`.
 5. A client-to-server abnormal-path case that proves the expected rejection,
    error, close, or recovery behavior.
-6. A distinct, never-before-used ID for each new client-to-server case,
-   allocated from the owning layer or module namespace in the
+6. A distinct, never-before-used and currently unreserved ID for each new
+   client-to-server case, allocated from the owning layer or module namespace
+   in the
    [validation specification](../../spec/validation.md#client-to-server-case-id-namespace).
 7. The new IDs recorded in the namespace registry in the same change.
 
@@ -34,17 +35,22 @@ new behavior.
 
 1. Inspect the changed-file scope and preserve unrelated user changes.
 2. Apply the Coverage Gate before treating validation as complete.
-3. For every new case ID, check `scripts/case_test.sh`,
+3. For every new case ID, refresh `origin/main`, check `scripts/case_test.sh`,
    `tests/test_client.c`, `tests/test_server.c`, and their Git history. Require
    no previous allocation and confirm the registry range matches the owning
    protocol layer or module.
-4. During development, use a focused registered CUnit test for fast feedback:
+4. Query all open pull requests targeting `main` and inspect the exact
+   published head SHA for each pull request other than the current one. Require
+   the candidate numeric token to be absent from the three selector files.
+   Follow the complete fail-closed procedure in the validation specification;
+   an incomplete query is not proof that an ID is free.
+5. During development, use a focused registered CUnit test for fast feedback:
 
    ```bash
    XQC_TEST_NAME=<test-name> ./scripts/validate.sh test
    ```
 
-5. Before creating or updating a code pull request, clear the focused-test
+6. Before creating or updating a code pull request, clear the focused-test
    selector and run the complete unit suite:
 
    ```bash
@@ -52,10 +58,10 @@ new behavior.
    ./scripts/validate.sh test
    ```
 
-6. Require the emitted CUnit summary to show `Ran == Total` and `Failed == 0`.
+7. Require the emitted CUnit summary to show `Ran == Total` and `Failed == 0`.
    Record the result as `<Ran>/<Total> CUnit tests`; `CTest 1/1` alone is not
    complete-unit-suite evidence.
-7. Run both relevant client-to-server case-test blocks, including their setup,
+8. Run both relevant client-to-server case-test blocks, including their setup,
    cleanup, and assertions. Because `scripts/case_test.sh` has no generic
    name filter, use the following conservative command unless the exact
    standalone commands for both blocks are executed and recorded:
@@ -64,19 +70,30 @@ new behavior.
    XQC_BUILD_DIR=build ./scripts/validate.sh full
    ```
 
-8. Require the complete unit suite and both relevant case tests to pass. Check
+9. Require the complete unit suite and both relevant case tests to pass. Check
    the case output for both expected `[       OK ]` names and for any
    `[     FAIL ]` or `>>>>>>>> pass:0` result; do not rely only on the script's
    exit code.
-9. Verify that `include/xquic/xqc_configure.h` and other generated artifacts
+10. Repeat the open-PR reservation scan for each new case ID after the tests
+    pass and immediately before PR submission or update. Record the snapshot
+    time, candidate IDs, number of heads checked, current PR exclusion, and
+    result.
+11. Verify that `include/xquic/xqc_configure.h` and other generated artifacts
    did not enter the source diff.
-10. Report the changed scope, CUnit `<Ran>/<Total>` and failed counts, paired
-    unit-test names, paired case IDs and namespaces, case-test names, exact
-    commands, and results.
-11. Put those current-head results in the repository
-   [pull-request template](../../../.github/pull_request_template.md).
-   Missing, stale, focused-only, or failed local evidence does not pass the
-   PR gate.
+12. Report the changed scope, CUnit `<Ran>/<Total>` and failed counts, paired
+    unit-test names, paired case IDs and namespaces, reservation snapshot,
+    case-test names, exact commands, and results in ignored local evidence.
+13. Summarize those current-head results in the repository
+    [pull-request template](../../../.github/pull_request_template.md). List
+    only each case ID and its concise behavior, then mark local regression
+    `Complete` or name concise failed cases. Do not copy commands, test
+    function names, logs, namespace ranges, or reservation snapshots into the
+    PR body. Missing, stale, focused-only, or failed local evidence still does
+    not pass the gate.
+14. After the PR or updated head is published, scan again with the current PR
+    included. On a duplicate, the lowest PR number keeps the ID; every later PR
+    must return to draft, mark local regression incomplete, reallocate, and
+    rerun this workflow.
 
 Documentation-only changes may use link, format, and command-syntax checks
 instead of inventing runtime tests. Validation-tooling changes require the
@@ -94,7 +111,11 @@ applicable.
 - Do not submit a code pull request with a missing happy-path or abnormal-path
   client-to-server case test.
 - Do not reuse an active or retired case ID, use an ID outside its documented
-  namespace, or give the paired happy and abnormal cases the same ID.
+  namespace, take an ID reserved by another open PR, or give the paired happy
+  and abnormal cases the same ID.
+- Do not treat a failed or partial open-PR query as an empty reservation set.
+- Do not keep a duplicate ID in the later-numbered PR after the
+  post-publication collision check.
 - Do not use a focused test as pull-request evidence in place of the complete
   local unit suite.
 - Do not use the aggregate `CTest 1/1` result in place of the CUnit
@@ -103,4 +124,4 @@ applicable.
   in draft or resolve the blocker before review.
 - Keep raw logs under the ignored validation artifact directory.
 - Treat the optional pre-push hook as an early check only. The pull request
-  must still contain the required named local evidence.
+  must still contain the required concise case and aggregate gate summary.

--- a/harness/skills/xquic-pr-formatting/SKILL.md
+++ b/harness/skills/xquic-pr-formatting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: xquic-pr-formatting
-description: Format and update XQUIC pull request descriptions, comments, and review summaries. Use when preparing or editing an alibaba/xquic pull request or issue-linked PR body so contributor requirements, validation evidence, and Markdown formatting remain consistent.
+description: Format, submit, and update concise XQUIC pull requests, descriptions, comments, and review summaries. Use after the development-pipeline validation gate passes when creating or editing an alibaba/xquic pull request or issue-linked PR body so protocol mechanisms, case summaries, aggregate contribution gates, and Markdown formatting remain consistent.
 ---
 
 # XQUIC PR Formatting
@@ -11,44 +11,72 @@ description: Format and update XQUIC pull request descriptions, comments, and re
    [pull-request specification](../../spec/pull-requests.md).
 2. Start from the repository
    [pull-request template](../../../.github/pull_request_template.md).
-3. Treat that template as the canonical PR body structure. Preserve its
-   contribution checklist and harness validation sections rather than
-   replacing them with a shorter body.
+3. Treat its three concise sections as the canonical PR body structure:
+   mechanism, validation cases, and aggregate `CONTRIBUTING.md` status.
 4. Check the branch name against the task-to-prefix mapping in
    `CONTRIBUTING.md`, then check commit format, CLA state, rebase and squash
    state, code style, full-suite result, relevant tests, CI state, and
    issue-closing syntax.
-5. For a production behavior change, require the PR body to name paired
-   happy-path and abnormal-path unit tests plus paired client-to-server case
-   tests.
-6. Require evidence that the complete local unit suite and both relevant case
-   tests passed; a focused unit test is insufficient.
-7. Include exact validation commands actually run and state limitations
-   plainly.
-8. For issue fixes, include `Fixes: #<issue-number>`.
-9. Write multiline descriptions or comments to a Markdown file first, then
-   submit the file through the available GitHub client.
-10. Fetch the published body after updating it and verify real line breaks,
-   headings, issue links, and test evidence.
+5. Explain the changed mechanism and cite the exact RFC or draft section for
+   protocol behavior. Include the exact `Fixes: #<issue-number>` line for an
+   issue fix.
+6. Verify internally that the complete local unit suite and both relevant
+   case tests passed; a focused unit test is insufficient. In the PR, list
+   only each client-to-server case ID and its concise behavior.
+7. For new case IDs, require a fresh, conflict-free reservation scan across
+   every other open PR's published head. Keep successful scan details in local
+   evidence; expose only a concise blocker when a conflict exists.
+8. Check every `CONTRIBUTING.md` item internally. Publish one overall result,
+   `Local regression: Complete` or concise failed cases, and `CI: Complete` or
+   only incomplete check names.
+9. Write multiline descriptions or comments to a Markdown file first.
+10. After the development pipeline's validation gate passes, create or update
+    the pull request through the available GitHub client using that file.
+    Publish a new-case PR, or a head that changes case IDs, in draft.
+11. Immediately repeat the reservation scan with the published current PR
+    included. If duplicate case IDs exist, the lowest PR number keeps them.
+    Keep or return every later PR to draft and send it back through allocation
+    and validation before another update.
+12. Reflect a collision as an incomplete local gate; keep successful details
+    out of the body. Fetch the published pull request and verify its title,
+    concise body, real line breaks, RFC and issue links, aggregate statuses,
+    draft or review state, and URL. Move an otherwise complete PR to review
+    only after this check passes.
 
 ## Pull Request Body
 
-Use `.github/pull_request_template.md` as the single body shape. Complete each
-applicable field and write `Not applicable` with a reason where the template
-allows an exemption. A checkbox is evidence only when the corresponding
-branch, commit, command, result, or contributor state supports it.
+Use `.github/pull_request_template.md` as the single body shape. Do not add
+per-check checklists or validation transcripts. Use `Not applicable` with a
+short reason when protocol or runtime cases do not apply.
+
+List cases only as:
+
+```text
+<case ID> — <concise behavior>
+```
 
 ## Guardrails
 
 - Keep claims factual and source-backed.
+- Keep the PR body concise; detailed evidence belongs in code, CI, or ignored
+  local validation artifacts.
 - Do not use escaped newline strings for multiline GitHub content.
 - Do not claim a full suite passed when only a focused test ran.
 - Do not move a production code pull request to review without paired coverage
   and passing local gate evidence.
-- Do not accept a checked template box without the corresponding command,
-  test or case name, result, and current-head evidence.
-- Do not mark a `CONTRIBUTING.md` checkbox complete when the branch, commits,
-  CLA, rebase state, style, tests, CI, or issue syntax do not support it.
+- Do not submit a new production code pull request before the development
+  pipeline's validation gate passes.
+- Do not publish or update a ready-for-review production PR with a case ID
+  reserved by another open PR.
+- Do not treat a failed or incomplete open-PR query as an empty reservation
+  set.
+- Do not leave the later-numbered PR ready after a post-publication collision;
+  reallocate its ID and rerun validation.
+- Do not publish detailed commands, test function names, case names, logs,
+  namespace ranges, tested SHA, or successful reservation snapshots.
+- Do not mark the aggregate `CONTRIBUTING.md` result passed when the branch,
+  commits, CLA, rebase state, style, local regression, CI, or issue syntax does
+  not support it.
 - Do not accept an allowed branch prefix when it belongs to a different task
   type.
 - Do not include internal agent names, temporary artifacts, or process

--- a/harness/spec/pull-requests.md
+++ b/harness/spec/pull-requests.md
@@ -7,18 +7,15 @@ request, follow the
 Start from the repository
 [pull-request template](../../.github/pull_request_template.md).
 
-Every pull request should let a reviewer answer four questions quickly:
-
-1. What behavior or project capability changes?
-2. Why is the change correct?
-3. How was it validated?
-4. What remains risky or unverified?
+Keep the pull request body short enough to scan. It contains only the changed
+mechanism, concise validation cases, and the aggregate contribution gate.
+Detailed commands, logs, test function names, and reservation snapshots remain
+in code, CI, or ignored local validation artifacts.
 
 ## CONTRIBUTING.md Compliance
 
 The repository [contribution guide](../../CONTRIBUTING.md) remains the
-authoritative contribution contract. Harness evidence extends it and does not
-replace it. Before review, confirm:
+authoritative contribution contract. Check every requirement before review:
 
 - the branch uses the documented pattern for its task type: `dev/` for a new
   feature, `fix/` for a bug fix, `perf/` for a performance optimization or
@@ -37,69 +34,69 @@ Documentation-only changes follow the same review process. They may use the
 documented runtime-test exemption, but must provide their applicable link,
 format, and command-syntax evidence.
 
-## Required Content
+Do not copy this internal checklist into the pull request. Publish only:
 
-- **Problem:** current behavior and user or protocol impact.
-- **Acceptance criteria:** observable conditions that define completion.
-- **Approach:** the smallest useful explanation of the implementation.
-- **Validation:** the complete local unit-suite command, exact relevant
-  case-test commands, and concise pass/fail results.
-- **Coverage map:** the happy-path and abnormal-path unit-test names plus the
-  matching happy-path and abnormal-path client-to-server case names.
-- **Evidence:** relevant tests and, when applicable, logs, traces, packet
-  captures, interoperability reports, or screenshots.
-- **Risk:** affected layers, compatibility concerns, and untested platforms or
-  configurations.
-- **Documentation impact:** durable guidance updated, or an explicit statement
-  that no project documentation changed.
-- **Issue link:** use the repository convention, for example `Fixes: #123`.
+- `Overall: Passed` when every item passes, otherwise `Pending` or
+  `Not passed`;
+- `Local regression: Complete` when the required local gate passes, otherwise
+  list only the failing case IDs and their concise behavior;
+- `CI: Complete` when all required checks pass, otherwise list only pending or
+  failed checks.
 
-## Protocol Changes
+## Mechanism
 
-For QUIC, HTTP/3, QPACK, or MoQ behavior, also include:
+Explain the behavioral or project mechanism being changed and why the new
+mechanism is correct. Avoid a file-by-file change inventory. For QUIC, HTTP/3,
+QPACK, or MoQ behavior, cite the exact RFC or draft section number beside the
+mechanism. For non-protocol work, state that no RFC applies.
 
-- the exact RFC or draft section;
-- whether the requirement is normative;
-- the wire-visible behavior before and after the change; and
-- the lowest-level regression test that proves the required behavior.
+When the pull request closes an issue, retain the exact standalone
+`Fixes: #<number>` line required by `CONTRIBUTING.md`.
 
-Use interoperability and packet-capture evidence when unit tests cannot prove
-the peer-visible outcome.
+## Validation Cases
 
-## Required Test Evidence
+The full validation gate remains mandatory. Its local record retains exact
+commands, the CUnit `Total/Ran/Passed/Failed` summary, unit-test names, case
+names, logs, and reservation snapshots. Do not copy those details into the
+pull request.
 
-Every production behavior change must identify:
+In the pull request, describe paired client-to-server coverage with one line
+per case:
 
-- a happy-path unit test;
-- an abnormal, rejection, boundary, or error-branch unit test;
-- a happy-path client-to-server case in `scripts/case_test.sh`, including its
-  case ID and documented namespace; and
-- an abnormal-path client-to-server case in `scripts/case_test.sh`, including
-  its different case ID and documented namespace.
+```text
+<case ID> — <concise behavior proved by the case>
+```
 
-New case IDs must be absent from both the current tree and repository history
-before allocation. Active and retired IDs cannot be reused, and every new ID
-must be recorded in the
-[case ID namespace registry](validation.md#client-to-server-case-id-namespace)
-in the same change.
+Include the happy path and abnormal path. Do not include commands, unit-test
+function names, `case_print_result` names, logs, namespace ranges, tested
+commit SHA, or successful reservation-scan details. Those are discoverable in
+the change and its validation artifacts.
 
-The pull request must show that `XQC_TEST_NAME` was unset when the complete
-local unit suite ran. Report its result as `<Ran>/<Total> CUnit tests` and
-include the failed count; the aggregate `CTest 1/1` result is not sufficient
-evidence. It must also show that both relevant case tests passed. If the case
-pair cannot run independently, use
-`XQC_BUILD_DIR=build ./scripts/validate.sh full`. Evidence must come from the
-current pull request head and be refreshed after every code revision.
+If runtime cases do not apply, state the reason in one line. For a failed local
+gate, list only each failing case ID and its concise behavior under
+`Local regression`; use a short suite-level description when the failure has
+no client-to-server case ID.
 
-The PR validation gate is not satisfied by a checkbox alone. The description
-must contain the exact complete-suite command and result, both unit-test
-names, both client-to-server case IDs, namespaces, names and commands, and the
-tested commit SHA. Keep a production code pull request in draft when any
-field is missing, failed, stale, or replaced by focused-test output.
+## Case-ID Coordination
 
-Documentation-only changes may replace runtime evidence with link, format, and
-command-syntax checks. Validation-tooling changes use the closest
-deterministic self-checks and explain why runtime coverage does not apply.
+New case IDs must still pass the allocation and open-PR reservation procedure
+in the [validation specification](validation.md#client-to-server-case-id-namespace).
+Keep its detailed snapshots out of a passing PR body. A conflict makes local
+regression incomplete and must be named concisely as a blocker.
+
+Publish new-case PRs and case-ID-changing updates in draft until the
+post-publication scan passes. If two open PRs claim the same ID, the lower PR
+number keeps it. The later PR must remain draft, reallocate, and rerun the
+complete validation gate.
+
+## Aggregate Gate
+
+Use exactly one aggregate `CONTRIBUTING.md` section. Mark local regression and
+CI `Complete` when they pass. If either has not run, is pending, or failed,
+state that status and list only the incomplete checks or concise failed cases.
+Mark `Overall: Passed` only when the complete internal contribution checklist,
+local regression, CI, and case-ID coordination all pass. Do not expand the
+internal checklist into additional PR fields.
 
 ## Scope Rules
 
@@ -113,3 +110,7 @@ deterministic self-checks and explain why runtime coverage does not apply.
 - Keep a production code pull request in draft while paired coverage is
   missing, the complete local unit suite fails, or either relevant case test
   fails.
+- Keep the later-numbered pull request in draft while it duplicates a case ID
+  reserved by another open pull request.
+- Do not turn the PR body into a validation log; preserve detailed evidence in
+  its source artifact and publish the concise aggregate.

--- a/harness/spec/validation.md
+++ b/harness/spec/validation.md
@@ -55,6 +55,11 @@ normal/default path and must not be allocated. Because the older ranges contain
 cross-layer assignments, the complete `[1, 704]` range is frozen for new IDs,
 including gaps.
 
+The registry is the permanent ledger for merged and historical allocations.
+It cannot show every unmerged branch, so each open pull request also holds a
+temporary reservation for every literal case ID present at its published head
+in `scripts/case_test.sh`, `tests/test_client.c`, or `tests/test_server.c`.
+
 | Range | Existing namespace | Permanently reserved IDs |
 |-------|--------------------|--------------------------|
 | `[1, 99]` | Legacy cross-layer QUIC, TLS, HTTP/3, and callback cases | `1-53`, `55-57`, `80`, `99` |
@@ -94,22 +99,70 @@ Apply these allocation rules before running a new case:
    may keep its ID only when its original behavior contract remains intact.
 3. Select the range for the lowest protocol layer or module that owns the
    behavior. Cross-layer cases use the lowest layer that injects the condition.
-4. Search the current tree and Git history before allocating an ID:
+4. Refresh the intended base, then search the current tree and Git history
+   before allocating an ID:
 
    ```bash
+   git fetch origin main
    case_id=1000  # replace with the candidate ID
-   rg -n -- \
-       "-x[[:space:]]+${case_id}([^0-9]|$)|g_test_case.*${case_id}([^0-9]|$)" \
+   rg -n -- "(^|[^0-9])${case_id}([^0-9]|$)" \
        scripts/case_test.sh tests/test_client.c tests/test_server.c
    git log --all -G \
-       "(-x[[:space:]]+|g_test_case.*)${case_id}([^0-9]|$)" -- \
+       "(^|[^0-9])${case_id}([^0-9]|$)" -- \
        scripts/case_test.sh tests/test_client.c tests/test_server.c
    ```
 
    Both commands must return no prior allocation.
-5. Add the allocated ID to this registry, implement the matching client and
-   server selector behavior, and record the ID, namespace, case name, command,
-   and result in the pull request.
+5. Query every open pull request targeting `main` and inspect the exact head
+   commit SHA returned by the query:
+
+   ```bash
+   gh api --paginate \
+       "repos/alibaba/xquic/pulls?state=open&base=main&per_page=100" \
+       --jq '.[] | {number, created_at, head_sha: .head.sha, url: .html_url}'
+   ```
+
+   For each result other than the current pull request, fetch
+   `refs/pull/<number>/head`, verify that its fetched commit equals the reported
+   `headRefOid`, and search the three selector files for the candidate as a
+   complete numeric token. For example:
+
+   ```bash
+   pr=123
+   head_sha=<head_sha-from-query>
+   pr_ref="refs/xquic-harness/pr-${pr}-${head_sha}"
+   cleanup_case_ref() { git update-ref -d "${pr_ref}"; }
+   trap cleanup_case_ref EXIT HUP INT TERM
+   git fetch --quiet origin "refs/pull/${pr}/head:${pr_ref}"
+   test "$(git rev-parse "${pr_ref}")" = "${head_sha}"
+   git grep -n -E "(^|[^0-9])${case_id}([^0-9]|$)" "${pr_ref}" -- \
+       scripts/case_test.sh tests/test_client.c tests/test_server.c
+   cleanup_case_ref
+   trap - EXIT HUP INT TERM
+   ```
+
+   A match means that pull request already reserves the candidate. A failed
+   query, fetch, or head-SHA check is inconclusive and fails the allocation
+   gate; it must not be treated as an empty result. Record the query time, each
+   candidate ID, the number of open pull-request heads checked, the current
+   pull request excluded (if any), and any conflicting PR number and head SHA.
+6. Add the allocated ID to this registry, implement the matching client and
+   server selector behavior, and retain the ID, namespace, case name, command,
+   and result in ignored local validation evidence.
+7. After the local tests pass and immediately before creating or updating the
+   pull request, repeat the open-PR scan. The final validation evidence must use
+   this second snapshot; an earlier acceptance-stage scan is not sufficient.
+8. Publish a pull request that introduces new case IDs, or an updated head that
+   changes them, in draft. Immediately scan again with the current pull request
+   included. This closes the race in which two contributors both passed their
+   pre-publication scans. If no duplicate exists, retain the result locally and
+   the PR may move to review. If duplicate IDs exist, the lowest pull-request
+   number keeps each reservation. Every later pull request using that ID must
+   remain or return to draft, mark local regression incomplete, allocate a new
+   ID, update all selectors and this registry, rerun the complete validation
+   gate, and refresh its evidence. A reservation is released when its pull
+   request closes without merge or publishes a head that no longer contains
+   the ID.
 
 ## Levels
 
@@ -158,7 +211,8 @@ Before creating or moving a production code pull request to review:
 
 1. Confirm the paired unit tests and paired client-to-server case tests exist.
    For new cases, confirm their distinct IDs are registered in the correct
-   namespace and have never appeared in the current tree or Git history.
+   namespace, have never appeared in the current tree or Git history, and are
+   not reserved by another open pull request.
 2. Run the complete local unit suite with no focused-test selector:
 
    ```bash
@@ -182,22 +236,31 @@ Before creating or moving a production code pull request to review:
    the pull request. Confirm both expected `[       OK ]` case names are
    present and no relevant `[     FAIL ]` or `>>>>>>>> pass:0` result exists;
    the legacy case script's process exit code alone is not sufficient.
+7. Repeat the open-PR reservation scan for every new case ID. Fail closed when
+   the query or any head inspection is incomplete, and do not submit or update
+   a pull request while another open pull request reserves an ID.
 
-The pull request evidence must name:
+Retain the detailed gate evidence locally: exact commands, CUnit counts, unit
+and case names, case IDs and namespaces, results, and reservation snapshots.
+The pull request summarizes only:
 
-- the happy-path unit test;
-- the abnormal-path unit test;
-- the happy-path `case_print_result` case;
-- the abnormal-path `case_print_result` case;
-- each case ID and its documented namespace;
-- the command that ran the complete unit suite; and
-- the `<Ran>/<Total> CUnit tests` result with the failed count; and
-- the commands and results for the relevant case-test pair.
+- each client-to-server case as `<ID> — <concise behavior>`;
+- `Local regression: Complete` after the full local gate passes, or concise
+  failed case IDs and meanings when it does not;
+- `CI: Complete` after required checks pass, or only incomplete check names;
+  and
+- the aggregate `CONTRIBUTING.md` result.
+
+Do not copy commands, test function names, case names, logs, namespace ranges,
+tested commit SHA, or successful reservation snapshots into the PR body.
 
 A focused unit test is iteration evidence only. A missing test, failed test,
 or environment blocker does not satisfy the gate; keep the pull request in
 draft until the gate passes. Repeat the gate after every subsequent code
 change so the recorded evidence matches the pull request's current head.
+After publishing, a collision is reported only as an incomplete local gate and
+concise blocker. A later pull request with a duplicate case ID does not pass
+the gate even when all runtime tests passed with that ID.
 
 ## Optional Pre-Push Gate
 
@@ -213,9 +276,9 @@ command fails or the legacy case output contains a failure result. Existing
 hooks are never overwritten. Use `git push --no-verify` only for an explicit
 exception; bypassing the hook does not relax the pull-request gate.
 
-Regardless of hook use, a production code pull request must record the
-current-head complete unit-suite result and the relevant happy-path and
-abnormal-path unit and client-to-server case evidence required above.
+Regardless of hook use, a production code pull request must show the concise
+current-head local-regression status and paired client-to-server case summary
+required above.
 
 ## Configuration
 
@@ -234,8 +297,7 @@ During test development, run one registered CUnit test by name:
 XQC_TEST_NAME=xqc_test_h3_stream ./scripts/validate.sh test
 ```
 
-A focused test is fast feedback, not a replacement for the full Test level in
-pull request evidence.
+A focused test is fast feedback, not a replacement for the full Test gate.
 
 Supported environment variables:
 
@@ -263,9 +325,8 @@ them below `build/artifacts/` because it selects `XQC_BUILD_DIR=build`.
 - `<level>.log`: complete command output for the selected validation level,
   including the normalized CUnit summary and gate result.
 
-Pull requests should summarize the result and name the commands run. Raw logs
-are evidence for diagnosis and audit; they are not a substitute for a concise
-pull request summary.
+Pull requests summarize the aggregate gate and case meanings without repeating
+commands. Raw logs retain the detailed evidence for diagnosis and audit.
 
 The current CMake configuration generates `include/xquic/xqc_configure.h` in
 the source tree. The validation script preserves and restores its pre-build


### PR DESCRIPTION
### Mechanism

The harness now makes PR submission a post-validation pipeline stage and
coordinates new case IDs across concurrent open PRs. Allocation scans the
published selector files at each PR's exact head; new-case PRs are checked
again after publication, and a later PR must reallocate and revalidate if two
PRs race for the same ID.

- RFC or draft: Not applicable; this changes the development harness only.

### Validation Cases

- Not applicable — no production or client-to-server behavior changes.

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Complete
- CI: Pending — Ubuntu build, macOS build, CodeQL
