### PR TITLE
[~]: Preserve local PR pre-review artifacts

### DIFF
--- a/harness/README.md
+++ b/harness/README.md
@@ -69,8 +69,10 @@ the validation gate or the local pre-review report.
 - Task-scoped issue-check reports belong under the ignored
   `build/harness/<task-id>/` directory and must not be committed.
 - Pull-request pre-review reports and exploratory bad-case artifacts belong
-  under the ignored `build/harness/pr-<number>/` directory and must not be
-  committed.
+  together under the local
+  `~/build/harness/pr-review-<number>/` directory. The current retrospective
+  is `pr-review-<number>.md`; the complete directory remains uncommitted and
+  may be reused as input to the next PR iteration.
 
 ## Portability
 

--- a/harness/pipelines/dev-pipeline.md
+++ b/harness/pipelines/dev-pipeline.md
@@ -169,11 +169,15 @@ the final reservation snapshot is complete and conflict-free.
    head commit, title, body, and draft state. Run the
    [`xquic-pr-pre-review` skill](../skills/xquic-pr-pre-review/SKILL.md)
    against that exact published base-to-head diff. Write its five-part report
-   to `build/harness/pr-<number>/pre-review.md`.
+   to
+   `~/build/harness/pr-review-<number>/pr-review-<number>.md`. Keep all
+   reviewer-created abnormal-case code and supporting artifacts in the same
+   local review directory so they can be reused in the next iteration.
 8. Continue only when the report reviews the published current head and says
-   `pre_review_result: true`. Keep the report and any exploratory bad-case
-   artifacts unstaged and uncommitted. A changed published head invalidates
-   the report and returns the pull request to this step.
+   `pre_review_result: true`. Keep the complete local review directory
+   unstaged and uncommitted. A changed published head invalidates the report,
+   returns the pull request to this step, and may reuse retained abnormal-case
+   artifacts only after rerunning them against the new head.
 9. Immediately scan open pull requests again with the published current PR
    included. If two PRs contain the same case ID, the lower-numbered PR keeps
    it. Keep or return every later PR to draft, then go back to Stage 2,
@@ -221,5 +225,5 @@ published pull request are consistent.
     favor of the lowest PR number; a later PR must reallocate and revalidate.
 13. Every new code pull request is submitted as draft after validation. It is
     moved to review only when its exact published current head has a true
-    five-part pre-review result; the local report and exploratory artifacts
-    are never committed.
+    five-part pre-review result; the PR-scoped local retrospective and
+    abnormal-case artifacts are never committed.

--- a/harness/skills/xquic-pr-formatting/SKILL.md
+++ b/harness/skills/xquic-pr-formatting/SKILL.md
@@ -39,9 +39,10 @@ description: Format, submit, and update concise XQUIC pull requests, description
 12. Run
     [`xquic-pr-pre-review`](../xquic-pr-pre-review/SKILL.md) against the
     published pull request. Read
-    `build/harness/pr-<number>/pre-review.md` and require
+    `~/build/harness/pr-review-<number>/pr-review-<number>.md` and require
     `pre_review_result: true` for its exact published head. Keep the report out
-    of the commit and concise PR body.
+    of the commit and concise PR body. Preserve its sibling abnormal-case
+    artifacts as local inputs to the next PR iteration.
 13. Immediately repeat the reservation scan with the published current PR
     included. If duplicate case IDs exist, the lowest PR number keeps them.
     Keep or return every later PR to draft and send it back through allocation

--- a/harness/skills/xquic-pr-pre-review/SKILL.md
+++ b/harness/skills/xquic-pr-pre-review/SKILL.md
@@ -1,14 +1,37 @@
 ---
 name: xquic-pr-pre-review
-description: Perform a fail-closed pre-review of a published draft XQUIC code pull request before ready-for-review state. Verify its exact published base-to-head implementation against authoritative RFC or pinned Internet-Draft text, paired positive and negative unit and client-to-server case coverage, an attempted adversarial bypass, protocol-stack performance and compiler optimization, and memory safety, ownership, bounds, and footprint; write the five-part conclusion to an ignored local review file.
+description: Pre-review a published draft XQUIC code pull request before ready-for-review state. Use for a fail-closed gate over the exact published base-to-head diff covering RFC or pinned-draft conformance, paired positive and negative unit and client-to-server cases, adversarial bypasses, performance and compiler optimization, and memory safety and footprint; preserve the five-part retrospective and reviewer-built abnormal-case artifacts in the fixed local PR review workspace for the next iteration.
 ---
 
 # XQUIC PR Pre-Review
 
 Review the published pull request's exact base-to-head diff and write the
-result to `build/harness/pr-<number>/pre-review.md`. Require a GitHub PR number
-and URL; do not substitute a local branch candidate. Never stage or commit the
-report or exploratory review artifacts.
+result to
+`~/build/harness/pr-review-<number>/pr-review-<number>.md`. Require a GitHub
+PR number and URL; do not substitute a local branch candidate. Never stage or
+commit the report or other local review artifacts.
+
+## Local Review Workspace
+
+1. Expand `~` to the current user's home directory and use exactly
+   `~/build/harness/pr-review-<number>/` as the review directory. Do not place
+   the workspace under the repository checkout.
+2. Use `pr-review-<number>.md` as the single current retrospective. Before
+   rerunning a changed PR head, read the existing retrospective and local
+   artifacts as hypotheses and reproduction inputs, then rewrite the current
+   retrospective for the new head.
+3. Keep every reviewer-created abnormal-case source file, patch, build or run
+   script, peer input, packet, compiler output, and log inside the same review
+   directory. Use descriptive filenames and preserve reusable abnormal-case
+   code across iterations.
+4. Do not edit the submitted PR diff to construct a review case. Build or run
+   reviewer-created code from the local review directory against the exact
+   published PR head.
+5. Index every retained artifact in the retrospective with its relative path,
+   purpose, reviewed head, exact reproduction command, and result. Mark stale
+   artifacts explicitly; never treat a prior-head result as current evidence.
+6. Keep the entire review directory local and uncommitted. It is both the
+   output of the current review and an input to the next PR iteration.
 
 ## Inputs and Gate
 
@@ -70,8 +93,8 @@ evidence cannot be inspected, return `inconclusive`; never infer a pass.
 - Trace the bad case through the actual parser and state machine. Attempt an
   executable focused unit or client-to-server reproduction when the local
   environment permits it.
-- Keep exploratory code, packets, and logs under the task review directory;
-  do not modify the submitted diff.
+- Keep all abnormal-case code and supporting artifacts in the fixed local
+  review directory; do not modify the submitted diff.
 - Fail when the bad case bypasses the intended restriction or exposes an
   unhandled state. Return `inconclusive` when a material bad case cannot be
   executed or ruled out.
@@ -120,6 +143,8 @@ reviewed_base: <commit>
 reviewed_head: <commit>
 review_target: <PR URL>
 review_time_utc: <timestamp>
+review_artifact_dir: <expanded absolute review directory>
+review_artifacts: <relative paths and reviewed heads, or none>
 pre_review_result: <true|false>
 ---
 
@@ -141,6 +166,7 @@ Conclusion: <...>
 ## 3. Adversarial Bad Case
 Status: <...>
 Attempt: <constructed input or sequence and execution result>
+Artifacts: <relative paths, reviewed heads, commands, and results, or none>
 Findings: <...>
 Conclusion: <...>
 

--- a/harness/spec/PROJECT_INSTRUCTIONS.md
+++ b/harness/spec/PROJECT_INSTRUCTIONS.md
@@ -129,8 +129,8 @@ A change is complete when:
 - the complete local unit suite and both relevant case tests pass;
 - generated and temporary artifacts are absent from the diff;
 - durable documentation and relative links remain accurate;
-- the task-scoped five-part pre-review report remains uncommitted and
-  passes; and
+- the PR-scoped five-part pre-review report passes, and its local review
+  workspace remains uncommitted and reusable for the next iteration; and
 - the pull request contains the evidence required by
   [pull-requests.md](pull-requests.md).
 

--- a/harness/spec/pull-requests.md
+++ b/harness/spec/pull-requests.md
@@ -102,9 +102,11 @@ Submit a new code PR as draft after local validation. Then run the
 [`xquic-pr-pre-review` skill](../skills/xquic-pr-pre-review/SKILL.md) against
 the published PR's exact base and head. Require `pre_review_result: true` from
 all five sections before ready-for-review state, and keep
-`build/harness/pr-<number>/pre-review.md` uncommitted. The local report is a
-gate input; do not copy it into the concise PR body. A changed published head
-invalidates the report and must be reviewed again.
+`~/build/harness/pr-review-<number>/pr-review-<number>.md` and every sibling
+abnormal-case artifact local and uncommitted. The review directory is a gate
+input and a reusable input to the next iteration; do not copy it into the
+concise PR body. A changed published head invalidates the report, and retained
+cases must be rerun against the new head.
 
 ## Scope Rules
 


### PR DESCRIPTION
### Mechanism

Store each pull request's current five-part pre-review retrospective at the
fixed local path
`~/build/harness/pr-review-<number>/pr-review-<number>.md`.
Keep reviewer-built abnormal-case code and supporting artifacts in the same
directory, index them from the retrospective, and rerun retained cases against
each newly published head before treating them as current evidence.

- RFC or draft: `Not applicable`

### Validation Cases

- `Not applicable` — harness documentation and skill behavior only; validated
  skill structure, registration, links, formatting, and fixed-path syntax.

### CONTRIBUTING.md

- Overall: `Pending`
- Local regression: `Complete`
- CI: `Pending — required checks await draft PR publication`
