### PR TITLE
[~]: Validate HTTP/3 single-varint frame lengths

### DIFF
--- a/harness/spec/validation.md
+++ b/harness/spec/validation.md
@@ -81,7 +81,7 @@ its case is retired so later changes cannot reuse it.
 | `[705, 799]` | QUIC Transport core | None |
 | `[800, 899]` | Recovery and congestion control | None |
 | `[900, 999]` | QUIC-TLS | None |
-| `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1006` |
+| `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1008` |
 | `[1100, 1149]` | QPACK | None |
 | `[1150, 1199]` | HTTP priority | None |
 | `[1200, 1299]` | QUIC DATAGRAM | None |

--- a/scripts/case_test.sh
+++ b/scripts/case_test.sh
@@ -5458,4 +5458,54 @@ fi
 
 killall test_server 2> /dev/null
 
+
+## RFC 9114 Section 7.1 single-varint frame payload lengths
+
+clear_log
+rm -f test_session xqc_token tp_localhost h3_frame_length_server.log
+${SERVER_BIN} -l d -e -x 1007 > h3_frame_length_server.log &
+sleep 1
+echo -e "HTTP/3 non-minimal MAX_PUSH_ID length is accepted ...\c"
+${CLIENT_BIN} -s 1024 -l d -t 1 -E -x 1007 > stdlog
+sent=`grep "\\[h3-frame-length-test\\]|declared:2|actual:2|write:0|send:0|" \
+    stdlog`
+received=`grep "|H3_MAX_PUSH_ID|max_push_id:1|" slog`
+server_ok=`grep "\\[h3-frame-length-test\\]|case:1007|conn_err:0|" \
+    h3_frame_length_server.log`
+result=`grep ">>>>>>>> pass:1" stdlog`
+if [ -n "$sent" ] && [ -n "$received" ] && [ -n "$server_ok" ] \
+    && [ -n "$result" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "h3_non_minimal_max_push_id_accepted" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "h3_non_minimal_max_push_id_accepted" "fail"
+fi
+
+killall test_server 2> /dev/null
+clear_log
+rm -f test_session xqc_token tp_localhost h3_frame_length_server.log
+${SERVER_BIN} -l d -e -x 1008 > h3_frame_length_server.log &
+sleep 1
+echo -e "HTTP/3 overlong MAX_PUSH_ID gets H3_FRAME_ERROR ...\c"
+${CLIENT_BIN} -s 1024 -l d -t 1 -E -x 1008 > stdlog
+sent=`grep "\\[h3-frame-length-test\\]|declared:5|actual:2|write:0|send:0|" \
+    stdlog`
+server_err=`grep "\\[h3-frame-length-test\\]|case:1008|conn_err:262|" \
+    h3_frame_length_server.log`
+wire_err=`grep "err:0x106" slog`
+client_err=`grep -E "(conn errno:262|conn_err:262)" stdlog`
+applied=`grep "|H3_MAX_PUSH_ID|max_push_id:1|" slog`
+if [ -n "$sent" ] && [ -n "$server_err" ] && [ -n "$wire_err" ] \
+    && [ -n "$client_err" ] && [ -z "$applied" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "h3_overlong_max_push_id_rejected" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "h3_overlong_max_push_id_rejected" "fail"
+fi
+
+killall test_server 2> /dev/null
+rm -f h3_frame_length_server.log
+
 cd -

--- a/src/http3/frame/xqc_h3_frame.c
+++ b/src/http3/frame/xqc_h3_frame.c
@@ -25,6 +25,36 @@
         sz -= nread;                                   \
     } while(0)
 
+static ssize_t xqc_h3_frm_parse_single_vint_payload(
+    const unsigned char *p, size_t sz, xqc_discrete_int_pctx_t *vint,
+    xqc_h3_frame_t *frame, xqc_bool_t *fin);
+
+
+static ssize_t
+xqc_h3_frm_parse_single_vint_payload(const unsigned char *p, size_t sz,
+    xqc_discrete_int_pctx_t *vint, xqc_h3_frame_t *frame, xqc_bool_t *fin)
+{
+    ssize_t nread = xqc_discrete_vint_parse(p, sz, vint, fin);
+    if (nread < 0) {
+        return -XQC_H3_DECODE_ERROR;
+    }
+
+    /*
+     * RFC 9114 Section 7.1 requires the payload to contain exactly its
+     * identified fields. Track encoded bytes because RFC 9000 Section 16
+     * permits a varint to use more than its minimum encoding length.
+     */
+    frame->consumed_len += nread;
+    if (frame->consumed_len > frame->len
+        || (*fin && frame->consumed_len != frame->len))
+    {
+        return -XQC_H3_DECODE_ERROR;
+    }
+
+    return nread;
+}
+
+
 void
 xqc_h3_frm_reset_pctx(xqc_h3_frame_pctx_t *pctx)
 {
@@ -59,11 +89,9 @@ xqc_h3_frm_reset_pctx(xqc_h3_frame_pctx_t *pctx)
 ssize_t
 xqc_h3_frm_parse_cancel_push(const unsigned char *p, size_t sz, xqc_h3_frame_t *frame, xqc_bool_t *fin)
 {
-    const unsigned char *pos = p;
-    *fin = XQC_FALSE;
     xqc_h3_frame_cancel_push_t *cancel_push = &frame->frame_payload.cancel_push;
-    XQC_H3_DECODE_DISCRETE_VINT_VALUE(pos, sz, cancel_push->push_id, fin);
-    return pos -p;
+    return xqc_h3_frm_parse_single_vint_payload(p, sz,
+        &cancel_push->push_id, frame, fin);
 }
 
 ssize_t
@@ -144,21 +172,17 @@ xqc_h3_frm_parse_push_promise(const unsigned char *p, size_t sz, xqc_h3_frame_t 
 ssize_t
 xqc_h3_frm_parse_goaway(const unsigned char *p, size_t sz, xqc_h3_frame_t *frame, xqc_bool_t *fin)
 {
-    const unsigned char *pos = p;
-    *fin = XQC_FALSE;
     xqc_h3_frame_goaway_t *goaway = &frame->frame_payload.goaway;
-    XQC_H3_DECODE_DISCRETE_VINT_VALUE(pos, sz, goaway->stream_id, fin);
-    return pos -p;
+    return xqc_h3_frm_parse_single_vint_payload(p, sz,
+        &goaway->stream_id, frame, fin);
 }
 
 ssize_t
 xqc_h3_frm_parse_max_push_id(const unsigned char *p, size_t sz, xqc_h3_frame_t *frame, xqc_bool_t *fin)
 {
-    const unsigned char *pos = p;
-    *fin = XQC_FALSE;
     xqc_h3_frame_max_push_id_t *max_push_id = &frame->frame_payload.max_push_id;
-    XQC_H3_DECODE_DISCRETE_VINT_VALUE(pos, sz, max_push_id->push_id, fin);
-    return pos - p;
+    return xqc_h3_frm_parse_single_vint_payload(p, sz,
+        &max_push_id->push_id, frame, fin);
 }
 
 ssize_t

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -73,6 +73,8 @@ printf_null(const char *format, ...)
 #define XQC_TEST_CASE_H3_MAX_PUSH_ID_WRONG_ROLE 1004
 #define XQC_TEST_CASE_H3_MAX_PUSH_ID_VALID 1005
 #define XQC_TEST_CASE_H3_MAX_PUSH_ID_DECREASE 1006
+#define XQC_TEST_CASE_H3_SINGLE_VINT_VALID 1007
+#define XQC_TEST_CASE_H3_SINGLE_VINT_OVERLONG 1008
 
 typedef struct user_conn_s user_conn_t;
 
@@ -82,6 +84,8 @@ static xqc_int_t xqc_client_send_test_request_frame(
     xqc_h3_request_t *h3_request, uint64_t frame_type);
 static void xqc_client_send_test_max_push_ids(xqc_h3_conn_t *h3_conn,
     uint64_t first, uint64_t second);
+static void xqc_client_send_test_single_vint_frame(
+    xqc_h3_conn_t *h3_conn, xqc_bool_t overlong);
 
 
 #define XQC_TEST_DGRAM_BATCH_SZ 32
@@ -1950,6 +1954,12 @@ xqc_client_h3_conn_handshake_finished(xqc_h3_conn_t *h3_conn, void *user_data)
 
     } else if (g_test_case == XQC_TEST_CASE_H3_MAX_PUSH_ID_DECREASE) {
         xqc_client_send_test_max_push_ids(h3_conn, 3, 1);
+
+    } else if (g_test_case == XQC_TEST_CASE_H3_SINGLE_VINT_VALID) {
+        xqc_client_send_test_single_vint_frame(h3_conn, XQC_FALSE);
+
+    } else if (g_test_case == XQC_TEST_CASE_H3_SINGLE_VINT_OVERLONG) {
+        xqc_client_send_test_single_vint_frame(h3_conn, XQC_TRUE);
     }
 
     if (g_test_case == 200 || g_test_case == 201) {
@@ -2033,6 +2043,45 @@ xqc_client_send_test_max_push_ids(xqc_h3_conn_t *h3_conn,
     printf("[h3-max-push-id-test]|first:%" PRIu64 "|second:%" PRIu64
            "|write:%d,%d|send:%d|\n",
            first, second, first_ret, second_ret, send_ret);
+}
+
+
+static void
+xqc_client_send_test_single_vint_frame(xqc_h3_conn_t *h3_conn,
+    xqc_bool_t overlong)
+{
+    const unsigned char valid[] = {
+        XQC_H3_FRM_MAX_PUSH_ID, 0x02, 0x40, 0x01
+    };
+    const unsigned char invalid[] = {
+        XQC_H3_FRM_MAX_PUSH_ID, 0x05, 0x40, 0x01, 0x21, 0x01, 0x00
+    };
+    const unsigned char *frame = overlong ? invalid : valid;
+    size_t frame_len = overlong ? sizeof(invalid) : sizeof(valid);
+    xqc_h3_stream_t *control = h3_conn->control_stream_out;
+    xqc_var_buf_t *buf = xqc_var_buf_create(frame_len);
+    xqc_int_t write_ret = -XQC_EMALLOC;
+    xqc_int_t send_ret = XQC_ERROR;
+
+    if (buf != NULL) {
+        write_ret = xqc_var_buf_save_data(buf, frame, frame_len);
+        if (write_ret == XQC_OK) {
+            write_ret = xqc_list_buf_to_tail(&control->send_buf, buf);
+        }
+
+        if (write_ret != XQC_OK) {
+            xqc_var_buf_free(buf);
+
+        } else {
+            send_ret = xqc_h3_stream_send_buffer(control);
+            if (send_ret == -XQC_EAGAIN) {
+                send_ret = XQC_OK;
+            }
+        }
+    }
+
+    printf("[h3-frame-length-test]|declared:%d|actual:2|write:%d"
+           "|send:%d|\n", frame[1], write_ret, send_ret);
 }
 
 

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -57,6 +57,8 @@ printf_null(const char *format, ...)
 #define XQC_TEST_CASE_H3_RESERVED_REQUEST_FRAME 1002
 #define XQC_TEST_CASE_H3_CLIENT_PUSH_PROMISE 1003
 #define XQC_TEST_CASE_H3_MAX_PUSH_ID_WRONG_ROLE 1004
+#define XQC_TEST_CASE_H3_SINGLE_VINT_VALID 1007
+#define XQC_TEST_CASE_H3_SINGLE_VINT_OVERLONG 1008
 
 extern long xqc_random(void);
 extern xqc_usec_t xqc_now();
@@ -975,6 +977,13 @@ xqc_server_h3_conn_close_notify(xqc_h3_conn_t *h3_conn, const xqc_cid_t *cid, vo
     } else if (g_test_case == XQC_TEST_CASE_H3_CLIENT_PUSH_PROMISE) {
         printf("[h3-request-frame-test]|push-promise|conn_err:%d|\n",
                stats.conn_err);
+        fflush(stdout);
+
+    } else if (g_test_case == XQC_TEST_CASE_H3_SINGLE_VINT_VALID
+               || g_test_case == XQC_TEST_CASE_H3_SINGLE_VINT_OVERLONG)
+    {
+        printf("[h3-frame-length-test]|case:%d|conn_err:%d|\n",
+               g_test_case, stats.conn_err);
         fflush(stdout);
     }
 

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -135,6 +135,11 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite, "xqc_test_new_conn_id_active_limit_exceeded",
                         xqc_test_new_conn_id_active_limit_exceeded)
         || !CU_add_test(pSuite, "xqc_test_h3_frame", xqc_test_frame)
+        || !CU_add_test(pSuite, "xqc_test_h3_single_vint_frame_valid",
+                        xqc_test_h3_single_vint_frame_valid)
+        || !CU_add_test(pSuite,
+                        "xqc_test_h3_single_vint_frame_length_error",
+                        xqc_test_h3_single_vint_frame_length_error)
         || !CU_add_test(pSuite, "xqc_test_tls", xqc_test_tls)
         || !CU_add_test(pSuite, "xqc_test_h3_stream", xqc_test_stream)
         || !CU_add_test(pSuite, "xqc_test_h3_critical_stream_close", xqc_test_h3_critical_stream_close)

--- a/tests/unittest/xqc_h3_test.c
+++ b/tests/unittest/xqc_h3_test.c
@@ -176,6 +176,91 @@ xqc_test_frame()
     xqc_var_buf_free(buf);
 }
 
+
+void
+xqc_test_h3_single_vint_frame_valid()
+{
+    const unsigned char frames[][4] = {
+        { XQC_H3_FRM_CANCEL_PUSH, 0x02, 0x40, 0x01 },
+        { XQC_H3_FRM_GOAWAY, 0x02, 0x40, 0x04 },
+        { XQC_H3_FRM_MAX_PUSH_ID, 0x02, 0x40, 0x01 },
+    };
+    const uint64_t types[] = {
+        XQC_H3_FRM_CANCEL_PUSH,
+        XQC_H3_FRM_GOAWAY,
+        XQC_H3_FRM_MAX_PUSH_ID,
+    };
+
+    for (size_t i = 0; i < sizeof(frames) / sizeof(frames[0]); i++) {
+        xqc_h3_frame_pctx_t pctx;
+        memset(&pctx, 0, sizeof(pctx));
+
+        ssize_t processed = xqc_h3_frm_parse(frames[i], 3, &pctx);
+        CU_ASSERT(processed == 3);
+        CU_ASSERT(pctx.state == XQC_H3_FRM_STATE_PAYLOAD);
+        CU_ASSERT(pctx.frame.consumed_len == 1);
+
+        processed = xqc_h3_frm_parse(frames[i] + 3, 1, &pctx);
+        CU_ASSERT(processed == 1);
+        CU_ASSERT(pctx.state == XQC_H3_FRM_STATE_END);
+        CU_ASSERT(pctx.frame.type == types[i]);
+        CU_ASSERT(pctx.frame.len == 2);
+        CU_ASSERT(pctx.frame.consumed_len == 2);
+
+        xqc_h3_frm_reset_pctx(&pctx);
+    }
+}
+
+
+void
+xqc_test_h3_single_vint_frame_length_error()
+{
+    const unsigned char overlong[][7] = {
+        { XQC_H3_FRM_CANCEL_PUSH, 0x05, 0x40, 0x01, 0x21, 0x01, 0x00 },
+        { XQC_H3_FRM_GOAWAY, 0x05, 0x40, 0x04, 0x21, 0x01, 0x00 },
+        { XQC_H3_FRM_MAX_PUSH_ID, 0x05, 0x40, 0x01, 0x21, 0x01, 0x00 },
+    };
+    const unsigned char short_payload[][4] = {
+        { XQC_H3_FRM_CANCEL_PUSH, 0x01, 0x40, 0x01 },
+        { XQC_H3_FRM_GOAWAY, 0x01, 0x40, 0x04 },
+        { XQC_H3_FRM_MAX_PUSH_ID, 0x01, 0x40, 0x01 },
+    };
+
+    for (size_t i = 0; i < sizeof(overlong) / sizeof(overlong[0]); i++) {
+        xqc_h3_frame_pctx_t pctx;
+        memset(&pctx, 0, sizeof(pctx));
+
+        ssize_t processed = xqc_h3_frm_parse(overlong[i], 3, &pctx);
+        CU_ASSERT(processed == 3);
+        CU_ASSERT(pctx.state == XQC_H3_FRM_STATE_PAYLOAD);
+        CU_ASSERT(pctx.frame.consumed_len == 1);
+
+        processed = xqc_h3_frm_parse(overlong[i] + 3,
+                                     sizeof(overlong[i]) - 3, &pctx);
+        CU_ASSERT(processed == -XQC_H3_DECODE_ERROR);
+        CU_ASSERT(pctx.state == XQC_H3_FRM_STATE_PAYLOAD);
+        CU_ASSERT(pctx.frame.consumed_len == 2);
+
+        xqc_h3_frm_reset_pctx(&pctx);
+    }
+
+    for (size_t i = 0;
+         i < sizeof(short_payload) / sizeof(short_payload[0]); i++)
+    {
+        xqc_h3_frame_pctx_t pctx;
+        memset(&pctx, 0, sizeof(pctx));
+
+        ssize_t processed = xqc_h3_frm_parse(short_payload[i],
+                                             sizeof(short_payload[i]), &pctx);
+        CU_ASSERT(processed == -XQC_H3_DECODE_ERROR);
+        CU_ASSERT(pctx.state == XQC_H3_FRM_STATE_PAYLOAD);
+        CU_ASSERT(pctx.frame.consumed_len == 2);
+
+        xqc_h3_frm_reset_pctx(&pctx);
+    }
+}
+
+
 void
 xqc_test_ins()
 {

--- a/tests/unittest/xqc_h3_test.h
+++ b/tests/unittest/xqc_h3_test.h
@@ -6,6 +6,8 @@
 #define XQUIC_XQC_H3_TEST_H
 
 void xqc_test_frame();
+void xqc_test_h3_single_vint_frame_valid();
+void xqc_test_h3_single_vint_frame_length_error();
 void xqc_test_stream();
 void xqc_test_ins();
 void xqc_test_rep();


### PR DESCRIPTION
### Mechanism

Track the encoded payload bytes consumed by `CANCEL_PUSH`, `GOAWAY`, and
`MAX_PUSH_ID`, and reject the frame unless its single varint occupies exactly
the declared payload length. This enforces RFC 9114 Section 7.1 while
preserving the non-minimal varint encodings permitted by RFC 9000 Section 16.

Fixes: #847

- RFC or draft: RFC 9114 Section 7.1; RFC 9000 Section 16

### Validation Cases

- 1007 — accepts a non-minimal two-byte `MAX_PUSH_ID` varint with an exact payload length
- 1008 — rejects trailing payload bytes with `H3_FRAME_ERROR` before applying `MAX_PUSH_ID`

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Complete
- CI: Pending — Build on Ubuntu, Build on macOS, CodeQL Analyze
