### PR TITLE
[~]: Handle oversized H3 field sections per stream

### DIFF
--- a/harness/spec/validation.md
+++ b/harness/spec/validation.md
@@ -81,7 +81,7 @@ its case is retired so later changes cannot reuse it.
 | `[705, 799]` | QUIC Transport core | None |
 | `[800, 899]` | Recovery and congestion control | None |
 | `[900, 999]` | QUIC-TLS | None |
-| `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1008` |
+| `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1012` |
 | `[1100, 1149]` | QPACK | None |
 | `[1150, 1199]` | HTTP priority | None |
 | `[1200, 1299]` | QUIC DATAGRAM | None |

--- a/scripts/case_test.sh
+++ b/scripts/case_test.sh
@@ -1286,11 +1286,10 @@ echo "$result"
 clear_log
 echo -e "test client long header ...\c"
 ${CLIENT_BIN} -l d -x 29 >> clog
-#clog_res=`grep "xqc_process_conn_close_frame|with err:" clog`
-#slog_res=`grep "READ_VALUE error" slog`
 slog_res=`grep -a "large nv|conn" slog`
-clog_res=`grep -a "xqc_process_conn_close_frame|with err:" clog`
-if [ -n "$clog_res" ] && [ -n "$slog_res" ]; then
+stream_reset=`grep -a "xqc_parse_reset_stream_frame|" clog \
+    | grep "err_code:270"`
+if [ -n "$stream_reset" ] && [ -n "$slog_res" ]; then
     case_print_result "test_client_long_header" "pass"
 else
     case_print_result "test_client_long_header" "fail"
@@ -5510,5 +5509,66 @@ fi
 
 killall test_server 2> /dev/null
 rm -f h3_frame_length_server.log
+
+
+## RFC 9114 Sections 4.1.2 and 10.5.1 field-section limits
+
+clear_log
+rm -f test_session xqc_token tp_localhost h3_field_section_server.log
+${SERVER_BIN} -l d -e -x 1011 > h3_field_section_server.log &
+sleep 1
+echo -e "HTTP/3 fields within limit keep all request streams usable ...\c"
+${CLIENT_BIN} -s 1024 -l d -t 1 -E -P 2 -n 2 -x 1011 > stdlog
+server_limit=`grep "\\[h3-field-section-test\\]|server_limit:512|" \
+    h3_field_section_server.log`
+received_count=`grep -c "\\[h3-field-section-test\\]|request_received|" \
+    h3_field_section_server.log`
+success_count=`grep -c ">>>>>>>> pass:1" stdlog`
+server_ok=`grep "\\[h3-field-section-test\\]|server_conn_close|case:1011|"\
+"conn_err:0|" h3_field_section_server.log`
+client_ok=`grep "\\[h3-field-section-test\\]|client_conn_close|case:1011|"\
+"conn_err:0|" stdlog`
+if [ -n "$server_limit" ] && [ "$received_count" -eq 2 ] \
+    && [ "$success_count" -eq 2 ] && [ -n "$server_ok" ] \
+    && [ -n "$client_ok" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "h3_field_section_within_limit_succeeds" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "h3_field_section_within_limit_succeeds" "fail"
+fi
+
+killall test_server 2> /dev/null
+clear_log
+rm -f test_session xqc_token tp_localhost h3_field_section_server.log
+${SERVER_BIN} -l d -e -x 1012 > h3_field_section_server.log &
+sleep 1
+echo -e "HTTP/3 oversized fields reset one stream only ...\c"
+${CLIENT_BIN} -s 1024 -l d -t 1 -E -P 2 -n 2 -x 1012 > stdlog
+oversized=`grep "\\[h3-field-section-test\\]|oversized_request_sent|" stdlog`
+stream_reset=`grep "\\[h3-field-section-test\\]|server_stream_close|"\
+".*|stream_err:270|" h3_field_section_server.log`
+peer_error=`grep "\\[h3-field-section-test\\]|client_stream_closing|"\
+".*|err:270|" stdlog`
+received_count=`grep -c "\\[h3-field-section-test\\]|request_received|" \
+    h3_field_section_server.log`
+success_count=`grep -c ">>>>>>>> pass:1" stdlog`
+server_ok=`grep "\\[h3-field-section-test\\]|server_conn_close|case:1012|"\
+"conn_err:0|" h3_field_section_server.log`
+client_ok=`grep "\\[h3-field-section-test\\]|client_conn_close|case:1012|"\
+"conn_err:0|" stdlog`
+if [ -n "$oversized" ] && [ -n "$stream_reset" ] \
+    && [ -n "$peer_error" ] && [ "$received_count" -eq 1 ] \
+    && [ "$success_count" -eq 1 ] && [ -n "$server_ok" ] \
+    && [ -n "$client_ok" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "h3_field_section_over_limit_is_stream_error" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "h3_field_section_over_limit_is_stream_error" "fail"
+fi
+
+killall test_server 2> /dev/null
+rm -f h3_field_section_server.log
 
 cd -

--- a/src/http3/xqc_h3_stream.c
+++ b/src/http3/xqc_h3_stream.c
@@ -1606,12 +1606,18 @@ xqc_h3_stream_process_in(xqc_h3_stream_t *h3s, unsigned char *data, size_t data_
                 errcode = -XQC_H3_EPROC_BYTESTREAM;
             }
             
-            if (processed == -XQC_H3_INVALID_HEADER) {
-                /* RFC 9114 §4.1.2: malformed request/response headers
-                 * MUST be treated as H3_MESSAGE_ERROR, not as a generic
-                 * protocol error. This path covers QPACK decode failures
-                 * surfaced as -XQC_H3_INVALID_HEADER. */
-                XQC_H3_CONN_ERR(h3c, H3_MESSAGE_ERROR, errcode);
+            if (processed == -XQC_H3_INVALID_HEADER
+                && h3c->conn->conn_err == 0)
+            {
+                /*
+                 * RFC 9114 Section 4.1.2 requires a malformed message to
+                 * be treated as an H3_MESSAGE_ERROR stream error. Consume
+                 * the processing error after resetting this stream so the
+                 * caller does not promote it to a connection error.
+                 */
+                xqc_stream_close_with_error(h3s->stream,
+                                            H3_MESSAGE_ERROR);
+                return XQC_OK;
 
             } else {
                 XQC_H3_CONN_ERR(h3c, H3_FRAME_ERROR, errcode);

--- a/src/transport/xqc_stream.c
+++ b/src/transport/xqc_stream.c
@@ -917,12 +917,15 @@ xqc_stream_record_trans_state(xqc_stream_t *stream, xqc_bool_t begin)
 }
 
 xqc_int_t
-xqc_stream_close(xqc_stream_t *stream)
+xqc_stream_close_with_error(xqc_stream_t *stream, uint64_t err_code)
 {
     xqc_int_t ret;
     xqc_connection_t *conn = stream->stream_conn;
-    xqc_log(conn->log, XQC_LOG_DEBUG, "|stream_id:%ui|stream_state_send:%d|stream_state_recv:%d|conn:%p|conn_state:%s|",
-            stream->stream_id, stream->stream_state_send, stream->stream_state_recv, conn, xqc_conn_state_2_str(conn->conn_state));
+    xqc_log(conn->log, XQC_LOG_DEBUG, "|stream_id:%ui|"
+            "stream_state_send:%d|stream_state_recv:%d|conn:%p|"
+            "conn_state:%s|err_code:%ui|", stream->stream_id,
+            stream->stream_state_send, stream->stream_state_recv, conn,
+            xqc_conn_state_2_str(conn->conn_state), err_code);
 
     XQC_STREAM_CLOSE_MSG(stream, "local reset");
 
@@ -934,9 +937,11 @@ xqc_stream_close(xqc_stream_t *stream)
     }
 
     xqc_send_queue_drop_stream_frame_packets(conn, stream->stream_id);
-    ret = xqc_write_reset_stream_to_packet(conn, stream, H3_REQUEST_CANCELLED, stream->stream_send_offset);
+    ret = xqc_write_reset_stream_to_packet(conn, stream, err_code,
+                                           stream->stream_send_offset);
     if (ret < 0) {
-        xqc_log(conn->log, XQC_LOG_ERROR, "|xqc_write_reset_stream_to_packet error|%d|", ret);
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|xqc_write_reset_stream_to_packet error|%d|", ret);
         XQC_CONN_ERR(conn, TRA_INTERNAL_ERROR);
     }
 
@@ -945,14 +950,17 @@ xqc_stream_close(xqc_stream_t *stream)
     if (stream->stream_state_recv == XQC_RECV_STREAM_ST_RECV
         || stream->stream_state_recv == XQC_RECV_STREAM_ST_SIZE_KNOWN)
     {
-        ret = xqc_write_stop_sending_to_packet(conn, stream, H3_REQUEST_CANCELLED);
+        ret = xqc_write_stop_sending_to_packet(conn, stream, err_code);
         if (ret < 0) {
-            xqc_log(conn->log, XQC_LOG_ERROR, "|xqc_write_stop_sending_to_packet error|%d|", ret);
+            xqc_log(conn->log, XQC_LOG_ERROR,
+                    "|xqc_write_stop_sending_to_packet error|%d|", ret);
             XQC_CONN_ERR(conn, TRA_INTERNAL_ERROR);
         }
     }
 
-    stream->stream_stats.max_pto_backoff = xqc_max(stream->stream_stats.max_pto_backoff, xqc_conn_get_max_pto_backoff(conn, 1));
+    stream->stream_stats.max_pto_backoff =
+        xqc_max(stream->stream_stats.max_pto_backoff,
+                xqc_conn_get_max_pto_backoff(conn, 1));
 
     xqc_engine_remove_wakeup_queue(conn->engine, conn);
     xqc_engine_add_active_queue(conn->engine, conn);
@@ -960,6 +968,12 @@ xqc_stream_close(xqc_stream_t *stream)
     xqc_stream_shutdown_write(stream);
     xqc_engine_conn_logic(conn->engine, conn);
     return XQC_OK;
+}
+
+xqc_int_t
+xqc_stream_close(xqc_stream_t *stream)
+{
+    return xqc_stream_close_with_error(stream, H3_REQUEST_CANCELLED);
 }
 
 xqc_int_t

--- a/src/transport/xqc_stream.h
+++ b/src/transport/xqc_stream.h
@@ -230,6 +230,9 @@ void xqc_stream_record_trans_state(xqc_stream_t *stream, xqc_bool_t begin);
 
 void xqc_destroy_stream(xqc_stream_t *stream);
 
+xqc_int_t xqc_stream_close_with_error(xqc_stream_t *stream,
+    uint64_t err_code);
+
 void xqc_process_write_streams(xqc_connection_t *conn);
 
 void xqc_process_read_streams(xqc_connection_t *conn);
@@ -303,4 +306,3 @@ xqc_bool_t xqc_is_stream_finished(xqc_stream_t *stream);
 
 void xqc_record_stream_state(xqc_stream_t *stream);
 #endif /* _XQC_STREAM_H_INCLUDED_ */
-

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -75,6 +75,8 @@ printf_null(const char *format, ...)
 #define XQC_TEST_CASE_H3_MAX_PUSH_ID_DECREASE 1006
 #define XQC_TEST_CASE_H3_SINGLE_VINT_VALID 1007
 #define XQC_TEST_CASE_H3_SINGLE_VINT_OVERLONG 1008
+#define XQC_TEST_CASE_H3_FIELD_SECTION_VALID 1011
+#define XQC_TEST_CASE_H3_FIELD_SECTION_OVER_LIMIT 1012
 
 typedef struct user_conn_s user_conn_t;
 
@@ -131,6 +133,7 @@ typedef struct user_stream_s {
     int                      abnormal_count;
     int                      body_read_notify_cnt;
     int                      h3_test_frame_queued;
+    int                      h3_test_request_index;
     xqc_usec_t               last_recv_log_time;
     uint64_t                 recv_log_bytes;
 
@@ -1885,6 +1888,14 @@ xqc_client_h3_conn_close_notify(xqc_h3_conn_t *conn, const xqc_cid_t *cid, void 
     printf("send_count:%u, lost_count:%u, tlp_count:%u, recv_count:%u, srtt:%"PRIu64" early_data_flag:%d, conn_err:%d, mp_state:%d, ack_info:%s, alpn:%s, conn_info:%s\n",
            stats.send_count, stats.lost_count, stats.tlp_count, stats.recv_count, stats.srtt, stats.early_data_flag, stats.conn_err, stats.mp_state, stats.ack_info, stats.alpn, stats.conn_info);
 
+    if (g_test_case == XQC_TEST_CASE_H3_FIELD_SECTION_VALID
+        || g_test_case == XQC_TEST_CASE_H3_FIELD_SECTION_OVER_LIMIT)
+    {
+        printf("[h3-field-section-test]|client_conn_close|case:%d|"
+               "conn_err:%d|\n", g_test_case, stats.conn_err);
+        fflush(stdout);
+    }
+
     if (!g_test_qch_mode) {
         printf("[h3-dgram]|recv_dgram_bytes:%zu|sent_dgram_bytes:%zu|lost_dgram_bytes:%zu|lost_cnt:%zu|\n", 
                user_conn->dgram_blk->data_recv, user_conn->dgram_blk->data_sent,
@@ -2664,6 +2675,20 @@ xqc_client_request_send(xqc_h3_request_t *h3_request, user_stream_t *user_stream
         },
     };
 
+    if (g_test_case == XQC_TEST_CASE_H3_FIELD_SECTION_OVER_LIMIT
+        && user_stream->h3_test_request_index == 1)
+    {
+        memset(test_long_value, 'a', 1024);
+        header[header_size].name.iov_base = "x-test-large";
+        header[header_size].name.iov_len = 12;
+        header[header_size].value.iov_base = test_long_value;
+        header[header_size].value.iov_len = 1024;
+        header[header_size].flags = 0;
+        header_size++;
+        printf("[h3-field-section-test]|oversized_request_sent|"
+               "stream_id:%"PRIu64"|\n", xqc_h3_stream_id(h3_request));
+    }
+
     if (g_test_case == 47) {
         header[header_size].name.iov_base = "test_null_hdr";
         header[header_size].name.iov_len = 13;
@@ -3237,9 +3262,13 @@ xqc_client_request_close_notify(xqc_h3_request_t *h3_request, void *user_data)
            stats.mp_standby_path_send_weight, stats.mp_standby_path_recv_weight,
            stats.stream_info);
 
-    printf("retx:%u, sent:%u, max_pto:%u\n", stats.retrans_cnt, stats.sent_pkt_cnt, stats.max_pto_backoff);
+    printf("retx:%u, sent:%u, max_pto:%u\n", stats.retrans_cnt,
+           stats.sent_pkt_cnt, stats.max_pto_backoff);
 
-    if (g_echo_check) {
+    if (g_echo_check
+        && !(g_test_case == XQC_TEST_CASE_H3_FIELD_SECTION_OVER_LIMIT
+             && stats.stream_err == H3_MESSAGE_ERROR))
+    {
         int pass = 0;
         if (user_stream->recv_fin && user_stream->send_body_len == user_stream->recv_body_len
             && memcmp(user_stream->send_body, user_stream->recv_body, user_stream->send_body_len) == 0)
@@ -3284,6 +3313,12 @@ xqc_client_request_closing_notify(xqc_h3_request_t *h3_request,
     user_stream_t *user_stream = (user_stream_t *)h3s_user_data;
 
     printf("***** request closing notify triggered\n");
+    if (g_test_case == XQC_TEST_CASE_H3_FIELD_SECTION_OVER_LIMIT) {
+        printf("[h3-field-section-test]|client_stream_closing|"
+               "stream_id:%"PRIu64"|err:%d|\n",
+               xqc_h3_stream_id(h3_request), err);
+        fflush(stdout);
+    }
 }
 
 void
@@ -5483,6 +5518,7 @@ int main(int argc, char *argv[]) {
                 g_req_cnt++;
                 user_stream_t *user_stream = calloc(1, sizeof(user_stream_t));
                 user_stream->user_conn = user_conn;
+                user_stream->h3_test_request_index = g_req_cnt;
                 user_stream->last_recv_log_time = xqc_now();
                 user_stream->recv_log_bytes = 0;
                 if (user_conn->h3 == 0 || user_conn->h3 == 2) {

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -59,6 +59,8 @@ printf_null(const char *format, ...)
 #define XQC_TEST_CASE_H3_MAX_PUSH_ID_WRONG_ROLE 1004
 #define XQC_TEST_CASE_H3_SINGLE_VINT_VALID 1007
 #define XQC_TEST_CASE_H3_SINGLE_VINT_OVERLONG 1008
+#define XQC_TEST_CASE_H3_FIELD_SECTION_VALID 1011
+#define XQC_TEST_CASE_H3_FIELD_SECTION_OVER_LIMIT 1012
 
 extern long xqc_random(void);
 extern xqc_usec_t xqc_now();
@@ -985,6 +987,14 @@ xqc_server_h3_conn_close_notify(xqc_h3_conn_t *h3_conn, const xqc_cid_t *cid, vo
         printf("[h3-frame-length-test]|case:%d|conn_err:%d|\n",
                g_test_case, stats.conn_err);
         fflush(stdout);
+
+    } else if (g_test_case == XQC_TEST_CASE_H3_FIELD_SECTION_VALID
+               || g_test_case
+                  == XQC_TEST_CASE_H3_FIELD_SECTION_OVER_LIMIT)
+    {
+        printf("[h3-field-section-test]|server_conn_close|case:%d|"
+               "conn_err:%d|\n", g_test_case, stats.conn_err);
+        fflush(stdout);
     }
 
     printf("[h3-dgram]|recv_dgram_bytes:%zu|sent_dgram_bytes:%zu|lost_dgram_bytes:%zu|lost_cnt:%zu|\n", 
@@ -1030,6 +1040,13 @@ xqc_server_h3_conn_handshake_finished(xqc_h3_conn_t *h3_conn, void *conn_user_da
     printf("0rtt_flag:%d\n", stats.early_data_flag);
     printf("h3_datagram_mss:%zd\n", xqc_h3_ext_datagram_get_mss(h3_conn));
 
+    if (g_test_case == XQC_TEST_CASE_H3_FIELD_SECTION_VALID
+        || g_test_case == XQC_TEST_CASE_H3_FIELD_SECTION_OVER_LIMIT)
+    {
+        printf("[h3-field-section-test]|server_limit:%"PRIu64"|\n",
+               h3_conn->local_h3_conn_settings.max_field_section_size);
+        fflush(stdout);
+    }
 
     if (g_test_case == 48) {
         printf("[initial-salt-test] server handshake ok, conn_err:%d\n",
@@ -1428,6 +1445,17 @@ xqc_server_request_close_notify(xqc_h3_request_t *h3_request, void *user_data)
     DEBUG;
     user_stream_t *user_stream = (user_stream_t*)user_data;
 
+    if (g_test_case == XQC_TEST_CASE_H3_FIELD_SECTION_VALID
+        || g_test_case == XQC_TEST_CASE_H3_FIELD_SECTION_OVER_LIMIT)
+    {
+        xqc_request_stats_t stats =
+            xqc_h3_request_get_stats(h3_request);
+        printf("[h3-field-section-test]|server_stream_close|"
+               "stream_id:%"PRIu64"|stream_err:%d|\n",
+               xqc_h3_stream_id(h3_request), stats.stream_err);
+        fflush(stdout);
+    }
+
     if (g_test_case == 100) {
         if (user_stream->ev_timeout) {
             event_free(user_stream->ev_timeout);
@@ -1489,6 +1517,15 @@ xqc_server_request_read_notify(xqc_h3_request_t *h3_request, xqc_request_notify_
         }
 
         user_stream->header_recvd++;
+
+        if (g_test_case == XQC_TEST_CASE_H3_FIELD_SECTION_VALID
+            || g_test_case == XQC_TEST_CASE_H3_FIELD_SECTION_OVER_LIMIT)
+        {
+            printf("[h3-field-section-test]|request_received|"
+                   "stream_id:%"PRIu64"|\n",
+                   xqc_h3_stream_id(h3_request));
+            fflush(stdout);
+        }
 
         if (fin) {
             /* only header. request received, start processing business logic. */
@@ -2889,6 +2926,12 @@ int main(int argc, char *argv[]) {
 
     if (g_test_case == 10) {
         xqc_h3_engine_set_max_field_section_size(ctx.engine, 10000000);
+    }
+
+    if (g_test_case == XQC_TEST_CASE_H3_FIELD_SECTION_VALID
+        || g_test_case == XQC_TEST_CASE_H3_FIELD_SECTION_OVER_LIMIT)
+    {
+        xqc_h3_engine_set_max_field_section_size(ctx.engine, 512);
     }
 
     /* for lb cid generate */

--- a/tests/unittest/xqc_h3_test.c
+++ b/tests/unittest/xqc_h3_test.c
@@ -1174,11 +1174,17 @@ xqc_test_h3_malformed_headers_uses_message_error()
     xqc_int_t ret = xqc_h3_stream_process_in(h3s, buf, sizeof(buf),
             XQC_TRUE);
 
-    /* process_in collapses sub-errors to -XQC_H3_EPROC_REQUEST */
-    CU_ASSERT(ret == -XQC_H3_EPROC_REQUEST);
-    CU_ASSERT(conn->conn_err == H3_MESSAGE_ERROR);
-    CU_ASSERT(conn->conn_err == 0x10E);
-    CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
+    /*
+     * RFC 9114 Section 4.1.2 makes this a stream error. process_in
+     * consumes the handled parse failure after scheduling RESET_STREAM.
+     */
+    CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(h3s->stream->stream_err == H3_MESSAGE_ERROR);
+    CU_ASSERT(h3s->stream->stream_err == 0x10E);
+    CU_ASSERT(h3s->stream->stream_state_send
+              == XQC_SEND_STREAM_ST_RESET_SENT);
+    CU_ASSERT(conn->conn_err == 0);
+    CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) == 0);
 
     xqc_h3_msgerr_teardown(h3s, h3c, conn);
 }
@@ -1244,6 +1250,9 @@ xqc_test_h3_valid_headers_smoke()
     CU_ASSERT(ret == XQC_OK);
     CU_ASSERT(conn->conn_err == 0);
     CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) == 0);
+    CU_ASSERT(h3s->stream->stream_err == 0);
+    CU_ASSERT(h3s->stream->stream_state_send
+              < XQC_SEND_STREAM_ST_RESET_SENT);
     /* the HEADERS frame should have advanced the request to 1 section */
     CU_ASSERT(h3s->h3r->current_header == 1);
 


### PR DESCRIPTION
### Mechanism

- RFC 9114 Sections 4.1.2, 4.2.2, and 10.5.1: an oversized decoded field
  section resets only the affected request stream with `H3_MESSAGE_ERROR`;
  application-driven stream cancellation remains `H3_REQUEST_CANCELLED`.

Fixes: #845

### Validation Cases

- `1011` — two in-limit field sections complete on one connection without
  stream or connection errors.
- `1012` — an oversized field section is reset with `H3_MESSAGE_ERROR` while
  a second request on the same connection completes.

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Complete
- CI: Pending — `Analyze`, `Build on Ubuntu (ubuntu-latest)`, and
  `Build on macOS (macos-latest)`
