### PR TITLE
[~]: Deduplicate concurrent Actions runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   harness-check:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/interop-docker.yml
+++ b/.github/workflows/interop-docker.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ main, interop ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions: read-all
 
 jobs:


### PR DESCRIPTION
### Mechanism

- RFC or draft: `Not applicable`
- Group each workflow by pull request number or pushed ref and cancel superseded runs, while keeping Build, CodeQL, and interop in independent concurrency groups.

### Validation Cases

- `Not applicable` — GitHub Actions scheduling metadata only; no runtime or endpoint behavior changes.

### CONTRIBUTING.md

- Overall: `Pending`
- Local regression: `Complete`
- CI: `Pending — Build and CodeQL`
