### PR TITLE
[~]: Preserve received CONNECTION_CLOSE error namespace

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -79,6 +79,21 @@ No 0-RTT packets were sent or received.
 #### XQC_0RTT_REJECT (0x02)
 0-RTT packets were rejected.
 
+### xqc_conn_err_type_t
+Namespace of an error code received in the first CONNECTION_CLOSE frame, as
+defined by RFC 9000 Section 19.19.
+
+#### XQC_CONN_ERR_TYPE_UNKNOWN (0x00)
+No peer CONNECTION_CLOSE frame has been received.
+
+#### XQC_CONN_ERR_TYPE_TRANSPORT (0x01)
+The error code was received in a transport CONNECTION_CLOSE frame of type
+0x1c.
+
+#### XQC_CONN_ERR_TYPE_APPLICATION (0x02)
+The error code was received in an application CONNECTION_CLOSE frame of type
+0x1d.
+
 ## Types
 ### xqc_engine_t
 xquic engine, manages connections, alpn registrations, generic environmental config and callback functions. Instance of xqc_engine_t can be created by _**xqc_engine_create**_ and be destroyed by _**xqc_engine_destroy**_.
@@ -462,6 +477,13 @@ _xqc_conn_close_ will close the connection. xquic will send CONNECTION_CLOSE fra
 xqc_int_t xqc_conn_get_errno(xqc_connection_t *conn);
 ```
 Get error code of specified connection.
+
+#### xqc_conn_get_err_type
+```
+xqc_conn_err_type_t xqc_conn_get_err_type(xqc_connection_t *conn);
+```
+Get the namespace of the first error received from a peer. Pair the result
+with _**xqc_conn_get_errno**_ when the peer closed the connection.
 
 
 #### xqc_conn_get_ssl

--- a/include/xquic/xqc_errno.h
+++ b/include/xquic/xqc_errno.h
@@ -8,6 +8,18 @@
 #include <stdint.h>
 
 /**
+ * @brief namespace of an error code received in CONNECTION_CLOSE
+ */
+typedef enum {
+    /** no peer CONNECTION_CLOSE frame has been received */
+    XQC_CONN_ERR_TYPE_UNKNOWN       = 0,
+    /** error code from CONNECTION_CLOSE type 0x1c */
+    XQC_CONN_ERR_TYPE_TRANSPORT     = 1,
+    /** error code from CONNECTION_CLOSE type 0x1d */
+    XQC_CONN_ERR_TYPE_APPLICATION   = 2,
+} xqc_conn_err_type_t;
+
+/**
  * @brief QUIC Transport Protocol error codes
  */
 typedef enum {

--- a/include/xquic/xquic.h
+++ b/include/xquic/xquic.h
@@ -1881,6 +1881,16 @@ xqc_int_t xqc_conn_close_with_error(xqc_connection_t *conn, uint64_t err_code);
 XQC_EXPORT_PUBLIC_API
 xqc_int_t xqc_conn_get_errno(xqc_connection_t *conn);
 
+/**
+ * Get the namespace of an error received in the first CONNECTION_CLOSE frame.
+ *
+ * Pair this with xqc_conn_get_errno() when the connection was closed by the
+ * peer. XQC_CONN_ERR_TYPE_UNKNOWN is returned before a peer CONNECTION_CLOSE
+ * frame is received.
+ */
+XQC_EXPORT_PUBLIC_API
+xqc_conn_err_type_t xqc_conn_get_err_type(xqc_connection_t *conn);
+
 
 /**
  * Get ssl handler of specified connection
@@ -2300,4 +2310,3 @@ xqc_conn_settings_t xqc_conn_get_conn_settings_template(xqc_conn_settings_type_t
 #endif
 
 #endif /* _XQUIC_H_INCLUDED_ */
-

--- a/scripts/case_test.sh
+++ b/scripts/case_test.sh
@@ -857,7 +857,9 @@ ${CLIENT_BIN} -s 1024 -l d -t 2 -E > stdlog 2>&1
 forced_cid=`grep "\[active-cid-limit-test\]" svr_stdlog`
 conn_id_limit_err=`grep -E "(conn errno:9|conn_err:9)" stdlog`
 frame_encoding_err=`grep -E "(conn errno:7|conn_err:7)" stdlog`
-if [ -n "$forced_cid" ] && [ -n "$conn_id_limit_err" ] && [ -z "$frame_encoding_err" ]; then
+transport_type=`grep "conn_err_type:1" stdlog`
+if [ -n "$forced_cid" ] && [ -n "$conn_id_limit_err" ] \
+    && [ -z "$frame_encoding_err" ] && [ -n "$transport_type" ]; then
     echo ">>>>>>>> pass:1"
     case_print_result "active_cid_limit_exceeded" "pass"
 else
@@ -5383,8 +5385,9 @@ server_err=`grep "\\[h3-request-frame-test\\]|push-promise|conn_err:261|" \
     h3_request_frame_server.log`
 wire_err=`grep "err:0x105" slog`
 client_err=`grep -E "(conn errno:261|conn_err:261)" stdlog`
+application_type=`grep "conn_err_type:2" stdlog`
 if [ -n "$sent" ] && [ -n "$server_err" ] && [ -n "$wire_err" ] \
-    && [ -n "$client_err" ]; then
+    && [ -n "$client_err" ] && [ -n "$application_type" ]; then
     echo ">>>>>>>> pass:1"
     case_print_result "h3_client_push_promise_rejected" "pass"
 else

--- a/scripts/xquic.lds
+++ b/scripts/xquic.lds
@@ -40,6 +40,7 @@ XQUIC_VERS_1.0 {
         xqc_connect;
         xqc_conn_close;
         xqc_conn_get_errno;
+        xqc_conn_get_err_type;
         xqc_conn_get_ssl;
         xqc_conn_set_transport_user_data;
         xqc_conn_get_peer_addr;

--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -3221,6 +3221,12 @@ xqc_conn_get_errno(xqc_connection_t *conn)
     return conn->conn_err;
 }
 
+xqc_conn_err_type_t
+xqc_conn_get_err_type(xqc_connection_t *conn)
+{
+    return conn->conn_err_type;
+}
+
 void *
 xqc_conn_get_ssl(xqc_connection_t *conn)
 {

--- a/src/transport/xqc_conn.h
+++ b/src/transport/xqc_conn.h
@@ -396,6 +396,7 @@ struct xqc_connection_s {
     uint32_t                        wakeup_pq_index;
 
     uint64_t                        conn_err;
+    xqc_conn_err_type_t             conn_err_type;
     const char                     *conn_close_msg;
 
     /* for multi-path */

--- a/src/transport/xqc_frame_parser.c
+++ b/src/transport/xqc_frame_parser.c
@@ -1378,6 +1378,17 @@ xqc_parse_conn_close_frame(xqc_packet_in_t *packet_in, uint64_t *err_code, xqc_c
 
     packet_in->pi_frame_types |= XQC_FRAME_BIT_CONNECTION_CLOSE;
 
+    /*
+     * RFC 9000 Section 19.19: the frame type selects the error-code
+     * namespace. Preserve it because transport CRYPTO_ERROR values overlap
+     * application error-code ranges.
+     */
+    if (conn->conn_err_type == XQC_CONN_ERR_TYPE_UNKNOWN) {
+        conn->conn_err_type = first_byte == 0x1c
+                              ? XQC_CONN_ERR_TYPE_TRANSPORT
+                              : XQC_CONN_ERR_TYPE_APPLICATION;
+    }
+
     xqc_log_event(conn->log, TRA_FRAMES_PROCESSED, XQC_FRAME_CONNECTION_CLOSE, *err_code);
     return XQC_OK;
 }

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -1863,7 +1863,10 @@ xqc_client_h3_conn_close_notify(xqc_h3_conn_t *conn, const xqc_cid_t *cid, void 
     DEBUG;
 
     user_conn_t *user_conn = (user_conn_t *) user_data;
+    xqc_connection_t *transport_conn = xqc_h3_conn_get_xqc_conn(conn);
     printf("conn errno:%d\n", xqc_h3_conn_get_errno(conn));
+    printf("conn_err_type:%d\n",
+           (int)xqc_conn_get_err_type(transport_conn));
     client_ctx_t *p_ctx;
     if (g_test_qch_mode) {
         p_ctx = user_conn->ctx;

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -134,6 +134,11 @@ main(int argc, char *argv[])
                         xqc_test_new_conn_id_active_limit_accept)
         || !CU_add_test(pSuite, "xqc_test_new_conn_id_active_limit_exceeded",
                         xqc_test_new_conn_id_active_limit_exceeded)
+        || !CU_add_test(pSuite, "xqc_test_conn_close_application_error_type",
+                        xqc_test_conn_close_application_error_type)
+        || !CU_add_test(pSuite,
+                        "xqc_test_conn_close_transport_error_type_overlap",
+                        xqc_test_conn_close_transport_error_type_overlap)
         || !CU_add_test(pSuite, "xqc_test_h3_frame", xqc_test_frame)
         || !CU_add_test(pSuite, "xqc_test_tls", xqc_test_tls)
         || !CU_add_test(pSuite, "xqc_test_h3_stream", xqc_test_stream)

--- a/tests/unittest/xqc_process_frame_test.c
+++ b/tests/unittest/xqc_process_frame_test.c
@@ -17,6 +17,9 @@ char XQC_TEST_ILL_FRAME_1[] = {0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 char XQC_TEST_ZERO_LEN_NEW_TOKEN_FRAME[] = {0x07, 0x00};
 char XQC_TEST_STREAM_FRAME[] = {0x0a, 0x00, 0x01, 0x00};
 
+static void xqc_test_conn_close_error_type(unsigned char *frame,
+    size_t frame_len, xqc_conn_err_type_t expected_type);
+
 
 static xqc_int_t
 xqc_test_parse_stream_frame_inner(unsigned char *frame_buf,
@@ -96,6 +99,92 @@ xqc_test_parse_padding_frame()
     CU_ASSERT(pi_padding_mix.pi_frame_types == (XQC_FRAME_BIT_PADDING | XQC_FRAME_BIT_MAX_DATA));
 
     xqc_engine_destroy(conn->engine);
+}
+
+static void
+xqc_test_conn_close_error_type(unsigned char *frame, size_t frame_len,
+    xqc_conn_err_type_t expected_type)
+{
+    unsigned char application_frame[] = {
+        0x1d, 0x41, 0x02, 0x00
+    };
+    unsigned char transport_frame[] = {
+        0x1c, 0x41, 0x02, 0x01, 0x00
+    };
+    xqc_connection_t *conn;
+    xqc_packet_in_t packet_in;
+    unsigned char *second_frame;
+    size_t second_frame_len;
+    uint64_t err_code;
+    xqc_int_t ret;
+
+    conn = test_engine_connect();
+    CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+
+    memset(&packet_in, 0, sizeof(packet_in));
+    packet_in.pos = frame;
+    packet_in.last = frame + frame_len;
+
+    CU_ASSERT(xqc_conn_get_err_type(conn) == XQC_CONN_ERR_TYPE_UNKNOWN);
+
+    ret = xqc_parse_conn_close_frame(&packet_in, &err_code, conn);
+
+    CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(err_code == H3_INTERNAL_ERROR);
+    CU_ASSERT(packet_in.pos == packet_in.last);
+    CU_ASSERT(xqc_conn_get_err_type(conn) == expected_type);
+
+    /*
+     * CONNECTION_CLOSE can be retransmitted. Preserve the namespace of the
+     * first received frame so it remains aligned with first-write-wins error
+     * reporting.
+     */
+    if (expected_type == XQC_CONN_ERR_TYPE_APPLICATION) {
+        second_frame = transport_frame;
+        second_frame_len = sizeof(transport_frame);
+
+    } else {
+        second_frame = application_frame;
+        second_frame_len = sizeof(application_frame);
+    }
+
+    memset(&packet_in, 0, sizeof(packet_in));
+    packet_in.pos = second_frame;
+    packet_in.last = second_frame + second_frame_len;
+    ret = xqc_parse_conn_close_frame(&packet_in, &err_code, conn);
+
+    CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(packet_in.pos == packet_in.last);
+    CU_ASSERT(xqc_conn_get_err_type(conn) == expected_type);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+void
+xqc_test_conn_close_application_error_type(void)
+{
+    unsigned char frame[] = {
+        0x1d, 0x41, 0x02, 0x00
+    };
+
+    xqc_test_conn_close_error_type(frame, sizeof(frame),
+                                   XQC_CONN_ERR_TYPE_APPLICATION);
+}
+
+void
+xqc_test_conn_close_transport_error_type_overlap(void)
+{
+    unsigned char frame[] = {
+        0x1c, 0x41, 0x02, 0x01, 0x00
+    };
+
+    /*
+     * 0x102 is both a transport CRYPTO_ERROR value and
+     * H3_INTERNAL_ERROR. The 0x1c frame type is the only reliable
+     * discriminator.
+     */
+    xqc_test_conn_close_error_type(frame, sizeof(frame),
+                                   XQC_CONN_ERR_TYPE_TRANSPORT);
 }
 
 

--- a/tests/unittest/xqc_process_frame_test.h
+++ b/tests/unittest/xqc_process_frame_test.h
@@ -39,4 +39,8 @@ void xqc_test_new_conn_id_active_limit_accept(void);
 
 void xqc_test_new_conn_id_active_limit_exceeded(void);
 
+void xqc_test_conn_close_application_error_type(void);
+
+void xqc_test_conn_close_transport_error_type_overlap(void);
+
 #endif /* _XQC_PROCESS_FRAME_TEST_H_INCLUDED_ */


### PR DESCRIPTION
### Mechanism

- RFC or draft: [RFC 9000 Section 19.19](https://www.rfc-editor.org/rfc/rfc9000.html#section-19.19)
- Preserve the frame-selected error namespace from the first peer
  `CONNECTION_CLOSE`, expose it through `xqc_conn_get_err_type()`, and leave
  the existing numeric connection error unchanged.

Fixes: #846

### Validation Cases

- 704 — Transport close retains the transport namespace for an overlapping
  numeric error.
- 1003 — HTTP/3 rejection retains the application error namespace.

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Complete
- CI: Pending — Build on Ubuntu (ubuntu-latest), Build on macOS
  (macos-latest), Analyze
