### PR TITLE
[~]: Reject invalid HTTP/3 CANCEL_PUSH IDs

### DIFF
--- a/include/xquic/xqc_errno.h
+++ b/include/xquic/xqc_errno.h
@@ -288,6 +288,7 @@ typedef enum {
     XQC_H3_REQUEST_FRAME_UNEXPECTED     = 835,  /**< control-only frame received on request stream (RFC 9114 §7.2) */
     XQC_H3_INVALID_MAX_PUSH_ID          = 836,  /**< RFC 9114 §7.2.7 */
     XQC_H3_EMALFORMED_HEADER            = 837,  /**< malformed HTTP/3 header field (RFC 9114 4.1.2 / 4.2) */
+    XQC_H3_INVALID_CANCEL_PUSH_ID       = 838,  /**< RFC 9114 §7.2.3 */
 
     XQC_H3_ERR_MAX,
 } xqc_h3_error_t;

--- a/scripts/case_test.sh
+++ b/scripts/case_test.sh
@@ -5512,6 +5512,58 @@ killall test_server 2> /dev/null
 rm -f h3_frame_length_server.log
 
 
+## RFC 9114 Sections 7.2.3 and 9 control-frame handling
+
+clear_log
+rm -f test_session xqc_token tp_localhost h3_control_frame_server.log
+stdbuf -oL ${SERVER_BIN} -l d -e -x 1009 > h3_control_frame_server.log &
+sleep 1
+echo -e "HTTP/3 reserved control frame remains usable ...\c"
+${CLIENT_BIN} -s 1024 -l d -t 1 -E -x 1009 > stdlog
+sent=`grep "\\[h3-control-frame-test\\]|type:0x21|write:0|send:0|" \
+    h3_control_frame_server.log`
+received=`grep "ignore unknown frame|type:21|" clog`
+client_ok=`grep "\\[h3-control-frame-test\\]|case:1009|conn_err:0|" stdlog`
+server_ok=`grep "\\[h3-control-frame-test\\]|case:1009|conn_err:0|" \
+    h3_control_frame_server.log`
+result=`grep ">>>>>>>> pass:1" stdlog`
+if [ -n "$sent" ] && [ -n "$received" ] && [ -n "$client_ok" ] \
+    && [ -n "$server_ok" ] && [ -n "$result" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "h3_reserved_control_frame_accepted" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "h3_reserved_control_frame_accepted" "fail"
+fi
+
+killall test_server 2> /dev/null
+clear_log
+rm -f test_session xqc_token tp_localhost h3_control_frame_server.log
+stdbuf -oL ${SERVER_BIN} -l d -e -x 1010 > h3_control_frame_server.log &
+sleep 1
+echo -e "HTTP/3 CANCEL_PUSH above unset maximum gets H3_ID_ERROR ...\c"
+${CLIENT_BIN} -s 1024 -l d -t 1 -E -x 1010 > stdlog
+sent=`grep "\\[h3-control-frame-test\\]|type:0x3|write:0|send:0|" \
+    h3_control_frame_server.log`
+wire_err=`grep "err:0x108" clog`
+client_err=`grep "\\[h3-control-frame-test\\]|case:1010|conn_err:264|" \
+    stdlog`
+server_err=`grep "\\[h3-control-frame-test\\]|case:1010|conn_err:264|" \
+    h3_control_frame_server.log`
+application_type=`grep "conn_err_type:2" stdlog`
+if [ -n "$sent" ] && [ -n "$wire_err" ] && [ -n "$client_err" ] \
+    && [ -n "$server_err" ] && [ -n "$application_type" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "h3_cancel_push_unset_rejected" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "h3_cancel_push_unset_rejected" "fail"
+fi
+
+killall test_server 2> /dev/null
+rm -f h3_control_frame_server.log
+
+
 ## RFC 9114 Sections 4.1.2 and 10.5.1 field-section limits
 
 clear_log

--- a/src/http3/xqc_h3_stream.c
+++ b/src/http3/xqc_h3_stream.c
@@ -772,8 +772,20 @@ xqc_h3_stream_process_control(xqc_h3_stream_t *h3s, unsigned char *data, size_t 
         if (pctx->state == XQC_H3_FRM_STATE_END) {
             switch (pctx->frame.type) {
             case XQC_H3_FRM_CANCEL_PUSH:
-                /* TODO: not implemented */
-                break;
+                /*
+                 * RFC 9114 Sections 4.6 and 7.2.3 require H3_ID_ERROR
+                 * when the push ID exceeds the allowed maximum or, at a
+                 * server, has not been mentioned in PUSH_PROMISE. XQUIC
+                 * neither sends MAX_PUSH_ID nor PUSH_PROMISE in production,
+                 * so no received CANCEL_PUSH ID is valid in either role.
+                 */
+                xqc_log(h3c->log, XQC_LOG_ERROR,
+                        "|invalid CANCEL_PUSH|push_id:%ui|",
+                        pl->cancel_push.push_id.vi);
+                xqc_h3_frm_reset_pctx(pctx);
+                XQC_H3_CONN_ERR(h3c, H3_ID_ERROR,
+                                -XQC_H3_INVALID_CANCEL_PUSH_ID);
+                return -XQC_H3_INVALID_CANCEL_PUSH_ID;
 
             case XQC_H3_FRM_SETTINGS:
                 if (h3s->h3c->flags & XQC_H3_CONN_FLAG_SETTINGS_RECVED) {

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -76,6 +76,8 @@ printf_null(const char *format, ...)
 #define XQC_TEST_CASE_H3_MAX_PUSH_ID_DECREASE 1006
 #define XQC_TEST_CASE_H3_SINGLE_VINT_VALID 1007
 #define XQC_TEST_CASE_H3_SINGLE_VINT_OVERLONG 1008
+#define XQC_TEST_CASE_H3_RESERVED_CONTROL_FRAME 1009
+#define XQC_TEST_CASE_H3_CANCEL_PUSH_UNSET 1010
 #define XQC_TEST_CASE_H3_FIELD_SECTION_VALID 1011
 #define XQC_TEST_CASE_H3_FIELD_SECTION_OVER_LIMIT 1012
 #define XQC_TEST_CASE_H3_LOWERCASE_RESPONSE 1013
@@ -1897,6 +1899,12 @@ xqc_client_h3_conn_close_notify(xqc_h3_conn_t *conn, const xqc_cid_t *cid, void 
         printf("[h3-field-section-test]|client_conn_close|case:%d|"
                "conn_err:%d|\n", g_test_case, stats.conn_err);
         fflush(stdout);
+
+    } else if (g_test_case == XQC_TEST_CASE_H3_RESERVED_CONTROL_FRAME
+        || g_test_case == XQC_TEST_CASE_H3_CANCEL_PUSH_UNSET)
+    {
+        printf("[h3-control-frame-test]|case:%d|conn_err:%d|\n",
+               g_test_case, stats.conn_err);
     }
 
     if (!g_test_qch_mode) {

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -60,6 +60,8 @@ printf_null(const char *format, ...)
 #define XQC_TEST_CASE_H3_MAX_PUSH_ID_WRONG_ROLE 1004
 #define XQC_TEST_CASE_H3_SINGLE_VINT_VALID 1007
 #define XQC_TEST_CASE_H3_SINGLE_VINT_OVERLONG 1008
+#define XQC_TEST_CASE_H3_RESERVED_CONTROL_FRAME 1009
+#define XQC_TEST_CASE_H3_CANCEL_PUSH_UNSET 1010
 #define XQC_TEST_CASE_H3_FIELD_SECTION_VALID 1011
 #define XQC_TEST_CASE_H3_FIELD_SECTION_OVER_LIMIT 1012
 #define XQC_TEST_CASE_H3_LOWERCASE_RESPONSE 1013
@@ -67,6 +69,9 @@ printf_null(const char *format, ...)
 
 extern long xqc_random(void);
 extern xqc_usec_t xqc_now();
+
+static void xqc_server_send_test_control_frame(xqc_h3_conn_t *h3_conn,
+    uint64_t frame_type);
 
 
 typedef struct user_datagram_block_s {
@@ -998,6 +1003,13 @@ xqc_server_h3_conn_close_notify(xqc_h3_conn_t *h3_conn, const xqc_cid_t *cid, vo
         printf("[h3-field-section-test]|server_conn_close|case:%d|"
                "conn_err:%d|\n", g_test_case, stats.conn_err);
         fflush(stdout);
+
+    } else if (g_test_case == XQC_TEST_CASE_H3_RESERVED_CONTROL_FRAME
+               || g_test_case == XQC_TEST_CASE_H3_CANCEL_PUSH_UNSET)
+    {
+        printf("[h3-control-frame-test]|case:%d|conn_err:%d|\n",
+               g_test_case, stats.conn_err);
+        fflush(stdout);
     }
 
     printf("[h3-dgram]|recv_dgram_bytes:%zu|sent_dgram_bytes:%zu|lost_dgram_bytes:%zu|lost_cnt:%zu|\n", 
@@ -1064,6 +1076,13 @@ xqc_server_h3_conn_handshake_finished(xqc_h3_conn_t *h3_conn, void *conn_user_da
 
         printf("[h3-max-push-id-test]|server_send:1|write:%d|send:%d|\n",
                write_ret, send_ret);
+
+    } else if (g_test_case == XQC_TEST_CASE_H3_RESERVED_CONTROL_FRAME) {
+        xqc_server_send_test_control_frame(h3_conn, 0x21);
+
+    } else if (g_test_case == XQC_TEST_CASE_H3_CANCEL_PUSH_UNSET) {
+        xqc_server_send_test_control_frame(h3_conn,
+                                           XQC_H3_FRM_CANCEL_PUSH);
     }
 
     if (g_test_case == 704) {
@@ -1116,6 +1135,43 @@ xqc_server_h3_conn_handshake_finished(xqc_h3_conn_t *h3_conn, void *conn_user_da
 
     }
 
+}
+
+
+static void
+xqc_server_send_test_control_frame(xqc_h3_conn_t *h3_conn,
+    uint64_t frame_type)
+{
+    xqc_h3_stream_t *control = h3_conn->control_stream_out;
+    xqc_int_t write_ret;
+
+    if (frame_type == XQC_H3_FRM_CANCEL_PUSH) {
+        write_ret = xqc_h3_frm_write_cancel_push(&control->send_buf, 0,
+                                                 XQC_FALSE);
+
+    } else {
+        unsigned char frame[] = { 0x21, 0x01, 0x00 };
+        xqc_var_buf_t *buf = xqc_var_buf_create(sizeof(frame));
+        write_ret = -XQC_EMALLOC;
+        if (buf != NULL) {
+            write_ret = xqc_var_buf_save_data(buf, frame, sizeof(frame));
+            if (write_ret == XQC_OK) {
+                write_ret = xqc_list_buf_to_tail(&control->send_buf, buf);
+            }
+
+            if (write_ret != XQC_OK) {
+                xqc_var_buf_free(buf);
+            }
+        }
+    }
+
+    xqc_int_t send_ret = XQC_ERROR;
+    if (write_ret == XQC_OK) {
+        send_ret = xqc_h3_stream_send_buffer(control);
+    }
+
+    printf("[h3-control-frame-test]|type:0x%" PRIx64
+           "|write:%d|send:%d|\n", frame_type, write_ret, send_ret);
 }
 
 void

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -165,6 +165,11 @@ main(int argc, char *argv[])
                         xqc_test_h3_max_push_id_valid)
         || !CU_add_test(pSuite, "xqc_test_h3_max_push_id_errors",
                         xqc_test_h3_max_push_id_errors)
+        || !CU_add_test(pSuite,
+                        "xqc_test_h3_reserved_control_frame_accepted",
+                        xqc_test_h3_reserved_control_frame_accepted)
+        || !CU_add_test(pSuite, "xqc_test_h3_cancel_push_rejected",
+                        xqc_test_h3_cancel_push_rejected)
         /* RFC 9114 §4.2.2 field-section-size 32B overhead (issue 751) */
         || !CU_add_test(pSuite, "xqc_test_h3_uncompressed_fields_size", xqc_test_h3_uncompressed_fields_size)
         || !CU_add_test(pSuite, "xqc_test_h3_recv_header_field_section_size", xqc_test_h3_recv_header_field_section_size)

--- a/tests/unittest/xqc_h3_test.c
+++ b/tests/unittest/xqc_h3_test.c
@@ -1398,6 +1398,83 @@ xqc_h3_ctrl_feed_max_push_id(xqc_h3_stream_t *h3s, unsigned char push_id)
 }
 
 
+static ssize_t
+xqc_h3_ctrl_feed_cancel_push(xqc_h3_stream_t *h3s, unsigned char push_id)
+{
+    unsigned char frame[] = { XQC_H3_FRM_CANCEL_PUSH, 0x01, push_id };
+    return xqc_h3_stream_process_control(h3s, frame, sizeof(frame));
+}
+
+
+void
+xqc_test_h3_reserved_control_frame_accepted()
+{
+    xqc_connection_t *conn = NULL;
+    xqc_h3_conn_t *h3c = NULL;
+    xqc_h3_stream_t *h3s = xqc_h3_ctrl_test_setup(&conn, &h3c);
+    CU_ASSERT_FATAL(h3s != NULL);
+
+    CU_ASSERT_FATAL(xqc_h3_ctrl_feed_settings(h3s) > 0);
+
+    /*
+     * RFC 9114 Section 9: the CANCEL_PUSH rejection must remain narrow;
+     * an unknown reserved control frame is ignored.
+     */
+    unsigned char reserved[] = { 0x21, 0x01, 0x00 };
+    CU_ASSERT(xqc_h3_stream_process_control(h3s, reserved,
+              sizeof(reserved)) == sizeof(reserved));
+    CU_ASSERT(conn->conn_err == 0);
+    CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) == 0);
+
+    xqc_h3_ctrl_test_teardown(h3s, h3c, conn);
+}
+
+
+void
+xqc_test_h3_cancel_push_rejected()
+{
+    xqc_connection_t *conn = NULL;
+    xqc_h3_conn_t *h3c = NULL;
+    xqc_h3_stream_t *h3s = xqc_h3_ctrl_test_setup(&conn, &h3c);
+    CU_ASSERT_FATAL(h3s != NULL);
+
+    CU_ASSERT_FATAL(conn->conn_type == XQC_CONN_TYPE_CLIENT);
+    CU_ASSERT_FATAL(xqc_h3_ctrl_feed_settings(h3s) > 0);
+
+    /*
+     * RFC 9114 Sections 4.6 and 7.2.3: XQUIC has no production path that
+     * sends MAX_PUSH_ID, so even push ID zero exceeds the unset maximum.
+     */
+    CU_ASSERT(xqc_h3_ctrl_feed_cancel_push(h3s, 0)
+              == -XQC_H3_INVALID_CANCEL_PUSH_ID);
+    CU_ASSERT(conn->conn_err == H3_ID_ERROR);
+    CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
+
+    xqc_h3_ctrl_test_teardown(h3s, h3c, conn);
+
+    conn = NULL;
+    h3c = NULL;
+    h3s = xqc_h3_ctrl_test_setup(&conn, &h3c);
+    CU_ASSERT_FATAL(h3s != NULL);
+
+    conn->conn_type = XQC_CONN_TYPE_SERVER;
+    CU_ASSERT_FATAL(xqc_h3_ctrl_feed_settings(h3s) > 0);
+    CU_ASSERT_FATAL(xqc_h3_ctrl_feed_max_push_id(h3s, 5) == 3);
+
+    /*
+     * XQUIC never sends PUSH_PROMISE in production. A cancellation from the
+     * client is therefore for an unmentioned push ID, even when the ID is
+     * within the received MAX_PUSH_ID range.
+     */
+    CU_ASSERT(xqc_h3_ctrl_feed_cancel_push(h3s, 0)
+              == -XQC_H3_INVALID_CANCEL_PUSH_ID);
+    CU_ASSERT(conn->conn_err == H3_ID_ERROR);
+    CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
+
+    xqc_h3_ctrl_test_teardown(h3s, h3c, conn);
+}
+
+
 void
 xqc_test_h3_max_push_id_valid()
 {

--- a/tests/unittest/xqc_h3_test.h
+++ b/tests/unittest/xqc_h3_test.h
@@ -17,6 +17,8 @@ void xqc_test_h3_reserved_uni_stream_accepted();
 void xqc_test_h3_push_stream_error_codes();
 void xqc_test_h3_max_push_id_valid();
 void xqc_test_h3_max_push_id_errors();
+void xqc_test_h3_reserved_control_frame_accepted();
+void xqc_test_h3_cancel_push_rejected();
 void xqc_test_h3_uncompressed_fields_size();
 void xqc_test_h3_recv_header_field_section_size();
 


### PR DESCRIPTION
### Mechanism

- RFC or draft: [RFC 9114 §4.6](https://www.rfc-editor.org/rfc/rfc9114.html#section-4.6)
  and [§7.2.3](https://www.rfc-editor.org/rfc/rfc9114.html#section-7.2.3)
- Reject `CANCEL_PUSH` with `H3_ID_ERROR` because XQUIC has neither advertised
  a maximum push ID nor promised a push that the peer can cancel.

Fixes: #848

### Validation Cases

- `1009` — a reserved control frame is ignored and the connection remains usable
- `1010` — `CANCEL_PUSH(0)` without an advertised maximum gets `H3_ID_ERROR`

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Complete
- CI: Pending — `Analyze` and `Harness Check`
