### PR TITLE
[~]: Reject zero-length NEW_CONNECTION_ID encoding

### DIFF
--- a/src/transport/xqc_frame_parser.c
+++ b/src/transport/xqc_frame_parser.c
@@ -1994,7 +1994,7 @@ xqc_parse_handshake_done_frame(xqc_packet_in_t *packet_in, xqc_connection_t *con
 }
 
 /*
- * https://tools.ietf.org/html/draft-ietf-quic-transport-34#section-19.15
+ * https://www.rfc-editor.org/rfc/rfc9000.html#section-19.15
  *
  * NEW_CONNECTION_ID Frame {
  *    Type (i) = 0x18,
@@ -2011,6 +2011,13 @@ ssize_t
 xqc_gen_new_conn_id_frame(xqc_packet_out_t *packet_out, xqc_cid_t *new_cid,
     uint64_t retire_prior_to, const uint8_t *sr_token)
 {
+    uint64_t cid_len = new_cid->cid_len;
+
+    /* RFC 9000 Section 19.15 requires CID lengths from 1 to 20. */
+    if (cid_len == 0 || cid_len > XQC_MAX_CID_LEN) {
+        return -XQC_EPARAM;
+    }
+
     unsigned char *dst_buf = packet_out->po_buf + packet_out->po_used_size;
     const unsigned char *begin = dst_buf;
 
@@ -2018,13 +2025,7 @@ xqc_gen_new_conn_id_frame(xqc_packet_out_t *packet_out, xqc_cid_t *new_cid,
 
     unsigned sequence_number_bits = xqc_vint_get_2bit(new_cid->cid_seq_num);
     unsigned retire_prior_to_bits = xqc_vint_get_2bit(retire_prior_to);
-    uint64_t cid_len = new_cid->cid_len;
     uint8_t cid_len_bits = xqc_vint_get_2bit(cid_len);
-
-    /* make sure cid_len won't exceed XQC_MAX_CID_LEN */
-    if (cid_len > XQC_MAX_CID_LEN) {
-        return -XQC_EPARAM;
-    }
 
     xqc_vint_write(dst_buf, new_cid->cid_seq_num, 
                    sequence_number_bits, xqc_vint_len(sequence_number_bits));

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -134,6 +134,10 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite, "xqc_test_ack_ecn_truncated", xqc_test_ack_ecn_truncated)
         || !CU_add_test(pSuite, "xqc_test_ack_ecn_followed_by_ping", xqc_test_ack_ecn_followed_by_ping)
         || !CU_add_test(pSuite, "xqc_test_new_conn_id_zero_len_cid", xqc_test_new_conn_id_zero_len_cid)
+        || !CU_add_test(pSuite, "xqc_test_gen_new_conn_id_frame_min_cid",
+                        xqc_test_gen_new_conn_id_frame_min_cid)
+        || !CU_add_test(pSuite, "xqc_test_gen_new_conn_id_frame_zero_cid",
+                        xqc_test_gen_new_conn_id_frame_zero_cid)
         || !CU_add_test(pSuite, "xqc_test_new_conn_id_active_limit_accept",
                         xqc_test_new_conn_id_active_limit_accept)
         || !CU_add_test(pSuite, "xqc_test_new_conn_id_active_limit_exceeded",

--- a/tests/unittest/xqc_process_frame_test.c
+++ b/tests/unittest/xqc_process_frame_test.c
@@ -9,6 +9,7 @@
 #include "src/transport/xqc_frame_parser.h"
 #include "src/transport/xqc_packet.h"
 #include "src/transport/xqc_packet_in.h"
+#include "src/transport/xqc_packet_out.h"
 #include "src/common/utils/vint/xqc_variable_len_int.h"
 #include "src/transport/xqc_conn.h"
 #include "xquic/xqc_errno.h"
@@ -803,6 +804,68 @@ xqc_test_new_conn_id_zero_len_cid(void)
     CU_ASSERT(conn->conn_err == TRA_FRAME_ENCODING_ERROR);
 
     xqc_engine_destroy(conn->engine);
+}
+
+
+void
+xqc_test_gen_new_conn_id_frame_min_cid(void)
+{
+    xqc_packet_out_t *packet_out;
+    xqc_cid_t cid;
+    uint8_t sr_token[XQC_STATELESS_RESET_TOKENLEN] = {0};
+    ssize_t ret;
+
+    packet_out = xqc_packet_out_create(XQC_QUIC_MAX_MSS);
+    CU_ASSERT(packet_out != NULL);
+    if (packet_out == NULL) {
+        return;
+    }
+
+    memset(&cid, 0, sizeof(cid));
+    cid.cid_len = 1;
+    cid.cid_seq_num = 1;
+    cid.cid_buf[0] = 0xa5;
+
+    ret = xqc_gen_new_conn_id_frame(packet_out, &cid, 0, sr_token);
+
+    CU_ASSERT(ret == 5 + XQC_STATELESS_RESET_TOKENLEN);
+    CU_ASSERT(packet_out->po_buf[0] == 0x18);
+    CU_ASSERT(packet_out->po_buf[1] == 0x01);
+    CU_ASSERT(packet_out->po_buf[2] == 0x00);
+    CU_ASSERT(packet_out->po_buf[3] == 0x01);
+    CU_ASSERT(packet_out->po_buf[4] == 0xa5);
+    CU_ASSERT(packet_out->po_frame_types
+              == XQC_FRAME_BIT_NEW_CONNECTION_ID);
+
+    xqc_packet_out_destroy(packet_out);
+}
+
+
+void
+xqc_test_gen_new_conn_id_frame_zero_cid(void)
+{
+    xqc_packet_out_t *packet_out;
+    xqc_cid_t cid;
+    uint8_t sr_token[XQC_STATELESS_RESET_TOKENLEN] = {0};
+    ssize_t ret;
+
+    packet_out = xqc_packet_out_create(XQC_QUIC_MAX_MSS);
+    CU_ASSERT(packet_out != NULL);
+    if (packet_out == NULL) {
+        return;
+    }
+
+    memset(&cid, 0, sizeof(cid));
+    packet_out->po_buf[0] = 0xa5;
+    packet_out->po_frame_types = XQC_FRAME_BIT_PING;
+
+    ret = xqc_gen_new_conn_id_frame(packet_out, &cid, 0, sr_token);
+
+    CU_ASSERT(ret == -XQC_EPARAM);
+    CU_ASSERT(packet_out->po_buf[0] == 0xa5);
+    CU_ASSERT(packet_out->po_frame_types == XQC_FRAME_BIT_PING);
+
+    xqc_packet_out_destroy(packet_out);
 }
 
 static size_t

--- a/tests/unittest/xqc_process_frame_test.h
+++ b/tests/unittest/xqc_process_frame_test.h
@@ -35,6 +35,10 @@ void xqc_test_ack_ecn_followed_by_ping();
 
 void xqc_test_new_conn_id_zero_len_cid(void);
 
+void xqc_test_gen_new_conn_id_frame_min_cid(void);
+
+void xqc_test_gen_new_conn_id_frame_zero_cid(void);
+
 void xqc_test_new_conn_id_active_limit_accept(void);
 
 void xqc_test_new_conn_id_active_limit_exceeded(void);


### PR DESCRIPTION
### Mechanism

Reject NEW_CONNECTION_ID connection ID lengths outside the RFC-defined
1-to-20-byte range before writing any frame bytes or setting frame flags.
Valid boundary encoding remains unchanged.

Fixes: #587

- RFC or draft: [RFC 9000 Section 19.15](https://www.rfc-editor.org/rfc/rfc9000.html#section-19.15)

### Validation Cases

- Not applicable — supported connection setup cannot select a zero-length
  local CID; the valid and invalid boundaries are covered directly at the
  frame encoder.

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Incomplete — client-to-server zero-length CID setup is unavailable
- CI: Pending — Build / Harness Check and CodeQL queued