### PR TITLE
[~] Fix QUIC 0-RTT transport error code collision

### DIFF
--- a/include/xquic/xqc_errno.h
+++ b/include/xquic/xqc_errno.h
@@ -37,8 +37,9 @@ typedef enum {
     TRA_INVALID_TOKEN               =  0xB,
     TRA_APPLICATION_ERROR           =  0xC,
     TRA_CRYPTO_BUFFER_EXCEEDED      =  0xD,
-    TRA_0RTT_TRANS_PARAMS_ERROR     =  0xE,   /**< MUST delete the current saved 0RTT transport parameters */
+    TRA_KEY_UPDATE_ERROR            =  0xE,   /**< RFC 9001 Section 6.7 */
     TRA_AEAD_LIMIT_REACHED          =  0x1e,  /**< RFC 9001 §6.6: AEAD integrity limit reached */
+    TRA_NO_VIABLE_PATH              =  0x10,  /**< RFC 9000 Section 8.2.4 */
     /*
      * RFC 9000 Section 6.2 does not assign a CONNECTION_CLOSE code for
      * the Version Negotiation abort path, because the client cannot
@@ -48,6 +49,14 @@ typedef enum {
      * close reasons, but it is never serialised onto the wire.
      */
     TRA_VERSION_NEGOTIATION_ERROR   =  0x53,
+    /*
+     * Library-internal close reasons. They remain visible through
+     * xqc_conn_get_errno() so callers can discard incompatible 0-RTT state,
+     * but CONNECTION_CLOSE serialization maps them to the errors required by
+     * RFC 9000 Section 7.4.1 and RFC 9221 Section 3.
+     */
+    TRA_0RTT_TRANS_PARAMS_ERROR     =  0x54,
+    TRA_0RTT_DGRAM_PARAMS_ERROR     =  0x55,
     /* RFC 9001 Section 4.8: TLS alert 120 maps to 0x100 + 120 = 0x178 */
     TRA_NO_APPLICATION_PROTOCOL     =  0x178,
 } xqc_trans_err_code_t;

--- a/scripts/case_test.sh
+++ b/scripts/case_test.sh
@@ -1980,8 +1980,8 @@ clear_log
 echo -e "0RTT max_datagram_frame_size is invalid...\c"
 ${CLIENT_BIN} -l d >> stdlog
 cli_result=`grep "|0RTT_transport_params|max_datagram_frame_size:9000|" clog`
-cli_err=`grep "[error].*err:0xe" clog`
-svr_err=`grep "[error].*err:0xe" slog`
+cli_err=`grep "[error].*err:0x55" clog`
+svr_err=`grep "[error].*err:0xa" slog`
 if [ -n "$cli_result" ] && [ -n "$cli_err" ] && [ -n "$svr_err" ]; then
     echo ">>>>>>>> pass:1"
     case_print_result "0rtt_max_datagram_frame_size_is_invalid" "pass"
@@ -3962,7 +3962,7 @@ sleep 1
 clear_log
 echo -e "check_clear_0rtt_ticket_flag_in_close_notify...\c"
 ${CLIENT_BIN} -l d -T 1 -s 4800 -U 1 -Q 65535 -E > stdlog
-cli_res2=`grep "should_clear_0rtt_ticket, conn_err:14, clear_0rtt_ticket:1" stdlog`
+cli_res2=`grep "conn_err:85, clear_0rtt_ticket:1" stdlog`
 errlog=`grep_err_log`
 if [ -n "$cli_res2" ] && [ -n "$errlog" ]; then
     echo ">>>>>>>> pass:1"
@@ -3984,7 +3984,7 @@ sleep 1
 clear_log
 echo -e "check_clear_0rtt_ticket_flag_in_h3_close_notify...\c"
 ${CLIENT_BIN} -l d -s 4800 -Q 65535 -E > stdlog
-cli_res2=`grep "should_clear_0rtt_ticket, conn_err:14, clear_0rtt_ticket:1" stdlog`
+cli_res2=`grep "conn_err:85, clear_0rtt_ticket:1" stdlog`
 errlog=`grep_err_log`
 if [ -n "$cli_res2" ] && [ -n "$errlog" ]; then
     echo ">>>>>>>> pass:1"
@@ -4006,7 +4006,7 @@ sleep 1
 clear_log
 echo -e "check_clear_0rtt_ticket_flag_in_h3_close_notify...\c"
 ${CLIENT_BIN} -l d -s 4800 -Q 65535 -E > stdlog
-cli_res2=`grep "should_clear_0rtt_ticket, conn_err:14, clear_0rtt_ticket:1" stdlog`
+cli_res2=`grep "conn_err:85, clear_0rtt_ticket:1" stdlog`
 errlog=`grep_err_log`
 if [ -n "$cli_res2" ] && [ -n "$errlog" ]; then
     echo ">>>>>>>> pass:1"
@@ -5266,8 +5266,8 @@ fi
 ## RFC 9000 Section 7.4.1: 0-RTT transport parameter validation
 
 # test 701: server reduces max_streams_bidi after first connection,
-# client detects reduction on 0-RTT resumption and closes with
-# TRANSPORT_PARAMETER_ERROR (0x0E = conn_err:14)
+# client detects reduction on 0-RTT resumption, reports its local cleanup
+# reason (0x54 = conn_err:84), and sends TRANSPORT_PARAMETER_ERROR (0x08)
 killall test_server 2> /dev/null
 clear_log
 rm -f test_session xqc_token tp_localhost
@@ -5278,8 +5278,9 @@ sleep 1
 ${CLIENT_BIN} -s 1024 -l d -t 1 -E > stdlog
 # second connection: 0-RTT with reduced max_streams_bidi on server
 ${CLIENT_BIN} -s 1024 -l d -t 1 -E > stdlog
-conn_err=`grep "conn_err:14" stdlog`
-if [ -n "$conn_err" ]; then
+conn_err=`grep "conn_err:84" stdlog`
+peer_err=`grep "[error].*err:0x8" slog`
+if [ -n "$conn_err" ] && [ -n "$peer_err" ]; then
     echo ">>>>>>>> pass:1"
     case_print_result "0RTT_param_reduction" "pass"
 else

--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -6222,7 +6222,7 @@ xqc_conn_tls_transport_params_cb(const uint8_t *tp, size_t len, void *user_data)
                 "remembered:%ui|new:%ui|",
                 conn->remote_settings.max_datagram_frame_size,
                 params.max_datagram_frame_size);
-        XQC_CONN_ERR(conn, TRA_0RTT_TRANS_PARAMS_ERROR);
+        XQC_CONN_ERR(conn, TRA_0RTT_DGRAM_PARAMS_ERROR);
         return;
     }
 
@@ -7159,7 +7159,9 @@ xqc_conn_destroy_ping_notification_list(xqc_connection_t *conn)
 xqc_bool_t 
 xqc_conn_should_clear_0rtt_ticket(xqc_int_t conn_err)
 {
-    if (conn_err == TRA_0RTT_TRANS_PARAMS_ERROR) {
+    if (conn_err == TRA_0RTT_TRANS_PARAMS_ERROR
+        || conn_err == TRA_0RTT_DGRAM_PARAMS_ERROR)
+    {
         return XQC_TRUE;
     }
     return XQC_FALSE;

--- a/src/transport/xqc_packet_out.c
+++ b/src/transport/xqc_packet_out.c
@@ -770,6 +770,22 @@ error:
     return ret;
 }
 
+uint64_t
+xqc_conn_close_wire_error_code(uint64_t err_code)
+{
+    /* Preserve local cleanup reasons without leaking them onto the wire. */
+    if (err_code == TRA_0RTT_TRANS_PARAMS_ERROR) {
+        return TRA_TRANSPORT_PARAMETER_ERROR;
+    }
+
+    if (err_code == TRA_0RTT_DGRAM_PARAMS_ERROR) {
+        return TRA_PROTOCOL_VIOLATION;
+    }
+
+    return err_code;
+}
+
+
 int
 xqc_write_conn_close_to_packet(xqc_connection_t *conn, uint64_t err_code)
 {
@@ -795,7 +811,9 @@ xqc_write_conn_close_to_packet(xqc_connection_t *conn, uint64_t err_code)
         return -XQC_EWRITE_PKT;
     }
 
-    ret = xqc_gen_conn_close_frame(packet_out, err_code, err_code >= H3_NO_ERROR ? 1:0, 0);
+    err_code = xqc_conn_close_wire_error_code(err_code);
+    ret = xqc_gen_conn_close_frame(packet_out, err_code,
+                                   err_code >= H3_NO_ERROR ? 1 : 0, 0);
     if (ret < 0) {
         xqc_log(conn->log, XQC_LOG_ERROR, "|xqc_gen_conn_close_frame error|");
         goto error;

--- a/src/transport/xqc_packet_out.h
+++ b/src/transport/xqc_packet_out.h
@@ -170,6 +170,8 @@ int xqc_write_ack_to_one_packet(xqc_connection_t *conn, xqc_packet_out_t *packet
 int xqc_write_ping_to_packet(xqc_connection_t *conn, xqc_path_ctx_t *path, 
     void *po_user_data, xqc_bool_t notify, xqc_ping_record_t *pr);
 
+uint64_t xqc_conn_close_wire_error_code(uint64_t err_code);
+
 int xqc_write_conn_close_to_packet(xqc_connection_t *conn, uint64_t err_code);
 
 int xqc_write_reset_stream_to_packet(xqc_connection_t *conn, xqc_stream_t *stream, uint64_t err_code, uint64_t final_size);

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -86,6 +86,10 @@ main(int argc, char *argv[])
         /* RFC 9000 §20.1 CRYPTO_ERROR dynamic construction */
         || !CU_add_test(pSuite, "xqc_test_conn_tls_error_cb_constructs_crypto_error", xqc_test_conn_tls_error_cb_constructs_crypto_error)
         || !CU_add_test(pSuite, "xqc_test_conn_crypto_error_base_value", xqc_test_conn_crypto_error_base_value)
+        || !CU_add_test(pSuite, "xqc_test_transport_error_code_passthrough",
+                        xqc_test_transport_error_code_passthrough)
+        || !CU_add_test(pSuite, "xqc_test_0rtt_error_wire_codes",
+                        xqc_test_0rtt_error_wire_codes)
         || !CU_add_test(pSuite, "xqc_test_conn_tls_error_first_writer_wins", xqc_test_conn_tls_error_first_writer_wins)
         || !CU_add_test(pSuite, "xqc_test_conn_tls_error_cb_alert_zero", xqc_test_conn_tls_error_cb_alert_zero)
         || !CU_add_test(pSuite, "xqc_test_conn_tls_error_cb_max_alert", xqc_test_conn_tls_error_cb_max_alert)
@@ -143,6 +147,8 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite,
                         "xqc_test_conn_close_transport_error_type_overlap",
                         xqc_test_conn_close_transport_error_type_overlap)
+        || !CU_add_test(pSuite, "xqc_test_peer_key_update_error_not_0rtt",
+                        xqc_test_peer_key_update_error_not_0rtt)
         || !CU_add_test(pSuite, "xqc_test_h3_frame", xqc_test_frame)
         || !CU_add_test(pSuite, "xqc_test_h3_single_vint_frame_valid",
                         xqc_test_h3_single_vint_frame_valid)

--- a/tests/unittest/xqc_conn_test.c
+++ b/tests/unittest/xqc_conn_test.c
@@ -21,6 +21,7 @@
 #include "src/transport/xqc_send_ctl.h"
 #include "src/transport/xqc_frame_parser.h"
 #include "src/transport/xqc_packet_in.h"
+#include "src/transport/xqc_packet_out.h"
 #include "src/transport/xqc_recv_record.h"
 
 extern void xqc_conn_tls_error_cb(xqc_int_t tls_err, void *user_data);
@@ -487,10 +488,15 @@ xqc_0rtt_test_fire(xqc_connection_t *conn, xqc_transport_params_t *params)
         || params->initial_max_stream_data_uni < remembered->max_stream_data_uni
         || params->initial_max_streams_bidi < remembered->max_streams_bidi
         || params->initial_max_streams_uni < remembered->max_streams_uni
-        || params->active_connection_id_limit < remembered->active_connection_id_limit
-        || params->max_datagram_frame_size < remembered->max_datagram_frame_size)
+        || params->active_connection_id_limit
+           < remembered->active_connection_id_limit)
     {
         XQC_CONN_ERR(conn, TRA_0RTT_TRANS_PARAMS_ERROR);
+
+    } else if (params->max_datagram_frame_size
+               < remembered->max_datagram_frame_size)
+    {
+        XQC_CONN_ERR(conn, TRA_0RTT_DGRAM_PARAMS_ERROR);
     }
 
     return conn->conn_err;
@@ -526,6 +532,45 @@ xqc_test_conn_crypto_error_base_value()
      */
     CU_ASSERT(TRA_CRYPTO_ERROR_BASE == 0x100);
     CU_ASSERT(TRA_INTERNAL_ERROR == 0x1);
+}
+
+
+void
+xqc_test_transport_error_code_passthrough(void)
+{
+    /* RFC 9000 Section 20.1 fixes these transport-error codepoints. */
+    CU_ASSERT_EQUAL(TRA_KEY_UPDATE_ERROR, 0x0e);
+    CU_ASSERT_EQUAL(TRA_NO_VIABLE_PATH, 0x10);
+
+    CU_ASSERT_EQUAL(xqc_conn_close_wire_error_code(TRA_KEY_UPDATE_ERROR),
+                    TRA_KEY_UPDATE_ERROR);
+    CU_ASSERT_EQUAL(xqc_conn_close_wire_error_code(TRA_NO_VIABLE_PATH),
+                    TRA_NO_VIABLE_PATH);
+
+    CU_ASSERT_FALSE(
+        xqc_conn_should_clear_0rtt_ticket(TRA_KEY_UPDATE_ERROR));
+}
+
+
+void
+xqc_test_0rtt_error_wire_codes(void)
+{
+    CU_ASSERT_NOT_EQUAL(TRA_0RTT_TRANS_PARAMS_ERROR,
+                        TRA_KEY_UPDATE_ERROR);
+    CU_ASSERT_NOT_EQUAL(TRA_0RTT_DGRAM_PARAMS_ERROR,
+                        TRA_KEY_UPDATE_ERROR);
+
+    CU_ASSERT_TRUE(xqc_conn_should_clear_0rtt_ticket(
+        TRA_0RTT_TRANS_PARAMS_ERROR));
+    CU_ASSERT_TRUE(xqc_conn_should_clear_0rtt_ticket(
+        TRA_0RTT_DGRAM_PARAMS_ERROR));
+
+    CU_ASSERT_EQUAL(
+        xqc_conn_close_wire_error_code(TRA_0RTT_TRANS_PARAMS_ERROR),
+        TRA_TRANSPORT_PARAMETER_ERROR);
+    CU_ASSERT_EQUAL(
+        xqc_conn_close_wire_error_code(TRA_0RTT_DGRAM_PARAMS_ERROR),
+        TRA_PROTOCOL_VIOLATION);
 }
 
 
@@ -603,31 +648,34 @@ void
 xqc_test_0rtt_params_each_reduced(void)
 {
     /*
-     * Reduce each MUST parameter individually and verify that every
-     * branch in the validation code triggers TRA_0RTT_TRANS_PARAMS_ERROR.
-     * Uses offset-based mutation so one loop covers all 8 fields.
+     * RFC 9000 Section 7.4.1 requires TRANSPORT_PARAMETER_ERROR for core
+     * parameters; RFC 9221 Section 3 requires PROTOCOL_VIOLATION for the
+     * DATAGRAM parameter. Local reasons keep both paths distinguishable.
      */
     struct {
-        size_t   tp_offset;       /* offset into xqc_transport_params_t */
-        size_t   rs_offset;       /* offset into xqc_trans_settings_t (for datagram) */
+        size_t   tp_offset;
         uint64_t remembered_val;
+        xqc_int_t expected_err;
     } cases[] = {
         { offsetof(xqc_transport_params_t, initial_max_data),
-          0, REMEMBERED_MAX_DATA },
+          REMEMBERED_MAX_DATA, TRA_0RTT_TRANS_PARAMS_ERROR },
         { offsetof(xqc_transport_params_t, initial_max_stream_data_bidi_local),
-          0, REMEMBERED_MAX_STREAM_DATA_BIDI_LOCAL },
+          REMEMBERED_MAX_STREAM_DATA_BIDI_LOCAL,
+          TRA_0RTT_TRANS_PARAMS_ERROR },
         { offsetof(xqc_transport_params_t, initial_max_stream_data_bidi_remote),
-          0, REMEMBERED_MAX_STREAM_DATA_BIDI_REMOTE },
+          REMEMBERED_MAX_STREAM_DATA_BIDI_REMOTE,
+          TRA_0RTT_TRANS_PARAMS_ERROR },
         { offsetof(xqc_transport_params_t, initial_max_stream_data_uni),
-          0, REMEMBERED_MAX_STREAM_DATA_UNI },
+          REMEMBERED_MAX_STREAM_DATA_UNI, TRA_0RTT_TRANS_PARAMS_ERROR },
         { offsetof(xqc_transport_params_t, initial_max_streams_bidi),
-          0, REMEMBERED_MAX_STREAMS_BIDI },
+          REMEMBERED_MAX_STREAMS_BIDI, TRA_0RTT_TRANS_PARAMS_ERROR },
         { offsetof(xqc_transport_params_t, initial_max_streams_uni),
-          0, REMEMBERED_MAX_STREAMS_UNI },
+          REMEMBERED_MAX_STREAMS_UNI, TRA_0RTT_TRANS_PARAMS_ERROR },
         { offsetof(xqc_transport_params_t, active_connection_id_limit),
-          0, REMEMBERED_ACTIVE_CID_LIMIT },
+          REMEMBERED_ACTIVE_CID_LIMIT, TRA_0RTT_TRANS_PARAMS_ERROR },
         { offsetof(xqc_transport_params_t, max_datagram_frame_size),
-          0, REMEMBERED_MAX_DGRAM_FRAME_SIZE },
+          REMEMBERED_MAX_DGRAM_FRAME_SIZE,
+          TRA_0RTT_DGRAM_PARAMS_ERROR },
     };
     size_t n = sizeof(cases) / sizeof(cases[0]);
 
@@ -643,7 +691,7 @@ xqc_test_0rtt_params_each_reduced(void)
         *field = cases[i].remembered_val - 1;
 
         xqc_int_t err = xqc_0rtt_test_fire(conn, &params);
-        CU_ASSERT_EQUAL(err, TRA_0RTT_TRANS_PARAMS_ERROR);
+        CU_ASSERT_EQUAL(err, cases[i].expected_err);
 
         xqc_engine_destroy(conn->engine);
     }

--- a/tests/unittest/xqc_conn_test.h
+++ b/tests/unittest/xqc_conn_test.h
@@ -13,6 +13,8 @@ void xqc_test_conn_early_data_reject_flow_ctl();
 /* RFC 9000 §20.1 CRYPTO_ERROR dynamic construction */
 void xqc_test_conn_tls_error_cb_constructs_crypto_error();
 void xqc_test_conn_crypto_error_base_value();
+void xqc_test_transport_error_code_passthrough(void);
+void xqc_test_0rtt_error_wire_codes(void);
 void xqc_test_conn_tls_error_first_writer_wins();
 void xqc_test_conn_tls_error_cb_alert_zero();
 void xqc_test_conn_tls_error_cb_max_alert();

--- a/tests/unittest/xqc_process_frame_test.c
+++ b/tests/unittest/xqc_process_frame_test.c
@@ -189,6 +189,35 @@ xqc_test_conn_close_transport_error_type_overlap(void)
 
 
 void
+xqc_test_peer_key_update_error_not_0rtt(void)
+{
+    unsigned char frame[] = {
+        0x1c, 0x0e, 0x00, 0x00
+    };
+    xqc_connection_t *conn;
+    xqc_packet_in_t packet_in;
+    xqc_int_t ret;
+
+    conn = test_engine_connect();
+    CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+
+    memset(&packet_in, 0, sizeof(packet_in));
+    packet_in.pos = frame;
+    packet_in.last = frame + sizeof(frame);
+
+    ret = xqc_process_conn_close_frame(conn, &packet_in);
+
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    CU_ASSERT_EQUAL(conn->conn_err, TRA_KEY_UPDATE_ERROR);
+    CU_ASSERT_EQUAL(xqc_conn_get_err_type(conn),
+                    XQC_CONN_ERR_TYPE_TRANSPORT);
+    CU_ASSERT_FALSE(xqc_conn_should_clear_0rtt_ticket(conn->conn_err));
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
+void
 xqc_test_large_ack_frame()
 {
     xqc_connection_t *conn = test_engine_connect();

--- a/tests/unittest/xqc_process_frame_test.h
+++ b/tests/unittest/xqc_process_frame_test.h
@@ -43,4 +43,6 @@ void xqc_test_conn_close_application_error_type(void);
 
 void xqc_test_conn_close_transport_error_type_overlap(void);
 
+void xqc_test_peer_key_update_error_not_0rtt(void);
+
 #endif /* _XQC_PROCESS_FRAME_TEST_H_INCLUDED_ */


### PR DESCRIPTION
### Mechanism

Free the RFC 9000 Section 20.1 `KEY_UPDATE_ERROR` codepoint by moving XQUIC's
local 0-RTT cleanup reasons to distinct internal values, and add the registered
`NO_VIABLE_PATH` name. `TRA_AEAD_LIMIT_REACHED` remains unchanged. Core 0-RTT
transport-parameter reductions are serialized as `TRANSPORT_PARAMETER_ERROR`
per RFC 9000 Section 7.4.1, while DATAGRAM parameter reductions are serialized
as `PROTOCOL_VIOLATION` per RFC 9221 Section 3.

Fixes: #628

- RFC or draft: RFC 9000 Sections 7.4.1 and 20.1; RFC 9001 Section 6.7;
  RFC 9221 Section 3

### Validation Cases

- Not executed — the existing 0-RTT client-to-server cases lack targeted
  selectors, and the full legacy case suite remains pending.

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Incomplete — legacy 0-RTT client-to-server cases not
  executed
- CI: Pending
