### PR TITLE
[~]: Fix read key installation error log without helper indirection

### DIFF
--- a/src/tls/xqc_tls.c
+++ b/src/tls/xqc_tls.c
@@ -1206,23 +1206,6 @@ xqc_tls_get_ssl(xqc_tls_t *tls)
  * ============================================================================
  */
 
-const char *
-xqc_tls_key_install_error_direction(xqc_key_type_t key_type, xqc_int_t ret)
-{
-    if (ret == XQC_OK) {
-        return NULL;
-    }
-
-    switch (key_type) {
-    case XQC_KEY_TYPE_RX_READ:
-        return "read";
-    case XQC_KEY_TYPE_TX_WRITE:
-        return "write";
-    default:
-        return "unknown";
-    }
-}
-
 int 
 xqc_tls_set_read_secret(SSL *ssl, enum ssl_encryption_level_t level,
     const SSL_CIPHER *cipher, const uint8_t *secret, size_t secret_len)
@@ -1257,12 +1240,8 @@ xqc_tls_set_read_secret(SSL *ssl, enum ssl_encryption_level_t level,
     /* derive and install read key */
     xqc_crypto_t *crypto = tls->crypto[level];
     ret = xqc_crypto_derive_keys(crypto, secret, secret_len, XQC_KEY_TYPE_RX_READ);
-    const char *key_direction = xqc_tls_key_install_error_direction(
-        XQC_KEY_TYPE_RX_READ, ret);
-    if (key_direction != NULL) {
-        xqc_log(tls->log, XQC_LOG_ERROR,
-                "|install %s key error|level:%d|ret:%d",
-                key_direction, level, ret);
+    if (ret != XQC_OK) {
+        xqc_log(tls->log, XQC_LOG_ERROR, "|install read key error|level:%d|ret:%d", level, ret);
         return XQC_SSL_FAIL;
     }
 
@@ -1304,12 +1283,8 @@ xqc_tls_set_write_secret(SSL *ssl, enum ssl_encryption_level_t level,
     /* derive and install write key */
     xqc_crypto_t *crypto = tls->crypto[level];
     ret = xqc_crypto_derive_keys(crypto, secret, secret_len, XQC_KEY_TYPE_TX_WRITE);
-    const char *key_direction = xqc_tls_key_install_error_direction(
-        XQC_KEY_TYPE_TX_WRITE, ret);
-    if (key_direction != NULL) {
-        xqc_log(tls->log, XQC_LOG_ERROR,
-                "|install %s key error|level:%d|ret:%d",
-                key_direction, level, ret);
+    if (ret != XQC_OK) {
+        xqc_log(tls->log, XQC_LOG_ERROR, "|install write key error|level:%d|ret:%d", level, ret);
         return XQC_SSL_FAIL;
     }
 

--- a/src/tls/xqc_tls.h
+++ b/src/tls/xqc_tls.h
@@ -165,9 +165,6 @@ xqc_int_t xqc_tls_decrypt_payload(xqc_tls_t *tls, xqc_encrypt_level_t level,
  */
 xqc_bool_t xqc_tls_is_key_ready(xqc_tls_t *tls, xqc_encrypt_level_t level, xqc_key_type_t key_type);
 
-const char *xqc_tls_key_install_error_direction(xqc_key_type_t key_type,
-    xqc_int_t ret);
-
 /**
  * @brief check whether it is adequate to send early data
  */

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -149,10 +149,6 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite,
                         "xqc_test_h3_single_vint_frame_length_error",
                         xqc_test_h3_single_vint_frame_length_error)
-        || !CU_add_test(pSuite, "xqc_test_tls_key_install_success",
-                        xqc_test_tls_key_install_success)
-        || !CU_add_test(pSuite, "xqc_test_tls_key_install_failure",
-                        xqc_test_tls_key_install_failure)
         || !CU_add_test(pSuite, "xqc_test_tls", xqc_test_tls)
         || !CU_add_test(pSuite, "xqc_test_h3_stream", xqc_test_stream)
         || !CU_add_test(pSuite, "xqc_test_h3_critical_stream_close", xqc_test_h3_critical_stream_close)

--- a/tests/unittest/xqc_tls_test.c
+++ b/tests/unittest/xqc_tls_test.c
@@ -882,36 +882,6 @@ void xqc_test_destroy_tls_ctx()
 }
 
 void
-xqc_test_tls_key_install_success()
-{
-    const char *direction;
-
-    direction = xqc_tls_key_install_error_direction(
-        XQC_KEY_TYPE_RX_READ, XQC_OK);
-    CU_ASSERT(direction == NULL);
-
-    direction = xqc_tls_key_install_error_direction(
-        XQC_KEY_TYPE_TX_WRITE, XQC_OK);
-    CU_ASSERT(direction == NULL);
-}
-
-void
-xqc_test_tls_key_install_failure()
-{
-    const char *direction;
-
-    direction = xqc_tls_key_install_error_direction(
-        XQC_KEY_TYPE_RX_READ, -XQC_TLS_DERIVE_KEY_ERROR);
-    CU_ASSERT(direction != NULL);
-    CU_ASSERT(strcmp(direction, "read") == 0);
-
-    direction = xqc_tls_key_install_error_direction(
-        XQC_KEY_TYPE_TX_WRITE, -XQC_TLS_DERIVE_KEY_ERROR);
-    CU_ASSERT(direction != NULL);
-    CU_ASSERT(strcmp(direction, "write") == 0);
-}
-
-void
 xqc_test_tls()
 {
     xqc_log_callbacks_t log_cb =  xqc_null_log_cb;

--- a/tests/unittest/xqc_tls_test.h
+++ b/tests/unittest/xqc_tls_test.h
@@ -6,7 +6,5 @@
 #define _XQC_TLS_TEST_INCLUDE_
 
 void xqc_test_tls();
-void xqc_test_tls_key_install_success();
-void xqc_test_tls_key_install_failure();
 
 #endif


### PR DESCRIPTION
### Mechanism

The key installation failure paths log their direction literal directly again,
and `xqc_tls_key_install_error_direction()` is removed. `key_type` is a
compile-time constant at both call sites, so the helper only replaced the
`ret != XQC_OK` failure check with a string-nullness check, exported a
cross-module symbol to produce a log literal, and turned static log text into
a runtime `%s` argument. Its unit tests asserted only the helper's own string
mapping and therefore passed even with a wrong format string at a call site;
read and write key installation stays covered by the existing handshake tests.
Diagnostic output only, no wire behavior change.

Fixes: #873

- RFC or draft: `Not applicable`

### Validation Cases

- Not applicable — diagnostic-only change with no client-to-server behavior.

### CONTRIBUTING.md

- Overall: `Pending`
- Local regression: `Complete`
- CI: `Pending`
