### PR TITLE
[~] Discard client-received 0-RTT packets

### DIFF
--- a/src/transport/xqc_packet.c
+++ b/src/transport/xqc_packet.c
@@ -155,6 +155,17 @@ xqc_packet_parse_single(xqc_connection_t *c, xqc_packet_in_t *packet_in)
     } else if (XQC_PACKET_IS_LONG_HEADER(pos)) {    /* long header */
         /* buffer packets if key is not ready */
         if (XQC_PACKET_LONG_HEADER_GET_TYPE(packet_in->pos) == XQC_PTYPE_0RTT) {
+            /*
+             * RFC 9001 Section 5.6: a client MUST NOT attempt to decrypt a
+             * received 0-RTT packet and MUST discard it.
+             */
+            if (c->conn_type == XQC_CONN_TYPE_CLIENT) {
+                xqc_log(c->log, XQC_LOG_INFO,
+                        "|discard 0-RTT packet received by client|"
+                        "RFC 9001 5.6|");
+                return -XQC_EIGNORE_PKT;
+            }
+
             c->conn_flag |= XQC_CONN_FLAG_HAS_0RTT;
 
             if (!xqc_tls_is_key_ready(c->tls, XQC_ENC_LEV_0RTT, XQC_KEY_TYPE_RX_READ)) {
@@ -280,7 +291,6 @@ xqc_packet_process_single(xqc_connection_t *c,
 
     return XQC_OK;
 }
-
 
 
 

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -100,6 +100,10 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite, "xqc_test_cubic_init_cwnd", xqc_test_cubic_init_cwnd)
         || !CU_add_test(pSuite, "xqc_test_short_header_parse_cid", xqc_test_short_header_packet_parse_cid)
         || !CU_add_test(pSuite, "xqc_test_long_header_parse_cid", xqc_test_long_header_packet_parse_cid)
+        || !CU_add_test(pSuite, "xqc_test_client_discards_received_zero_rtt",
+                        xqc_test_client_discards_received_zero_rtt)
+        || !CU_add_test(pSuite, "xqc_test_server_buffers_received_zero_rtt",
+                        xqc_test_server_buffers_received_zero_rtt)
         || !CU_add_test(pSuite, "xqc_test_crypto_frame_flood", xqc_test_crypto_frame_flood)
         || !CU_add_test(pSuite, "xqc_test_crypto_frame_bytes_limit", xqc_test_crypto_frame_bytes_limit)
         || !CU_add_test(pSuite, "xqc_test_crypto_frame_recycle", xqc_test_crypto_frame_recycle)

--- a/tests/unittest/xqc_packet_test.c
+++ b/tests/unittest/xqc_packet_test.c
@@ -19,6 +19,9 @@
 
 #define XQC_TEST_SHORT_HEADER_PACKET_A "\x40\xAB\x3f\x12\x0a\xcd\xef\x00\x89"
 #define XQC_TEST_LONG_HEADER_PACKET_B "\xC0\x00\x00\x00\x01\x08\xAB\x3f\x12\x0a\xcd\xef\x00\x89\x08\xAB\x3f\x12\x0a\xcd\xef\x00\x89"
+#define XQC_TEST_ZERO_RTT_PACKET                                         \
+    "\xD0\x00\x00\x00\x01\x08\xAB\x3f\x12\x0a\xcd\xef\x00\x89" \
+    "\x08\xAB\x3f\x12\x0a\xcd\xef\x00\x89\x01\x00"
 
 #define XQC_TEST_CHECK_CID "ab3f120acdef0089"
 
@@ -64,6 +67,59 @@ xqc_test_long_header_packet_parse_cid()
 {
     xqc_test_packet_parse_cid((unsigned char *)XQC_TEST_LONG_HEADER_PACKET_B,
                               sizeof(XQC_TEST_LONG_HEADER_PACKET_B)-1, 0);
+}
+
+
+void
+xqc_test_client_discards_received_zero_rtt(void)
+{
+    xqc_connection_t *conn = test_engine_connect();
+    xqc_packet_in_t packet_in;
+    xqc_int_t ret;
+
+    CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+    CU_ASSERT_EQUAL_FATAL(conn->conn_type, XQC_CONN_TYPE_CLIENT);
+
+    xqc_packet_in_init(&packet_in,
+                       (unsigned char *)XQC_TEST_ZERO_RTT_PACKET,
+                       sizeof(XQC_TEST_ZERO_RTT_PACKET) - 1, NULL, 0, 0);
+
+    ret = xqc_packet_process_single(conn, &packet_in);
+
+    /*
+     * RFC 9001 Section 5.6 requires discard before decryption. The receive
+     * path must not retain the packet or mark client-side 0-RTT state.
+     */
+    CU_ASSERT_EQUAL(ret, -XQC_EIGNORE_PKT);
+    CU_ASSERT_EQUAL(conn->undecrypt_count[XQC_ENC_LEV_0RTT], 0);
+    CU_ASSERT_FALSE(conn->conn_flag & XQC_CONN_FLAG_HAS_0RTT);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
+void
+xqc_test_server_buffers_received_zero_rtt(void)
+{
+    xqc_connection_t *conn = test_engine_connect();
+    xqc_packet_in_t packet_in;
+    xqc_int_t ret;
+
+    CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+    conn->conn_type = XQC_CONN_TYPE_SERVER;
+
+    xqc_packet_in_init(&packet_in,
+                       (unsigned char *)XQC_TEST_ZERO_RTT_PACKET,
+                       sizeof(XQC_TEST_ZERO_RTT_PACKET) - 1, NULL, 0, 0);
+
+    ret = xqc_packet_process_single(conn, &packet_in);
+
+    CU_ASSERT_EQUAL(ret, -XQC_EWAITING);
+    CU_ASSERT_EQUAL(conn->undecrypt_count[XQC_ENC_LEV_0RTT], 1);
+    CU_ASSERT_TRUE(conn->conn_flag & XQC_CONN_FLAG_HAS_0RTT);
+
+    conn->conn_type = XQC_CONN_TYPE_CLIENT;
+    xqc_engine_destroy(conn->engine);
 }
 
 

--- a/tests/unittest/xqc_packet_test.h
+++ b/tests/unittest/xqc_packet_test.h
@@ -7,6 +7,8 @@
 
 void xqc_test_short_header_packet_parse_cid();
 void xqc_test_long_header_packet_parse_cid();
+void xqc_test_client_discards_received_zero_rtt(void);
+void xqc_test_server_buffers_received_zero_rtt(void);
 void xqc_test_packet_encrypt_hp_sample_boundary();
 void xqc_test_empty_pkt();
 void xqc_test_stateless_reset_parse_boundary(void);


### PR DESCRIPTION
### Mechanism

Discard 0-RTT packets at the client receive dispatch boundary before key
lookup, buffering, parsing, or decryption. Server-side 0-RTT receive behavior
remains unchanged.

Fixes: #593

- RFC or draft: RFC 9001 Section 5.6

### Validation Cases

- Missing — targeted server-sent 0-RTT packet injection into the client

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Incomplete — client receive path lacks targeted
  server-sent 0-RTT case coverage
- CI: Pending
