### PR TITLE
[+]: Add PR pre-review skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,9 @@ branch.
 - Before submitting an issue, use
   [`issue-check`](harness/skills/issue-check/SKILL.md) and then
   [`issue-submit`](harness/skills/issue-submit/SKILL.md).
+- After submitting a code pull request as draft and before moving it to
+  review, use
+  [`xquic-pr-pre-review`](harness/skills/xquic-pr-pre-review/SKILL.md).
 - Read the closest module documentation and protocol specification before
   changing wire behavior.
 
@@ -92,9 +95,14 @@ A code change is done when:
 - paired client-to-server case tests cover the corresponding end-to-end
   behavior;
 - the complete local unit suite and both relevant case tests pass;
+- the five-part local pre-review report passes and remains uncommitted;
 - the diff has been reviewed for scope and regressions; and
 - the pull request contains the evidence required by the
   [pull-request specification](harness/spec/pull-requests.md).
 
-When preparing or updating a pull request, follow the
-[`xquic-pr-formatting` skill](harness/skills/xquic-pr-formatting/SKILL.md).
+When preparing or updating a pull request, follow
+[`xquic-pr-formatting`](harness/skills/xquic-pr-formatting/SKILL.md) to publish
+the draft, run
+[`xquic-pr-pre-review`](harness/skills/xquic-pr-pre-review/SKILL.md), then
+return to the formatting skill to update the pull request and move it to
+review.

--- a/harness/README.md
+++ b/harness/README.md
@@ -20,6 +20,7 @@ harness/
 - [Validation skill](skills/validate/SKILL.md)
 - [Issue verification skill](skills/issue-check/SKILL.md)
 - [Issue submission skill](skills/issue-submit/SKILL.md)
+- [Pull request pre-review skill](skills/xquic-pr-pre-review/SKILL.md)
 - [Pull request formatting skill](skills/xquic-pr-formatting/SKILL.md)
 
 ## Setup
@@ -50,8 +51,7 @@ directory. To install the optional pre-push validation hook:
 
 The [pre-push hook](../scripts/hooks/pre-push) runs the complete local unit
 and case-test suites. It is an early failure signal, not a substitute for
-naming the relevant happy-path and abnormal-path tests and their current-head
-results in the pull request.
+the validation gate or the local pre-review report.
 
 ## Naming
 
@@ -68,6 +68,9 @@ results in the pull request.
   in `harness/`.
 - Task-scoped issue-check reports belong under the ignored
   `build/harness/<task-id>/` directory and must not be committed.
+- Pull-request pre-review reports and exploratory bad-case artifacts belong
+  under the ignored `build/harness/pr-<number>/` directory and must not be
+  committed.
 
 ## Portability
 

--- a/harness/pipelines/dev-pipeline.md
+++ b/harness/pipelines/dev-pipeline.md
@@ -11,7 +11,7 @@ tests, build scripts, validation tooling, or repository automation.
 ```text
 Requirement analysis -> Acceptance criteria -> Working branch
                      -> Implementation -> Validation
-                     -> Review and PR submission
+                     -> Draft PR -> Pre-review -> Ready for review
 ```
 
 ## Stage 1: Requirement Analysis
@@ -141,7 +141,7 @@ the open-PR query, fetch, or head-SHA verification is incomplete.
 Exit only when the complete unit suite and both relevant case tests pass and
 the final reservation snapshot is complete and conflict-free.
 
-## Stage 6: Review and PR Submission
+## Stage 6: Draft PR, Pre-Review, and Review Submission
 
 1. Review staged and unstaged diffs separately and verify the final scope.
 2. Confirm generated headers, validation artifacts, and task-scoped
@@ -162,24 +162,33 @@ the final reservation snapshot is complete and conflict-free.
    SHA, or successful reservation snapshots into the PR body.
 6. After Stage 5 passes, invoke the
    [`xquic-pr-formatting` skill](../skills/xquic-pr-formatting/SKILL.md) to
-   format and submit a new pull request, or update an existing pull request
-   after a follow-up revision, through the available GitHub client. Publish a
-   new-case PR or a head that changes case IDs in draft until the
-   post-publication scan passes.
-7. Immediately scan open pull requests again with the published current PR
+   format and submit every new code pull request as draft, or update an
+   existing pull request after a follow-up revision and keep it in draft,
+   through the available GitHub client.
+7. Fetch the published pull request and verify its number, URL, base commit,
+   head commit, title, body, and draft state. Run the
+   [`xquic-pr-pre-review` skill](../skills/xquic-pr-pre-review/SKILL.md)
+   against that exact published base-to-head diff. Write its five-part report
+   to `build/harness/pr-<number>/pre-review.md`.
+8. Continue only when the report reviews the published current head and says
+   `pre_review_result: true`. Keep the report and any exploratory bad-case
+   artifacts unstaged and uncommitted. A changed published head invalidates
+   the report and returns the pull request to this step.
+9. Immediately scan open pull requests again with the published current PR
    included. If two PRs contain the same case ID, the lower-numbered PR keeps
    it. Keep or return every later PR to draft, then go back to Stage 2,
    reallocate the colliding ID, update the selectors and registry, and rerun
    Stage 5 before publishing another head.
-8. Reflect a post-publication collision as an incomplete local-regression
+10. Reflect a post-publication collision as an incomplete local-regression
    blocker; keep successful scan details in local evidence. Fetch the published
    pull request and verify its title, concise body, real line breaks, issue and
-   RFC linkage, aggregate gates, draft or review state, and URL. Only then move
-   an otherwise complete PR to review.
+    RFC linkage, aggregate gates, base, head, draft or review state, and URL.
+    Only then update the concise body and move an otherwise complete PR to
+    review.
 
 Complete the loop only when the acceptance criteria, paired unit and case-test
-coverage, validation evidence, scope review, and published pull request are
-consistent.
+coverage, validation evidence, five-part pre-review, scope review, and
+published pull request are consistent.
 
 ## Enforcement Rules
 
@@ -210,3 +219,7 @@ consistent.
 12. Case-ID allocation fails closed unless the base, repository history, and
     all open PR heads were checked. A post-publication collision is resolved in
     favor of the lowest PR number; a later PR must reallocate and revalidate.
+13. Every new code pull request is submitted as draft after validation. It is
+    moved to review only when its exact published current head has a true
+    five-part pre-review result; the local report and exploratory artifacts
+    are never committed.

--- a/harness/skills/xquic-pr-formatting/SKILL.md
+++ b/harness/skills/xquic-pr-formatting/SKILL.md
@@ -30,18 +30,27 @@ description: Format, submit, and update concise XQUIC pull requests, description
    `Local regression: Complete` or concise failed cases, and `CI: Complete` or
    only incomplete check names.
 9. Write multiline descriptions or comments to a Markdown file first.
-10. After the development pipeline's validation gate passes, create or update
-    the pull request through the available GitHub client using that file.
-    Publish a new-case PR, or a head that changes case IDs, in draft.
-11. Immediately repeat the reservation scan with the published current PR
+10. After the development pipeline's validation gate passes, create every new
+    code pull request as draft through the available GitHub client using that
+    file. Keep follow-up updates in draft until their current head passes
+    pre-review.
+11. Fetch the published pull request and confirm its number, URL, base, head,
+    title, body, real line breaks, and draft state.
+12. Run
+    [`xquic-pr-pre-review`](../xquic-pr-pre-review/SKILL.md) against the
+    published pull request. Read
+    `build/harness/pr-<number>/pre-review.md` and require
+    `pre_review_result: true` for its exact published head. Keep the report out
+    of the commit and concise PR body.
+13. Immediately repeat the reservation scan with the published current PR
     included. If duplicate case IDs exist, the lowest PR number keeps them.
     Keep or return every later PR to draft and send it back through allocation
     and validation before another update.
-12. Reflect a collision as an incomplete local gate; keep successful details
+14. Reflect a collision as an incomplete local gate; keep successful details
     out of the body. Fetch the published pull request and verify its title,
     concise body, real line breaks, RFC and issue links, aggregate statuses,
-    draft or review state, and URL. Move an otherwise complete PR to review
-    only after this check passes.
+    base, head, draft or review state, and URL. Update the concise body and
+    move an otherwise complete PR to review only after this check passes.
 
 ## Pull Request Body
 
@@ -65,7 +74,10 @@ List cases only as:
 - Do not move a production code pull request to review without paired coverage
   and passing local gate evidence.
 - Do not submit a new production code pull request before the development
-  pipeline's validation gate passes.
+  pipeline's validation gate passes, and do not create it initially as ready.
+- Do not move a production code pull request to review before its exact
+  published current head passes pre-review.
+- Do not accept a missing, stale, false, or inconclusive pre-review report.
 - Do not publish or update a ready-for-review production PR with a case ID
   reserved by another open PR.
 - Do not treat a failed or incomplete open-PR query as an empty reservation

--- a/harness/skills/xquic-pr-pre-review/SKILL.md
+++ b/harness/skills/xquic-pr-pre-review/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: xquic-pr-pre-review
+description: Perform a fail-closed pre-review of a published draft XQUIC code pull request before ready-for-review state. Verify its exact published base-to-head implementation against authoritative RFC or pinned Internet-Draft text, paired positive and negative unit and client-to-server case coverage, an attempted adversarial bypass, protocol-stack performance and compiler optimization, and memory safety, ownership, bounds, and footprint; write the five-part conclusion to an ignored local review file.
+---
+
+# XQUIC PR Pre-Review
+
+Review the published pull request's exact base-to-head diff and write the
+result to `build/harness/pr-<number>/pre-review.md`. Require a GitHub PR number
+and URL; do not substitute a local branch candidate. Never stage or commit the
+report or exploratory review artifacts.
+
+## Inputs and Gate
+
+1. Fetch the pull request from GitHub. Record its number, URL, base commit,
+   published head commit, changed files, draft state, and review time.
+2. Confirm the fetched head matches the PR's published head, then read the
+   changed implementation, callers, tests, architecture map, and
+   adjacent module documentation. Treat the PR and issue descriptions as
+   context, not evidence.
+3. For protocol behavior, retrieve the authoritative text from RFC Editor or
+   the IETF Datatracker. Pin an Internet-Draft to the revision implemented by
+   the repository. Record the document URL, exact section, normative keyword,
+   and a source excerpt of no more than 25 words. Do not rely on a quotation
+   copied into the PR or issue.
+4. Use `pass`, `fail`, `inconclusive`, or `not-applicable` for each section.
+   Use `not-applicable` only with a concrete scope reason.
+5. Set `pre_review_result: true` only when every section is `pass` or justified
+   `not-applicable`. A `fail` or `inconclusive` result is a closed gate.
+6. Invalidate and rerun the report whenever the published PR head changes.
+
+If the official specification, reviewed source, or current-head validation
+evidence cannot be inspected, return `inconclusive`; never infer a pass.
+
+## 1. RFC Conformance
+
+- Derive the affected protocol mechanism from the code and wire behavior.
+- Compare every changed state transition, limit, role restriction, error code,
+  and peer-visible result with the authoritative section.
+- Trace peer input from parsing through validation, state mutation, and error
+  handling. Cite current file and line evidence.
+- Check interactions with related RFC requirements and negotiated extensions,
+  not only the paragraph cited by the PR.
+- Check verified RFC errata or pinned-draft changes that alter the cited
+  mechanism.
+- Fail on a semantic deviation unless the RFC permits the implementation
+  choice and the report explains that allowance.
+
+## 2. Validation Coverage
+
+- Inspect committed tests rather than trusting the PR summary.
+- Require a positive and negative CUnit case tied to each changed production
+  path.
+- Require positive and abnormal client-to-server cases in
+  `scripts/case_test.sh`, with distinct IDs and matching selectors in
+  `tests/test_client.c` and `tests/test_server.c`.
+- Confirm the end-to-end cases prove the endpoint-visible result, not merely a
+  process exit or generic failure.
+- Verify current-head local evidence shows the complete CUnit suite and both
+  relevant case tests passed. Fail when coverage or current-head evidence is
+  missing.
+
+## 3. Adversarial Bad Case
+
+- Construct the smallest peer-controlled input or event sequence that could
+  bypass the RFC guard. Consider boundary values, duplicate or reordered
+  frames, wrong endpoint roles, invalid state transitions, truncated or
+  non-canonical encodings, retransmission, 0-RTT, and callback reentrancy when
+  relevant.
+- Trace the bad case through the actual parser and state machine. Attempt an
+  executable focused unit or client-to-server reproduction when the local
+  environment permits it.
+- Keep exploratory code, packets, and logs under the task review directory;
+  do not modify the submitted diff.
+- Fail when the bad case bypasses the intended restriction or exposes an
+  unhandled state. Return `inconclusive` when a material bad case cannot be
+  executed or ruled out.
+
+## 4. Performance and Compiler Optimization
+
+- Identify whether the change is on a packet, frame, stream, request, timer, or
+  connection hot path and estimate its invocation frequency.
+- Compare the time complexity and critical-path work with viable alternatives.
+  Check repeated scans, avoidable parsing, allocations, copies, branches,
+  cache-unfriendly access, locking, and contention.
+- Inspect whether types, aliasing, control flow, data layout, and function
+  boundaries allow the configured compiler to inline, fold constants,
+  eliminate dead work, and vectorize where useful.
+- Read the actual release build flags before assuming an optimization is
+  enabled.
+- Use optimized-build assembly, compiler remarks, profiles, or benchmarks for
+  material performance claims when practical. Do not call an implementation
+  optimal without evidence.
+- Fail on an avoidable asymptotic regression or a material hot-path slowdown
+  without a correctness requirement or measured tradeoff.
+
+## 5. Memory Safety and Footprint
+
+- Build an ownership and lifetime map for every touched allocation, buffer,
+  pointer, list node, callback context, and borrowed reference.
+- Check success, error, timeout, close, retry, and reentrant callback paths for
+  leaks, double frees, use-after-free, stale aliases, null dereferences,
+  integer overflow, out-of-bounds access, and length/capacity mismatches.
+- Quantify new long-lived bytes per connection, stream, request, and path.
+  Project server cost at realistic concurrency and check for unbounded or
+  peer-controlled retention.
+- Use sanitizer, static-analysis, or focused stress evidence when the changed
+  ownership or bounds cannot be proved by inspection.
+- Prefer execution efficiency when memory footprint and speed conflict, but
+  record the alternatives, concurrency cost, measured or reasoned speed
+  benefit, and why the retained memory is bounded and acceptable.
+
+## Report Format
+
+Write exactly five numbered review sections after the metadata:
+
+```markdown
+---
+reviewed_base: <commit>
+reviewed_head: <commit>
+review_target: <PR URL>
+review_time_utc: <timestamp>
+pre_review_result: <true|false>
+---
+
+# XQUIC PR Pre-Review
+
+## 1. RFC Conformance
+Status: <pass|fail|inconclusive|not-applicable>
+Sources: <official document, section, URL>
+Evidence: <source/tests and short authoritative excerpt>
+Findings: <blocking and non-blocking findings, or none>
+Conclusion: <reasoned conclusion>
+
+## 2. Validation Coverage
+Status: <...>
+Evidence: <positive/negative unit and end-to-end case IDs/results>
+Findings: <...>
+Conclusion: <...>
+
+## 3. Adversarial Bad Case
+Status: <...>
+Attempt: <constructed input or sequence and execution result>
+Findings: <...>
+Conclusion: <...>
+
+## 4. Performance and Compiler Optimization
+Status: <...>
+Evidence: <hot path, complexity, compiler and measurement evidence>
+Findings: <...>
+Conclusion: <...>
+
+## 5. Memory Safety and Footprint
+Status: <...>
+Evidence: <ownership, bounds, per-scope footprint and concurrency estimate>
+Tradeoff: <memory versus execution-efficiency decision>
+Findings: <...>
+Conclusion: <...>
+```
+
+For every blocking finding, cite the reviewed file and line, explain the
+failure mode, and state the minimum condition for the gate to pass. Do not fix
+the PR while performing pre-review unless the user separately requests it.

--- a/harness/spec/PROJECT_INSTRUCTIONS.md
+++ b/harness/spec/PROJECT_INSTRUCTIONS.md
@@ -44,6 +44,7 @@ remain in the root [`README.md`](../../README.md).
 | Build, test, or validation | [Validation specification](validation.md) and [`validate` skill](../skills/validate/SKILL.md) |
 | Verify an issue or protocol-defect claim | [`issue-check` skill](../skills/issue-check/SKILL.md) |
 | Prepare or submit a GitHub issue | [`issue-submit` skill](../skills/issue-submit/SKILL.md), gated by [`issue-check`](../skills/issue-check/SKILL.md) |
+| Pre-review a code pull request | [`xquic-pr-pre-review` skill](../skills/xquic-pr-pre-review/SKILL.md), after draft PR publication and before ready-for-review state |
 | Pull request preparation or update | [Pull-request specification](pull-requests.md) and [`xquic-pr-formatting` skill](../skills/xquic-pr-formatting/SKILL.md) |
 | Query or analysis | Relevant source, tests, module docs, and [architecture map](architecture.md) |
 
@@ -127,7 +128,9 @@ A change is complete when:
   corresponding end-to-end behavior;
 - the complete local unit suite and both relevant case tests pass;
 - generated and temporary artifacts are absent from the diff;
-- durable documentation and relative links remain accurate; and
+- durable documentation and relative links remain accurate;
+- the task-scoped five-part pre-review report remains uncommitted and
+  passes; and
 - the pull request contains the evidence required by
   [pull-requests.md](pull-requests.md).
 
@@ -146,6 +149,7 @@ documentation in the same change when it affects future work.
 | Development workflow | [dev-pipeline.md](../pipelines/dev-pipeline.md) |
 | Harness registration | [setup_harness.sh](../../scripts/setup_harness.sh) |
 | Build and test validation | [validation.md](validation.md) |
+| Pull-request pre-review | [xquic-pr-pre-review](../skills/xquic-pr-pre-review/SKILL.md) |
 | Pull-request evidence | [pull-requests.md](pull-requests.md) |
 | Contribution and code style | [CONTRIBUTING.md](../../CONTRIBUTING.md) |
 | Supported features and setup | [README.md](../../README.md) |

--- a/harness/spec/pull-requests.md
+++ b/harness/spec/pull-requests.md
@@ -98,6 +98,14 @@ Mark `Overall: Passed` only when the complete internal contribution checklist,
 local regression, CI, and case-ID coordination all pass. Do not expand the
 internal checklist into additional PR fields.
 
+Submit a new code PR as draft after local validation. Then run the
+[`xquic-pr-pre-review` skill](../skills/xquic-pr-pre-review/SKILL.md) against
+the published PR's exact base and head. Require `pre_review_result: true` from
+all five sections before ready-for-review state, and keep
+`build/harness/pr-<number>/pre-review.md` uncommitted. The local report is a
+gate input; do not copy it into the concise PR body. A changed published head
+invalidates the report and must be reviewed again.
+
 ## Scope Rules
 
 - Do not mix harness construction with unrelated product fixes unless the

--- a/scripts/tests/setup_harness_test.sh
+++ b/scripts/tests/setup_harness_test.sh
@@ -60,6 +60,7 @@ EXPECTED_SKILLS=(
     issue-check
     issue-submit
     validate
+    xquic-pr-pre-review
     xquic-pr-formatting
 )
 


### PR DESCRIPTION
### Mechanism

Adds a fail-closed PR pre-review skill that records an exact-head, five-part
local review covering authoritative RFC conformance, paired validation,
adversarial bypass attempts, protocol-stack performance, and memory safety.
After local validation, the development pipeline publishes the code PR as
Draft, reviews its exact published base and head, and requires the ignored
local report to pass before ready-for-review state.

- RFC or draft: Not applicable — harness workflow only

### Validation Cases

- Not applicable — no production or client-to-server behavior changes; harness
  registration, idempotency, collision refusal, skill structure, and relative
  links pass locally

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Complete
- CI: Pending — Analyze, Ubuntu, macOS
