### PR TITLE
[~]: Enforce HTTP/3 MAX_PUSH_ID validation

### DIFF
--- a/harness/spec/validation.md
+++ b/harness/spec/validation.md
@@ -81,7 +81,7 @@ its case is retired so later changes cannot reuse it.
 | `[705, 799]` | QUIC Transport core | None |
 | `[800, 899]` | Recovery and congestion control | None |
 | `[900, 999]` | QUIC-TLS | None |
-| `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1003` |
+| `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1006` |
 | `[1100, 1149]` | QPACK | None |
 | `[1150, 1199]` | HTTP priority | None |
 | `[1200, 1299]` | QUIC DATAGRAM | None |

--- a/include/xquic/xqc_errno.h
+++ b/include/xquic/xqc_errno.h
@@ -272,6 +272,7 @@ typedef enum {
     XQC_H3_CONTROL_FRAME_UNEXPECTED     = 833,  /**< request-only frame received on control stream (RFC 9114 §7.2.1/§7.2.5) */
     XQC_H3_MISSING_SETTINGS             = 834,  /**< first frame on control stream is not SETTINGS, RFC 9114 §6.2.1 */
     XQC_H3_REQUEST_FRAME_UNEXPECTED     = 835,  /**< control-only frame received on request stream (RFC 9114 §7.2) */
+    XQC_H3_INVALID_MAX_PUSH_ID          = 836,  /**< RFC 9114 §7.2.7 */
 
     XQC_H3_ERR_MAX,
 } xqc_h3_error_t;

--- a/scripts/case_test.sh
+++ b/scripts/case_test.sh
@@ -5357,4 +5357,67 @@ killall test_server 2> /dev/null
 rm -f h3_request_frame_server.log
 
 
+## RFC 9114 Section 7.2.7 MAX_PUSH_ID handling
+
+clear_log
+rm -f test_session xqc_token tp_localhost
+${SERVER_BIN} -l d -e -x 1005 > /dev/null &
+sleep 1
+echo -e "HTTP/3 increasing MAX_PUSH_ID values are accepted ...\c"
+${CLIENT_BIN} -s 1024 -l d -t 1 -E -x 1005 > stdlog
+sent=`grep "\\[h3-max-push-id-test\\]|first:1|second:3|write:0,0|send:0|" \
+    stdlog`
+first_received=`grep "|H3_MAX_PUSH_ID|max_push_id:1|" slog`
+second_received=`grep "|H3_MAX_PUSH_ID|max_push_id:3|" slog`
+result=`grep ">>>>>>>> pass:1" stdlog`
+conn_err_zero=`grep -E "conn_err:0[^0-9]" stdlog`
+if [ -n "$sent" ] && [ -n "$first_received" ] \
+    && [ -n "$second_received" ] && [ -n "$result" ] \
+    && [ -n "$conn_err_zero" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "h3_max_push_id_increase_accepted" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "h3_max_push_id_increase_accepted" "fail"
+fi
+
+killall test_server 2> /dev/null
+clear_log
+rm -f test_session xqc_token tp_localhost
+${SERVER_BIN} -l d -e -x 1006 > /dev/null &
+sleep 1
+echo -e "HTTP/3 decreasing MAX_PUSH_ID gets H3_ID_ERROR ...\c"
+${CLIENT_BIN} -s 1024 -l d -t 1 -E -x 1006 > stdlog
+sent=`grep "\\[h3-max-push-id-test\\]|first:3|second:1|write:0,0|send:0|" \
+    stdlog`
+server_err=`grep "err:0x108" slog`
+client_err=`grep -E "(conn errno:264|conn_err:264)" stdlog`
+if [ -n "$sent" ] && [ -n "$server_err" ] && [ -n "$client_err" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "h3_max_push_id_decrease_rejected" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "h3_max_push_id_decrease_rejected" "fail"
+fi
+
+killall test_server 2> /dev/null
+clear_log
+rm -f test_session xqc_token tp_localhost
+stdbuf -oL ${SERVER_BIN} -l d -e -x 1004 > svr_stdlog &
+sleep 1
+echo -e "HTTP/3 server MAX_PUSH_ID gets H3_FRAME_UNEXPECTED ...\c"
+${CLIENT_BIN} -s 1024 -l d -t 1 -E -x 1004 > stdlog
+sent=`grep "\\[h3-max-push-id-test\\]|server_send:1|write:0|send:0|" svr_stdlog`
+client_err_log=`grep "err:0x105" clog`
+server_err=`grep -E "(conn errno:261|conn_err:261)" svr_stdlog`
+if [ -n "$sent" ] && [ -n "$client_err_log" ] && [ -n "$server_err" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "h3_max_push_id_wrong_role_rejected" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "h3_max_push_id_wrong_role_rejected" "fail"
+fi
+
+killall test_server 2> /dev/null
+
 cd -

--- a/src/http3/xqc_h3_stream.c
+++ b/src/http3/xqc_h3_stream.c
@@ -810,8 +810,41 @@ xqc_h3_stream_process_control(xqc_h3_stream_t *h3s, unsigned char *data, size_t 
 
 
             case XQC_H3_FRM_MAX_PUSH_ID:
-                /* PUSH related is not implemented yet */
+                /*
+                 * RFC 9114 Section 7.2.7: servers cannot send MAX_PUSH_ID,
+                 * and a newly received maximum cannot decrease. Sections
+                 * 6.2.1 and 7.2.7 put all peer MAX_PUSH_ID frames on its
+                 * single control stream. RFC 9000 Section 2.2 delivers that
+                 * stream as ordered bytes, so packet reordering cannot
+                 * reorder these frames here. A decrease therefore indicates
+                 * an implementation error at the peer.
+                 */
+                if (h3c->conn->conn_type == XQC_CONN_TYPE_CLIENT) {
+                    xqc_log(h3c->log, XQC_LOG_ERROR,
+                            "|client received MAX_PUSH_ID from server|");
+                    xqc_h3_frm_reset_pctx(pctx);
+                    XQC_H3_CONN_ERR(h3c, H3_FRAME_UNEXPECTED,
+                                    -XQC_H3_INVALID_MAX_PUSH_ID);
+                    return -XQC_H3_INVALID_MAX_PUSH_ID;
+                }
+
+                if (h3c->max_stream_id_recvd
+                    > pl->max_push_id.push_id.vi)
+                {
+                    xqc_log(h3c->log, XQC_LOG_ERROR,
+                            "|MAX_PUSH_ID decreased|old:%ui|new:%ui|",
+                            h3c->max_stream_id_recvd,
+                            pl->max_push_id.push_id.vi);
+                    xqc_h3_frm_reset_pctx(pctx);
+                    XQC_H3_CONN_ERR(h3c, H3_ID_ERROR,
+                                    -XQC_H3_INVALID_MAX_PUSH_ID);
+                    return -XQC_H3_INVALID_MAX_PUSH_ID;
+                }
+
                 h3c->max_stream_id_recvd = pl->max_push_id.push_id.vi;
+                xqc_log(h3c->log, XQC_LOG_DEBUG,
+                        "|H3_MAX_PUSH_ID|max_push_id:%ui|",
+                        h3c->max_stream_id_recvd);
                 break;
 
             default:

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -70,6 +70,9 @@ printf_null(const char *format, ...)
 #define XQC_TEST_CASE_H3_CLIENT_PUSH_STREAM 1001
 #define XQC_TEST_CASE_H3_RESERVED_REQUEST_FRAME 1002
 #define XQC_TEST_CASE_H3_CLIENT_PUSH_PROMISE 1003
+#define XQC_TEST_CASE_H3_MAX_PUSH_ID_WRONG_ROLE 1004
+#define XQC_TEST_CASE_H3_MAX_PUSH_ID_VALID 1005
+#define XQC_TEST_CASE_H3_MAX_PUSH_ID_DECREASE 1006
 
 typedef struct user_conn_s user_conn_t;
 
@@ -77,6 +80,8 @@ static void xqc_client_send_test_uni_stream(xqc_h3_conn_t *h3_conn,
     xqc_h3_stream_type_t stream_type);
 static xqc_int_t xqc_client_send_test_request_frame(
     xqc_h3_request_t *h3_request, uint64_t frame_type);
+static void xqc_client_send_test_max_push_ids(xqc_h3_conn_t *h3_conn,
+    uint64_t first, uint64_t second);
 
 
 #define XQC_TEST_DGRAM_BATCH_SZ 32
@@ -1939,6 +1944,12 @@ xqc_client_h3_conn_handshake_finished(xqc_h3_conn_t *h3_conn, void *user_data)
     } else if (g_test_case == XQC_TEST_CASE_H3_CLIENT_PUSH_STREAM) {
         xqc_client_send_test_uni_stream(h3_conn,
                 XQC_H3_STREAM_TYPE_PUSH);
+
+    } else if (g_test_case == XQC_TEST_CASE_H3_MAX_PUSH_ID_VALID) {
+        xqc_client_send_test_max_push_ids(h3_conn, 1, 3);
+
+    } else if (g_test_case == XQC_TEST_CASE_H3_MAX_PUSH_ID_DECREASE) {
+        xqc_client_send_test_max_push_ids(h3_conn, 3, 1);
     }
 
     if (g_test_case == 200 || g_test_case == 201) {
@@ -2005,6 +2016,23 @@ xqc_client_send_test_request_frame(xqc_h3_request_t *h3_request,
     printf("[h3-request-frame-test]|type:0x%" PRIx64 "|ret:%d|\n",
            frame_type, ret);
     return ret;
+}
+
+
+static void
+xqc_client_send_test_max_push_ids(xqc_h3_conn_t *h3_conn,
+    uint64_t first, uint64_t second)
+{
+    xqc_h3_stream_t *control = h3_conn->control_stream_out;
+    xqc_int_t first_ret = xqc_h3_frm_write_max_push_id(
+        &control->send_buf, first, XQC_FALSE);
+    xqc_int_t second_ret = xqc_h3_frm_write_max_push_id(
+        &control->send_buf, second, XQC_FALSE);
+    xqc_int_t send_ret = xqc_h3_stream_send_buffer(control);
+
+    printf("[h3-max-push-id-test]|first:%" PRIu64 "|second:%" PRIu64
+           "|write:%d,%d|send:%d|\n",
+           first, second, first_ret, second_ret, send_ret);
 }
 
 

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -18,6 +18,7 @@
 #include <stdint.h>
 
 #include "platform.h"
+#include "src/http3/xqc_h3_conn.h"
 #include "src/transport/xqc_conn.h"
 #include "src/transport/xqc_packet_out.h"
 
@@ -55,6 +56,7 @@ printf_null(const char *format, ...)
 
 #define XQC_TEST_CASE_H3_RESERVED_REQUEST_FRAME 1002
 #define XQC_TEST_CASE_H3_CLIENT_PUSH_PROMISE 1003
+#define XQC_TEST_CASE_H3_MAX_PUSH_ID_WRONG_ROLE 1004
 
 extern long xqc_random(void);
 extern xqc_usec_t xqc_now();
@@ -1023,6 +1025,16 @@ xqc_server_h3_conn_handshake_finished(xqc_h3_conn_t *h3_conn, void *conn_user_da
     if (g_test_case == 48) {
         printf("[initial-salt-test] server handshake ok, conn_err:%d\n",
                stats.conn_err);
+    }
+
+    if (g_test_case == XQC_TEST_CASE_H3_MAX_PUSH_ID_WRONG_ROLE) {
+        xqc_h3_stream_t *control = h3_conn->control_stream_out;
+        xqc_int_t write_ret = xqc_h3_frm_write_max_push_id(
+            &control->send_buf, 1, XQC_FALSE);
+        xqc_int_t send_ret = xqc_h3_stream_send_buffer(control);
+
+        printf("[h3-max-push-id-test]|server_send:1|write:%d|send:%d|\n",
+               write_ret, send_ret);
     }
 
     if (g_test_case == 704) {

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -143,6 +143,10 @@ main(int argc, char *argv[])
                         xqc_test_h3_reserved_uni_stream_accepted)
         || !CU_add_test(pSuite, "xqc_test_h3_push_stream_error_codes",
                         xqc_test_h3_push_stream_error_codes)
+        || !CU_add_test(pSuite, "xqc_test_h3_max_push_id_valid",
+                        xqc_test_h3_max_push_id_valid)
+        || !CU_add_test(pSuite, "xqc_test_h3_max_push_id_errors",
+                        xqc_test_h3_max_push_id_errors)
         /* RFC 9114 §4.2.2 field-section-size 32B overhead (issue 751) */
         || !CU_add_test(pSuite, "xqc_test_h3_uncompressed_fields_size", xqc_test_h3_uncompressed_fields_size)
         || !CU_add_test(pSuite, "xqc_test_h3_recv_header_field_section_size", xqc_test_h3_recv_header_field_section_size)

--- a/tests/unittest/xqc_h3_test.c
+++ b/tests/unittest/xqc_h3_test.c
@@ -1284,6 +1284,83 @@ xqc_h3_ctrl_feed_settings(xqc_h3_stream_t *h3s)
     return xqc_h3_stream_process_control(h3s, settings, sizeof(settings));
 }
 
+
+static ssize_t
+xqc_h3_ctrl_feed_max_push_id(xqc_h3_stream_t *h3s, unsigned char push_id)
+{
+    unsigned char frame[] = { XQC_H3_FRM_MAX_PUSH_ID, 0x01, push_id };
+    return xqc_h3_stream_process_control(h3s, frame, sizeof(frame));
+}
+
+
+void
+xqc_test_h3_max_push_id_valid()
+{
+    xqc_connection_t *conn = NULL;
+    xqc_h3_conn_t *h3c = NULL;
+    xqc_h3_stream_t *h3s = xqc_h3_ctrl_test_setup(&conn, &h3c);
+    CU_ASSERT_FATAL(h3s != NULL);
+
+    conn->conn_type = XQC_CONN_TYPE_SERVER;
+    CU_ASSERT_FATAL(xqc_h3_ctrl_feed_settings(h3s) > 0);
+
+    /*
+     * RFC 9114 Section 7.2.7: a server accepts MAX_PUSH_ID from a client,
+     * including the first value zero, later increases, and equal values.
+     */
+    CU_ASSERT(xqc_h3_ctrl_feed_max_push_id(h3s, 0) == 3);
+    CU_ASSERT(h3c->max_stream_id_recvd == 0);
+    CU_ASSERT(xqc_h3_ctrl_feed_max_push_id(h3s, 5) == 3);
+    CU_ASSERT(h3c->max_stream_id_recvd == 5);
+    CU_ASSERT(xqc_h3_ctrl_feed_max_push_id(h3s, 5) == 3);
+    CU_ASSERT(h3c->max_stream_id_recvd == 5);
+    CU_ASSERT(conn->conn_err == 0);
+    CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) == 0);
+
+    xqc_h3_ctrl_test_teardown(h3s, h3c, conn);
+}
+
+
+void
+xqc_test_h3_max_push_id_errors()
+{
+    xqc_connection_t *conn = NULL;
+    xqc_h3_conn_t *h3c = NULL;
+    xqc_h3_stream_t *h3s = xqc_h3_ctrl_test_setup(&conn, &h3c);
+    CU_ASSERT_FATAL(h3s != NULL);
+
+    CU_ASSERT_FATAL(conn->conn_type == XQC_CONN_TYPE_CLIENT);
+    CU_ASSERT_FATAL(xqc_h3_ctrl_feed_settings(h3s) > 0);
+
+    /* A client cannot receive MAX_PUSH_ID from a server. */
+    CU_ASSERT(xqc_h3_ctrl_feed_max_push_id(h3s, 1)
+              == -XQC_H3_INVALID_MAX_PUSH_ID);
+    CU_ASSERT(conn->conn_err == H3_FRAME_UNEXPECTED);
+    CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
+    CU_ASSERT(h3c->max_stream_id_recvd == 0);
+
+    xqc_h3_ctrl_test_teardown(h3s, h3c, conn);
+
+    conn = NULL;
+    h3c = NULL;
+    h3s = xqc_h3_ctrl_test_setup(&conn, &h3c);
+    CU_ASSERT_FATAL(h3s != NULL);
+
+    conn->conn_type = XQC_CONN_TYPE_SERVER;
+    CU_ASSERT_FATAL(xqc_h3_ctrl_feed_settings(h3s) > 0);
+    CU_ASSERT_FATAL(xqc_h3_ctrl_feed_max_push_id(h3s, 5) == 3);
+
+    /* A decreasing value is H3_ID_ERROR and cannot replace the maximum. */
+    CU_ASSERT(xqc_h3_ctrl_feed_max_push_id(h3s, 4)
+              == -XQC_H3_INVALID_MAX_PUSH_ID);
+    CU_ASSERT(conn->conn_err == H3_ID_ERROR);
+    CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
+    CU_ASSERT(h3c->max_stream_id_recvd == 5);
+
+    xqc_h3_ctrl_test_teardown(h3s, h3c, conn);
+}
+
+
 /* Case 1: DATA frame (with payload) rejected on control stream */
 static void
 xqc_test_h3_ctrl_reject_data(void)

--- a/tests/unittest/xqc_h3_test.h
+++ b/tests/unittest/xqc_h3_test.h
@@ -13,6 +13,8 @@ void xqc_test_h3_critical_stream_close();
 void xqc_test_h3_second_control_stream_rejected();
 void xqc_test_h3_reserved_uni_stream_accepted();
 void xqc_test_h3_push_stream_error_codes();
+void xqc_test_h3_max_push_id_valid();
+void xqc_test_h3_max_push_id_errors();
 void xqc_test_h3_uncompressed_fields_size();
 void xqc_test_h3_recv_header_field_section_size();
 


### PR DESCRIPTION
### Mechanism

XQUIC now validates `MAX_PUSH_ID` before updating the stored peer maximum.
A client rejects a server-originated frame with `H3_FRAME_UNEXPECTED`, while
a server rejects a decreasing value with `H3_ID_ERROR`. Valid initial, equal,
and increasing values remain accepted, as required by RFC 9114 Section 7.2.7.

RFC 9114 Sections 6.2.1 and 7.2.7 place peer `MAX_PUSH_ID` frames on one
control stream, and RFC 9000 Section 2.2 delivers stream bytes in order.
Packet reordering therefore cannot produce a decreasing value at the HTTP/3
parser boundary; such a decrease indicates a peer implementation error.

Fixes: #850

### Validation Cases

- `1004` — client rejects server-originated `MAX_PUSH_ID`
- `1005` — server accepts increasing `MAX_PUSH_ID` values
- `1006` — server rejects a decreasing `MAX_PUSH_ID`

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Complete
- CI: Pending — Build on Ubuntu (ubuntu-latest), Build on macOS
  (macos-latest), Analyze
