### PR TITLE
[~]: Enforce AEAD confidentiality limits

### DIFF
--- a/harness/spec/validation.md
+++ b/harness/spec/validation.md
@@ -99,7 +99,7 @@ its case is retired so later changes cannot reuse it.
 |-------|--------------------|---------------|
 | `[705, 799]` | QUIC Transport core | `705-710` |
 | `[800, 899]` | Recovery and congestion control | None |
-| `[900, 999]` | QUIC-TLS | None |
+| `[900, 999]` | QUIC-TLS | `902-903` |
 | `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1014` |
 | `[1100, 1149]` | QPACK | None |
 | `[1150, 1199]` | HTTP priority | None |

--- a/harness/spec/validation.md
+++ b/harness/spec/validation.md
@@ -99,7 +99,7 @@ its case is retired so later changes cannot reuse it.
 |-------|--------------------|---------------|
 | `[705, 799]` | QUIC Transport core | None |
 | `[800, 899]` | Recovery and congestion control | None |
-| `[900, 999]` | QUIC-TLS | None |
+| `[900, 999]` | QUIC-TLS | `902-903` |
 | `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1012` |
 | `[1100, 1149]` | QPACK | None |
 | `[1150, 1199]` | HTTP priority | None |

--- a/include/xquic/xqc_errno.h
+++ b/include/xquic/xqc_errno.h
@@ -38,7 +38,8 @@ typedef enum {
     TRA_APPLICATION_ERROR           =  0xC,
     TRA_CRYPTO_BUFFER_EXCEEDED      =  0xD,
     TRA_0RTT_TRANS_PARAMS_ERROR     =  0xE,   /**< MUST delete the current saved 0RTT transport parameters */
-    TRA_AEAD_LIMIT_REACHED          =  0x1e,  /**< RFC 9001 §6.6: AEAD integrity limit reached */
+    /** RFC 9000 Section 20.1: confidentiality or integrity limit reached */
+    TRA_AEAD_LIMIT_REACHED          =  0xF,
     /*
      * RFC 9000 Section 6.2 does not assign a CONNECTION_CLOSE code for
      * the Version Negotiation abort path, because the client cannot
@@ -154,7 +155,8 @@ typedef enum {
     XQC_ESTATELESS_RESET                = 641,      /**< connection is reset by peer */
     XQC_EPACKET_FILETER_CALLBACK        = 642,      /**< error with packet filter callback function */
     XQC_EVERSION_NEGOTIATION            = 643,      /**< client received a Version Negotiation packet, RFC 9000 §6.2 mandates abandoning the connection attempt */
-    XQC_EAEAD_LIMIT                     = 644,      /**< AEAD integrity limit reached per RFC 9001 §6.6 */
+    /** RFC 9001 Section 6.6: AEAD confidentiality or integrity limit */
+    XQC_EAEAD_LIMIT                     = 644,
 
     XQC_EMP_NOT_SUPPORT_MP              = 650,      /**< Multipath - don't support multipath */
     XQC_EMP_NO_AVAIL_PATH_ID            = 651,      /**< Multipath - no available path id */

--- a/include/xquic/xqc_errno.h
+++ b/include/xquic/xqc_errno.h
@@ -38,7 +38,7 @@ typedef enum {
     TRA_APPLICATION_ERROR           =  0xC,
     TRA_CRYPTO_BUFFER_EXCEEDED      =  0xD,
     TRA_KEY_UPDATE_ERROR            =  0xE,   /**< RFC 9001 Section 6.7 */
-    TRA_AEAD_LIMIT_REACHED          =  0x1e,  /**< RFC 9001 §6.6: AEAD integrity limit reached */
+    TRA_AEAD_LIMIT_REACHED          =  0xF,   /**< RFC 9000 Section 20.1 */
     TRA_NO_VIABLE_PATH              =  0x10,  /**< RFC 9000 Section 8.2.4 */
     /*
      * RFC 9000 Section 6.2 does not assign a CONNECTION_CLOSE code for
@@ -163,7 +163,8 @@ typedef enum {
     XQC_ESTATELESS_RESET                = 641,      /**< connection is reset by peer */
     XQC_EPACKET_FILETER_CALLBACK        = 642,      /**< error with packet filter callback function */
     XQC_EVERSION_NEGOTIATION            = 643,      /**< client received a Version Negotiation packet, RFC 9000 §6.2 mandates abandoning the connection attempt */
-    XQC_EAEAD_LIMIT                     = 644,      /**< AEAD integrity limit reached per RFC 9001 §6.6 */
+    /** RFC 9001 Section 6.6: AEAD confidentiality or integrity limit */
+    XQC_EAEAD_LIMIT                     = 644,
 
     XQC_EMP_NOT_SUPPORT_MP              = 650,      /**< Multipath - don't support multipath */
     XQC_EMP_NO_AVAIL_PATH_ID            = 651,      /**< Multipath - no available path id */

--- a/include/xquic/xquic.h
+++ b/include/xquic/xquic.h
@@ -1345,7 +1345,11 @@ typedef struct xqc_conn_settings_s {
     int32_t                     spurious_loss_detect_on;
     /** limit of anti-amplification, default 5 */
     uint32_t                    anti_amplification_limit;
-    /** packet limit of a single 1-rtt key, 0 for unlimited */ 
+    /**
+     * Optional early key-update threshold for one 1-RTT key phase. Zero
+     * disables the early trigger; the selected AEAD's mandatory usage limit
+     * still applies.
+     */
     uint64_t                    keyupdate_pkt_threshold; 
     size_t                      max_pkt_out_size;
     size_t                      probing_pkt_out_size;

--- a/scripts/case_test.sh
+++ b/scripts/case_test.sh
@@ -5262,6 +5262,54 @@ else
     case_print_result "crypto_error_not_fixed_enum" "fail"
 fi
 
+## RFC 9001 Section 6.6: AEAD confidentiality limits
+
+killall test_server 2> /dev/null
+clear_log
+rm -f test_session xqc_token tp_localhost aead_confidentiality_server.log
+${SERVER_BIN} -l d -e -x 902 > aead_confidentiality_server.log &
+sleep 1
+echo -e "AEAD confidentiality: last permitted packet updates keys ...\c"
+${CLIENT_BIN} -s 1024 -l d -t 1 -E -x 902 > stdlog
+injected=`grep "\[aead-confidentiality-test\]|case:902|" stdlog`
+updated=`grep "|key phase changed to" clog`
+received=`grep "\[aead-confidentiality-test\]|request_received|case:902|" \
+    aead_confidentiality_server.log`
+success=`grep ">>>>>>>> pass:1" stdlog`
+limit_error=`grep "|AEAD confidentiality limit reached|" clog`
+if [ -n "$injected" ] && [ -n "$updated" ] && [ -n "$received" ] \
+    && [ -n "$success" ] && [ -z "$limit_error" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "aead_confidentiality_boundary_updates_keys" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "aead_confidentiality_boundary_updates_keys" "fail"
+fi
+
+killall test_server 2> /dev/null
+clear_log
+rm -f test_session xqc_token tp_localhost aead_confidentiality_server.log
+${SERVER_BIN} -l d -e -x 903 > aead_confidentiality_server.log &
+sleep 1
+echo -e "AEAD confidentiality: exhausted keys reject next packet ...\c"
+${CLIENT_BIN} -s 1024 -l d -t 1 -E -x 903 > stdlog
+injected=`grep "\[aead-confidentiality-test\]|case:903|" stdlog`
+limit_error=`grep "|AEAD confidentiality limit reached|" clog`
+wire_error=`grep "|err:0xf" clog`
+received=`grep "\[aead-confidentiality-test\]|request_received|case:903|" \
+    aead_confidentiality_server.log`
+if [ -n "$injected" ] && [ -n "$limit_error" ] && [ -n "$wire_error" ] \
+    && [ -z "$received" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "aead_confidentiality_exhaustion_stops_sender" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "aead_confidentiality_exhaustion_stops_sender" "fail"
+fi
+
+killall test_server 2> /dev/null
+rm -f aead_confidentiality_server.log
+
 ## RFC 9000 Section 7.4.1: 0-RTT transport parameter validation
 
 # test 701: server reduces max_streams_bidi after first connection,

--- a/scripts/case_test.sh
+++ b/scripts/case_test.sh
@@ -5310,6 +5310,54 @@ else
     case_print_result "crypto_error_not_fixed_enum" "fail"
 fi
 
+## RFC 9001 Section 6.6: AEAD confidentiality limits
+
+killall test_server 2> /dev/null
+clear_log
+rm -f test_session xqc_token tp_localhost aead_confidentiality_server.log
+${SERVER_BIN} -l d -e -x 902 > aead_confidentiality_server.log &
+sleep 1
+echo -e "AEAD confidentiality: last permitted packet updates keys ...\c"
+${CLIENT_BIN} -s 1024 -l d -t 1 -E -x 902 > stdlog
+injected=`grep "\[aead-confidentiality-test\]|case:902|" stdlog`
+updated=`grep "|key phase changed to" clog`
+received=`grep "\[aead-confidentiality-test\]|request_received|case:902|" \
+    aead_confidentiality_server.log`
+success=`grep ">>>>>>>> pass:1" stdlog`
+limit_error=`grep "|AEAD confidentiality limit reached|" clog`
+if [ -n "$injected" ] && [ -n "$updated" ] && [ -n "$received" ] \
+    && [ -n "$success" ] && [ -z "$limit_error" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "aead_confidentiality_boundary_updates_keys" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "aead_confidentiality_boundary_updates_keys" "fail"
+fi
+
+killall test_server 2> /dev/null
+clear_log
+rm -f test_session xqc_token tp_localhost aead_confidentiality_server.log
+${SERVER_BIN} -l d -e -x 903 > aead_confidentiality_server.log &
+sleep 1
+echo -e "AEAD confidentiality: exhausted keys reject next packet ...\c"
+${CLIENT_BIN} -s 1024 -l d -t 1 -E -x 903 > stdlog
+injected=`grep "\[aead-confidentiality-test\]|case:903|" stdlog`
+limit_error=`grep "|AEAD confidentiality limit reached|" clog`
+wire_error=`grep "|err:0xf" clog`
+received=`grep "\[aead-confidentiality-test\]|request_received|case:903|" \
+    aead_confidentiality_server.log`
+if [ -n "$injected" ] && [ -n "$limit_error" ] && [ -n "$wire_error" ] \
+    && [ -z "$received" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "aead_confidentiality_exhaustion_stops_sender" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "aead_confidentiality_exhaustion_stops_sender" "fail"
+fi
+
+killall test_server 2> /dev/null
+rm -f aead_confidentiality_server.log
+
 ## RFC 9000 Section 7.4.1: 0-RTT transport parameter validation
 
 # test 701: server reduces max_streams_bidi after first connection,

--- a/src/tls/xqc_crypto.c
+++ b/src/tls/xqc_crypto.c
@@ -810,3 +810,23 @@ xqc_aead_integrity_limit(uint32_t cipher_id)
         return XQC_AEAD_CONSERVATIVE_INTEGRITY_LIMIT;
     }
 }
+
+uint64_t
+xqc_aead_confidentiality_limit(uint32_t cipher_id)
+{
+    /* RFC 9001 Section 6.6: confidentiality limits for each AEAD. */
+    switch (cipher_id) {
+    case XQC_TLS13_AES_128_GCM_SHA256:
+        return XQC_AES_128_GCM_CONFIDENTIALITY_LIMIT;
+
+    case XQC_TLS13_AES_256_GCM_SHA384:
+        return XQC_AES_256_GCM_CONFIDENTIALITY_LIMIT;
+
+    case XQC_TLS13_CHACHA20_POLY1305_SHA256:
+        return XQC_CHACHA20_POLY1305_CONFIDENTIALITY_LIMIT;
+
+    default:
+        /* Unknown ciphers use the most conservative supported limit. */
+        return XQC_AEAD_CONSERVATIVE_CONFIDENTIALITY_LIMIT;
+    }
+}

--- a/src/tls/xqc_crypto.h
+++ b/src/tls/xqc_crypto.h
@@ -196,6 +196,25 @@ void xqc_crypto_destroy(xqc_crypto_t *crypto);
 uint64_t xqc_aead_integrity_limit(uint32_t cipher_id);
 
 /**
+ * AEAD confidentiality limits, RFC 9001 Section 6.6. XQUIC uses the
+ * conservative default AES-GCM limit instead of the larger packet-size-based
+ * allowance in Appendix B.1.1.
+ */
+#define XQC_AES_128_GCM_CONFIDENTIALITY_LIMIT         (1ULL << 23)
+#define XQC_AES_256_GCM_CONFIDENTIALITY_LIMIT         (1ULL << 23)
+#define XQC_CHACHA20_POLY1305_CONFIDENTIALITY_LIMIT   (1ULL << 62)
+#define XQC_AEAD_CONSERVATIVE_CONFIDENTIALITY_LIMIT   \
+    XQC_AES_128_GCM_CONFIDENTIALITY_LIMIT
+
+/**
+ * @brief return AEAD confidentiality limit for the given cipher_id
+ *
+ * AES-128/256-GCM: 2^23, ChaCha20-Poly1305: 2^62. Unknown AEADs use the
+ * conservative AES-GCM limit.
+ */
+uint64_t xqc_aead_confidentiality_limit(uint32_t cipher_id);
+
+/**
  * @brief install keys from secret
  */
 xqc_int_t xqc_crypto_derive_keys(xqc_crypto_t *crypto, const uint8_t *secret, size_t secretlen,

--- a/src/tls/xqc_tls.h
+++ b/src/tls/xqc_tls.h
@@ -181,7 +181,7 @@ xqc_tls_early_data_accept_t xqc_tls_is_early_data_accepted(xqc_tls_t *tls);
 ssize_t xqc_tls_aead_tag_len(xqc_tls_t *tls, xqc_encrypt_level_t level);
 
 /**
- * @brief get 1-RTT cipher_id for AEAD integrity limit check per RFC 9001 §6.6
+ * @brief get 1-RTT cipher_id for AEAD usage limits per RFC 9001 Section 6.6
  */
 uint32_t xqc_tls_get_1rtt_cipher_id(xqc_tls_t *tls);
 

--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -656,6 +656,7 @@ xqc_conn_init_key_update_ctx(xqc_connection_t *conn)
     ctx->first_sent_pktno  = 0;
     ctx->first_recv_pktno  = 0;
     ctx->enc_pkt_cnt       = 0;
+    ctx->aead_confidentiality_limit = 0;
 
     ctx->initiate_time_guard   = 0;
 }

--- a/src/transport/xqc_conn.h
+++ b/src/transport/xqc_conn.h
@@ -286,6 +286,8 @@ typedef struct {
     xqc_packet_number_t     first_sent_pktno;  /* lowest packet number sent with each key phase */
     xqc_packet_number_t     first_recv_pktno;  /* lowest packet number recv with each key phase */
     uint64_t                enc_pkt_cnt;       /* number of packet encrypt with each key phase */
+    /* cached RFC 9001 Section 6.6 confidentiality limit */
+    uint64_t                aead_confidentiality_limit;
     xqc_usec_t              initiate_time_guard;  /* time limit for initiating next key update */
 
 } xqc_key_update_ctx_t;

--- a/src/transport/xqc_packet_parser.c
+++ b/src/transport/xqc_packet_parser.c
@@ -21,6 +21,7 @@
 #include "src/transport/xqc_send_ctl.h"
 #include "src/transport/xqc_defs.h"
 #include "src/common/xqc_random.h"
+#include "src/tls/xqc_crypto.h"
 
 #define xqc_packet_number_bits2len(b) ((b) + 1)
 
@@ -575,18 +576,95 @@ xqc_packet_parse_zero_rtt(xqc_connection_t *c, xqc_packet_in_t *packet_in)
 
 
 xqc_int_t
+xqc_packet_check_aead_confidentiality_limit(xqc_connection_t *conn)
+{
+    uint64_t limit = conn->key_update_ctx.aead_confidentiality_limit;
+
+    if (conn->key_update_ctx.enc_pkt_cnt < limit) {
+        return XQC_OK;
+    }
+
+    xqc_log(conn->log, XQC_LOG_ERROR,
+            "|AEAD confidentiality limit reached|encrypted:%ui|limit:%ui|",
+            conn->key_update_ctx.enc_pkt_cnt, limit);
+    XQC_CONN_ERR(conn, TRA_AEAD_LIMIT_REACHED);
+    return -XQC_EAEAD_LIMIT;
+}
+
+static xqc_bool_t
+xqc_packet_can_initiate_key_update(xqc_connection_t *conn)
+{
+    return conn->key_update_ctx.first_sent_pktno
+               <= conn->conn_initial_path->path_send_ctl
+                      ->ctl_largest_acked[XQC_PNS_APP_DATA]
+           && xqc_monotonic_timestamp()
+                  > conn->key_update_ctx.initiate_time_guard;
+}
+
+static xqc_int_t
+xqc_packet_initiate_key_update(xqc_connection_t *conn)
+{
+    xqc_int_t ret = xqc_tls_update_1rtt_keys(conn->tls,
+                                             XQC_KEY_TYPE_RX_READ);
+    if (ret != XQC_OK) {
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|xqc_tls_update_rx_keys error|");
+        return ret;
+    }
+
+    ret = xqc_tls_update_1rtt_keys(conn->tls, XQC_KEY_TYPE_TX_WRITE);
+    if (ret != XQC_OK) {
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|xqc_tls_update_tx_keys error|");
+        return ret;
+    }
+
+    ret = xqc_conn_confirm_key_update(conn);
+    if (ret != XQC_OK) {
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|xqc_conn_confirm_key_update error|");
+    }
+    return ret;
+}
+
+xqc_int_t
 xqc_packet_encrypt_buf(xqc_connection_t *conn, xqc_packet_out_t *packet_out,
     unsigned char *enc_pkt, size_t enc_pkt_cap, size_t *enc_pkt_len)
 {
     xqc_int_t ret;
     size_t enc_payload_len = 0;
 
-    xqc_encrypt_level_t level = xqc_packet_type_to_enc_level(packet_out->po_pkt.pkt_type);
+    xqc_encrypt_level_t level =
+        xqc_packet_type_to_enc_level(packet_out->po_pkt.pkt_type);
+    xqc_bool_t is_1rtt = packet_out->po_pkt.pkt_type
+                            == XQC_PTYPE_SHORT_HEADER
+                        && level == XQC_ENC_LEV_1RTT;
    
     /* check encrypt key ready */
     if (xqc_tls_is_key_ready(conn->tls, level, XQC_KEY_TYPE_TX_WRITE) == XQC_FALSE) {
         xqc_log(conn->log, XQC_LOG_ERROR, "|crypto not initialized|level:%d|", level);
         return -XQC_TLS_INVALID_STATE;
+    }
+
+    if (is_1rtt) {
+        if (conn->key_update_ctx.aead_confidentiality_limit == 0) {
+            uint32_t cipher_id = xqc_tls_get_1rtt_cipher_id(conn->tls);
+            if (cipher_id == 0) {
+                /* XQUIC's experimental no-crypto mode has no AEAD limit. */
+                is_1rtt = XQC_FALSE;
+
+            } else {
+                conn->key_update_ctx.aead_confidentiality_limit =
+                    xqc_aead_confidentiality_limit(cipher_id);
+            }
+        }
+
+        if (is_1rtt) {
+            ret = xqc_packet_check_aead_confidentiality_limit(conn);
+            if (ret != XQC_OK) {
+                return ret;
+            }
+        }
     }
 
     /* source buffer */
@@ -649,32 +727,26 @@ xqc_packet_encrypt_buf(xqc_connection_t *conn, xqc_packet_out_t *packet_out,
         return ret;
     }
 
-    /* update enc_pkt_cnt for current 1-rtt key & maybe initiate a key update */
-    if (conn->conn_settings.keyupdate_pkt_threshold > 0
-        && packet_out->po_pkt.pkt_type == XQC_PTYPE_SHORT_HEADER && level == XQC_ENC_LEV_1RTT)
-    {
+    /* RFC 9001 Section 6.6: count every protected packet per write key. */
+    if (is_1rtt) {
         conn->key_update_ctx.enc_pkt_cnt++;
 
-        if (conn->key_update_ctx.enc_pkt_cnt > conn->conn_settings.keyupdate_pkt_threshold
-            && conn->key_update_ctx.first_sent_pktno <=
-                conn->conn_initial_path->path_send_ctl->ctl_largest_acked[XQC_PNS_APP_DATA]
-            && xqc_monotonic_timestamp() > conn->key_update_ctx.initiate_time_guard)
+        xqc_bool_t confidentiality_trigger =
+            conn->key_update_ctx.enc_pkt_cnt
+                >= conn->key_update_ctx.aead_confidentiality_limit;
+        xqc_bool_t configured_trigger =
+            conn->conn_settings.keyupdate_pkt_threshold > 0
+            && conn->key_update_ctx.enc_pkt_cnt
+                   > conn->conn_settings.keyupdate_pkt_threshold;
+
+        if ((confidentiality_trigger || configured_trigger)
+            && xqc_packet_can_initiate_key_update(conn))
         {
-            ret = xqc_tls_update_1rtt_keys(conn->tls, XQC_KEY_TYPE_RX_READ);
+            ret = xqc_packet_initiate_key_update(conn);
             if (ret != XQC_OK) {
-                xqc_log(conn->log, XQC_LOG_ERROR, "|xqc_tls_update_rx_keys error|");
-                return ret;
-            }
-
-            ret = xqc_tls_update_1rtt_keys(conn->tls, XQC_KEY_TYPE_TX_WRITE);
-            if (ret != XQC_OK) {
-                xqc_log(conn->log, XQC_LOG_ERROR, "|xqc_tls_update_tx_keys error|");
-                return ret;
-            }
-
-            ret = xqc_conn_confirm_key_update(conn);
-            if (ret != XQC_OK) {
-                xqc_log(conn->log, XQC_LOG_ERROR, "|xqc_conn_confirm_key_update error|");
+                if (confidentiality_trigger) {
+                    XQC_CONN_ERR(conn, TRA_AEAD_LIMIT_REACHED);
+                }
                 return ret;
             }
         }

--- a/src/transport/xqc_packet_parser.h
+++ b/src/transport/xqc_packet_parser.h
@@ -76,6 +76,9 @@ xqc_int_t xqc_packet_encrypt(xqc_connection_t *conn, xqc_packet_out_t *packet_ou
 xqc_int_t xqc_packet_encrypt_buf(xqc_connection_t *conn, xqc_packet_out_t *packet_out,
     unsigned char *enc_pkt, size_t enc_pkt_cap, size_t *enc_pkt_len);
 
+xqc_int_t xqc_packet_check_aead_confidentiality_limit(
+    xqc_connection_t *conn);
+
 void xqc_gen_reset_token(xqc_cid_t *cid, unsigned char *token, int token_len, char *key, size_t keylen);
 
 xqc_int_t xqc_packet_parse_stateless_reset(const unsigned char *buf,

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -18,6 +18,9 @@
 #include <xquic/xqc_http3.h>
 #include "src/http3/xqc_h3_conn.h"
 #include "src/http3/xqc_h3_request.h"
+#include "src/transport/xqc_conn.h"
+#include "src/tls/xqc_crypto.h"
+#include "src/tls/xqc_tls.h"
 #include "platform.h"
 #ifndef XQC_SYS_WINDOWS
 #include <unistd.h>
@@ -77,6 +80,8 @@ printf_null(const char *format, ...)
 #define XQC_TEST_CASE_H3_SINGLE_VINT_OVERLONG 1008
 #define XQC_TEST_CASE_H3_FIELD_SECTION_VALID 1011
 #define XQC_TEST_CASE_H3_FIELD_SECTION_OVER_LIMIT 1012
+#define XQC_TEST_CASE_AEAD_CONFIDENTIALITY_BELOW_LIMIT 902
+#define XQC_TEST_CASE_AEAD_CONFIDENTIALITY_AT_LIMIT 903
 
 typedef struct user_conn_s user_conn_t;
 
@@ -256,7 +261,7 @@ int g_spec_url;
 int g_is_get;
 uint64_t g_last_sock_op_time;
 /*
- * currently, the maximum used test case id is 704
+ * currently, the maximum used test case id is 1012
  * please keep this comment updated if you are adding more test cases. :-D
  * 55 for RFC 9114 Section 4.2 forbidden header e2e validation
  * 99 for pure fin
@@ -267,6 +272,8 @@ uint64_t g_last_sock_op_time;
  * 701/702 for 0-RTT transport param validation
  * 703 for CRYPTO_ERROR validation
  * 704 for active_connection_id_limit validation
+ * 902/903 for AEAD confidentiality-limit validation
+ * 1000-1012 for HTTP/3 protocol validation
  */
 int g_test_case;
 int g_ipv6;
@@ -1941,6 +1948,24 @@ xqc_client_h3_conn_handshake_finished(xqc_h3_conn_t *h3_conn, void *user_data)
     printf("====>SCID:%s\n", xqc_scid_str(p_ctx->engine, &user_conn->cid));
 
     hsk_completed = 1;
+
+    if (g_test_case == XQC_TEST_CASE_AEAD_CONFIDENTIALITY_BELOW_LIMIT
+        || g_test_case == XQC_TEST_CASE_AEAD_CONFIDENTIALITY_AT_LIMIT)
+    {
+        xqc_connection_t *conn = xqc_h3_conn_get_xqc_conn(h3_conn);
+        uint32_t cipher_id = xqc_tls_get_1rtt_cipher_id(conn->tls);
+        uint64_t limit = xqc_aead_confidentiality_limit(cipher_id);
+
+        conn->key_update_ctx.enc_pkt_cnt =
+            g_test_case == XQC_TEST_CASE_AEAD_CONFIDENTIALITY_BELOW_LIMIT
+            ? limit - 1 : limit;
+        conn->key_update_ctx.aead_confidentiality_limit = limit;
+        printf("[aead-confidentiality-test]|case:%d|cipher_id:%u|"
+               "encrypted:%"PRIu64"|limit:%"PRIu64"|\n",
+               g_test_case, cipher_id,
+               conn->key_update_ctx.enc_pkt_cnt, limit);
+        fflush(stdout);
+    }
 
     user_conn->dgram_mss = xqc_h3_ext_datagram_get_mss(h3_conn);
     if (user_conn->dgram_mss == 0) {

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -19,8 +19,11 @@
 #include <xquic/xqc_http3.h>
 #include "src/http3/xqc_h3_conn.h"
 #include "src/http3/xqc_h3_request.h"
+#include "src/transport/xqc_conn.h"
 #include "src/transport/xqc_packet_out.h"
 #include "src/transport/xqc_frame_parser.h"
+#include "src/tls/xqc_crypto.h"
+#include "src/tls/xqc_tls.h"
 #include "platform.h"
 #ifndef XQC_SYS_WINDOWS
 #include <unistd.h>
@@ -84,6 +87,8 @@ printf_null(const char *format, ...)
 #define XQC_TEST_CASE_H3_FIELD_SECTION_OVER_LIMIT 1012
 #define XQC_TEST_CASE_H3_LOWERCASE_RESPONSE 1013
 #define XQC_TEST_CASE_H3_UPPERCASE_RESPONSE 1014
+#define XQC_TEST_CASE_AEAD_CONFIDENTIALITY_BELOW_LIMIT 902
+#define XQC_TEST_CASE_AEAD_CONFIDENTIALITY_AT_LIMIT 903
 
 typedef struct user_conn_s user_conn_t;
 
@@ -263,7 +268,7 @@ int g_spec_url;
 int g_is_get;
 uint64_t g_last_sock_op_time;
 /*
- * currently, the maximum used test case id is 710
+ * currently, the maximum used test case id is 1014
  * please keep this comment updated if you are adding more test cases. :-D
  * 55 for RFC 9114 Section 4.2 forbidden header e2e validation
  * 99 for pure fin
@@ -275,6 +280,8 @@ uint64_t g_last_sock_op_time;
  * 703 for CRYPTO_ERROR validation
  * 704 for active_connection_id_limit validation
  * 709/710 for active_connection_id_limit minimum validation
+ * 902/903 for AEAD confidentiality-limit validation
+ * 1000-1014 for HTTP/3 protocol validation
  */
 int g_test_case;
 int g_ipv6;
@@ -2027,6 +2034,24 @@ xqc_client_h3_conn_handshake_finished(xqc_h3_conn_t *h3_conn, void *user_data)
     printf("====>SCID:%s\n", xqc_scid_str(p_ctx->engine, &user_conn->cid));
 
     hsk_completed = 1;
+
+    if (g_test_case == XQC_TEST_CASE_AEAD_CONFIDENTIALITY_BELOW_LIMIT
+        || g_test_case == XQC_TEST_CASE_AEAD_CONFIDENTIALITY_AT_LIMIT)
+    {
+        xqc_connection_t *conn = xqc_h3_conn_get_xqc_conn(h3_conn);
+        uint32_t cipher_id = xqc_tls_get_1rtt_cipher_id(conn->tls);
+        uint64_t limit = xqc_aead_confidentiality_limit(cipher_id);
+
+        conn->key_update_ctx.enc_pkt_cnt =
+            g_test_case == XQC_TEST_CASE_AEAD_CONFIDENTIALITY_BELOW_LIMIT
+            ? limit - 1 : limit;
+        conn->key_update_ctx.aead_confidentiality_limit = limit;
+        printf("[aead-confidentiality-test]|case:%d|cipher_id:%u|"
+               "encrypted:%"PRIu64"|limit:%"PRIu64"|\n",
+               g_test_case, cipher_id,
+               conn->key_update_ctx.enc_pkt_cnt, limit);
+        fflush(stdout);
+    }
 
     user_conn->dgram_mss = xqc_h3_ext_datagram_get_mss(h3_conn);
     if (user_conn->dgram_mss == 0) {

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -61,6 +61,8 @@ printf_null(const char *format, ...)
 #define XQC_TEST_CASE_H3_SINGLE_VINT_OVERLONG 1008
 #define XQC_TEST_CASE_H3_FIELD_SECTION_VALID 1011
 #define XQC_TEST_CASE_H3_FIELD_SECTION_OVER_LIMIT 1012
+#define XQC_TEST_CASE_AEAD_CONFIDENTIALITY_BELOW_LIMIT 902
+#define XQC_TEST_CASE_AEAD_CONFIDENTIALITY_AT_LIMIT 903
 
 extern long xqc_random(void);
 extern xqc_usec_t xqc_now();
@@ -155,7 +157,7 @@ int g_send_body_size_defined;
 int g_save_body;
 int g_read_body;
 int g_spec_url;
-/* 99 pure fin, 7XX for 0-RTT transport param validation */
+/* 99 pure fin, 7XX for transport, 9XX for QUIC-TLS */
 int g_test_case;
 int g_server_conn_cnt;
 xqc_conn_settings_t g_conn_settings;
@@ -1517,6 +1519,15 @@ xqc_server_request_read_notify(xqc_h3_request_t *h3_request, xqc_request_notify_
         }
 
         user_stream->header_recvd++;
+
+        if (g_test_case == XQC_TEST_CASE_AEAD_CONFIDENTIALITY_BELOW_LIMIT
+            || g_test_case == XQC_TEST_CASE_AEAD_CONFIDENTIALITY_AT_LIMIT)
+        {
+            printf("[aead-confidentiality-test]|request_received|case:%d|"
+                   "stream_id:%"PRIu64"|\n", g_test_case,
+                   xqc_h3_stream_id(h3_request));
+            fflush(stdout);
+        }
 
         if (g_test_case == XQC_TEST_CASE_H3_FIELD_SECTION_VALID
             || g_test_case == XQC_TEST_CASE_H3_FIELD_SECTION_OVER_LIMIT)

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -66,6 +66,8 @@ printf_null(const char *format, ...)
 #define XQC_TEST_CASE_H3_FIELD_SECTION_OVER_LIMIT 1012
 #define XQC_TEST_CASE_H3_LOWERCASE_RESPONSE 1013
 #define XQC_TEST_CASE_H3_UPPERCASE_RESPONSE 1014
+#define XQC_TEST_CASE_AEAD_CONFIDENTIALITY_BELOW_LIMIT 902
+#define XQC_TEST_CASE_AEAD_CONFIDENTIALITY_AT_LIMIT 903
 
 extern long xqc_random(void);
 extern xqc_usec_t xqc_now();
@@ -163,7 +165,7 @@ int g_send_body_size_defined;
 int g_save_body;
 int g_read_body;
 int g_spec_url;
-/* 99 pure fin, 7XX for 0-RTT transport param validation */
+/* 99 pure fin, 7XX for transport, 9XX for QUIC-TLS */
 int g_test_case;
 int g_server_conn_cnt;
 xqc_conn_settings_t g_conn_settings;
@@ -1648,6 +1650,15 @@ xqc_server_request_read_notify(xqc_h3_request_t *h3_request, xqc_request_notify_
         }
 
         user_stream->header_recvd++;
+
+        if (g_test_case == XQC_TEST_CASE_AEAD_CONFIDENTIALITY_BELOW_LIMIT
+            || g_test_case == XQC_TEST_CASE_AEAD_CONFIDENTIALITY_AT_LIMIT)
+        {
+            printf("[aead-confidentiality-test]|request_received|case:%d|"
+                   "stream_id:%"PRIu64"|\n", g_test_case,
+                   xqc_h3_stream_id(h3_request));
+            fflush(stdout);
+        }
 
         if (g_test_case == XQC_TEST_CASE_H3_FIELD_SECTION_VALID
             || g_test_case == XQC_TEST_CASE_H3_FIELD_SECTION_OVER_LIMIT)

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -340,6 +340,13 @@ main(int argc, char *argv[])
                         xqc_test_aead_integrity_limit_conn_triggered)
         || !CU_add_test(pSuite, "xqc_test_aead_integrity_limit_conn_no_crypto",
                         xqc_test_aead_integrity_limit_conn_no_crypto)
+        /* issue #703: AEAD confidentiality limit, RFC 9001 Section 6.6 */
+        || !CU_add_test(pSuite, "xqc_test_aead_confidentiality_limit",
+                        xqc_test_aead_confidentiality_limit)
+        || !CU_add_test(pSuite, "xqc_test_aead_confidentiality_below_limit",
+                        xqc_test_aead_confidentiality_below_limit)
+        || !CU_add_test(pSuite, "xqc_test_aead_confidentiality_at_limit",
+                        xqc_test_aead_confidentiality_at_limit)
         /* ALPN negotiation tests (issue #709) */
         || !CU_add_test(pSuite, "xqc_test_alpn_error_code_value",
                         xqc_test_alpn_error_code_value)

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -286,6 +286,13 @@ main(int argc, char *argv[])
                         xqc_test_aead_integrity_limit_conn_triggered)
         || !CU_add_test(pSuite, "xqc_test_aead_integrity_limit_conn_no_crypto",
                         xqc_test_aead_integrity_limit_conn_no_crypto)
+        /* issue #703: AEAD confidentiality limit, RFC 9001 Section 6.6 */
+        || !CU_add_test(pSuite, "xqc_test_aead_confidentiality_limit",
+                        xqc_test_aead_confidentiality_limit)
+        || !CU_add_test(pSuite, "xqc_test_aead_confidentiality_below_limit",
+                        xqc_test_aead_confidentiality_below_limit)
+        || !CU_add_test(pSuite, "xqc_test_aead_confidentiality_at_limit",
+                        xqc_test_aead_confidentiality_at_limit)
         /* ALPN negotiation tests (issue #709) */
         || !CU_add_test(pSuite, "xqc_test_alpn_error_code_value",
                         xqc_test_alpn_error_code_value)

--- a/tests/unittest/xqc_crypto_test.c
+++ b/tests/unittest/xqc_crypto_test.c
@@ -6,6 +6,7 @@
 #include <CUnit/CUnit.h>
 #include "xqc_common_test.h"
 #include "src/transport/xqc_conn.h"
+#include "src/transport/xqc_packet_parser.h"
 #include "src/tls/xqc_tls_defs.h"
 #include "src/tls/xqc_tls.h"
 #include "src/tls/xqc_crypto.h"
@@ -481,6 +482,60 @@ xqc_test_aead_integrity_limit_unknown_cipher()
     /* unknown cipher_id: should return conservative (ChaCha20) limit */
     uint64_t unknown_limit = xqc_aead_integrity_limit(XQC_TEST_UNKOWND_CIPHER_ID);
     CU_ASSERT_EQUAL(unknown_limit, 68719476736ULL);
+}
+
+void
+xqc_test_aead_confidentiality_limit()
+{
+    CU_ASSERT_EQUAL(xqc_aead_confidentiality_limit(
+                        XQC_TLS13_AES_128_GCM_SHA256),
+                    8388608ULL);
+    CU_ASSERT_EQUAL(xqc_aead_confidentiality_limit(
+                        XQC_TLS13_AES_256_GCM_SHA384),
+                    8388608ULL);
+    CU_ASSERT_EQUAL(xqc_aead_confidentiality_limit(
+                        XQC_TLS13_CHACHA20_POLY1305_SHA256),
+                    4611686018427387904ULL);
+    CU_ASSERT_EQUAL(xqc_aead_confidentiality_limit(
+                        XQC_TEST_UNKOWND_CIPHER_ID),
+                    8388608ULL);
+}
+
+void
+xqc_test_aead_confidentiality_below_limit()
+{
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_FATAL(conn != NULL);
+
+    conn->key_update_ctx.enc_pkt_cnt =
+        XQC_AES_128_GCM_CONFIDENTIALITY_LIMIT - 1;
+    conn->key_update_ctx.aead_confidentiality_limit =
+        XQC_AES_128_GCM_CONFIDENTIALITY_LIMIT;
+
+    xqc_int_t ret = xqc_packet_check_aead_confidentiality_limit(conn);
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    CU_ASSERT_EQUAL(conn->conn_err, 0);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+void
+xqc_test_aead_confidentiality_at_limit()
+{
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_FATAL(conn != NULL);
+
+    conn->key_update_ctx.enc_pkt_cnt =
+        XQC_AES_128_GCM_CONFIDENTIALITY_LIMIT;
+    conn->key_update_ctx.aead_confidentiality_limit =
+        XQC_AES_128_GCM_CONFIDENTIALITY_LIMIT;
+
+    xqc_int_t ret = xqc_packet_check_aead_confidentiality_limit(conn);
+    CU_ASSERT_EQUAL(ret, -XQC_EAEAD_LIMIT);
+    CU_ASSERT_EQUAL(conn->conn_err, TRA_AEAD_LIMIT_REACHED);
+    CU_ASSERT_EQUAL(TRA_AEAD_LIMIT_REACHED, 0x0f);
+
+    xqc_engine_destroy(conn->engine);
 }
 
 /*

--- a/tests/unittest/xqc_crypto_test.h
+++ b/tests/unittest/xqc_crypto_test.h
@@ -23,4 +23,9 @@ void xqc_test_aead_integrity_limit_unknown_cipher();
 void xqc_test_aead_integrity_limit_conn_triggered();
 void xqc_test_aead_integrity_limit_conn_no_crypto();
 
+/* RFC 9001 Section 6.6 AEAD confidentiality limit */
+void xqc_test_aead_confidentiality_limit();
+void xqc_test_aead_confidentiality_below_limit();
+void xqc_test_aead_confidentiality_at_limit();
+
 #endif


### PR DESCRIPTION
### Mechanism

Enforce each 1-RTT write key's AEAD confidentiality limit independently of the
optional early key-update threshold. The last permitted packet initiates a key
update when the existing update guards allow it; exhausted keys reject further
protection with the assigned `AEAD_LIMIT_REACHED` transport error `0x0f`.

Fixes: #703

- RFC or draft: RFC 9001 Section 6.6; RFC 9000 Section 20.1

### Validation Cases

- 902 — The last permitted packet updates keys and reaches the server.
- 903 — Exhausted keys stop the sender before the request reaches the server.

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Complete
- CI: Pending
