### PR TITLE
[~]: Reject wrong-direction stream frames per RFC 9000

### DIFF
--- a/harness/spec/validation.md
+++ b/harness/spec/validation.md
@@ -97,7 +97,7 @@ its case is retired so later changes cannot reuse it.
 
 | Range | New-case namespace | Allocated IDs |
 |-------|--------------------|---------------|
-| `[705, 799]` | QUIC Transport core | `709-710` |
+| `[705, 799]` | QUIC Transport core | `705-710` |
 | `[800, 899]` | Recovery and congestion control | None |
 | `[900, 999]` | QUIC-TLS | None |
 | `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1014` |

--- a/scripts/case_test.sh
+++ b/scripts/case_test.sh
@@ -5712,4 +5712,50 @@ fi
 
 killall test_server 2> /dev/null
 
+
+# issues #565 / #566 / #567: a frame naming a stream the peer does not own must
+# close the connection with STREAM_STATE_ERROR (0x5) per RFC 9000 section 19.4,
+# section 19.5 and section 19.8. Each case asserts both the server side reason
+# and the error code the client actually observes in CONNECTION_CLOSE, so a
+# generic failure or an unrelated close cannot satisfy it.
+
+function wrong_direction_stream_case() {
+    case_id=$1
+    case_name=$2
+    server_reason=$3
+
+    killall test_server 2> /dev/null
+    clear_log
+    rm -f test_session xqc_token tp_localhost
+    ${SERVER_BIN} -l d -e > /dev/null &
+    sleep 1
+    echo -e "${case_name} ...\c"
+    ${CLIENT_BIN} -s 1024 -l d -t 1 -E -x ${case_id} >> clog
+    sleep 1
+    server_rejected=`grep "${server_reason}" slog`
+    client_close_code=`grep "xqc_parse_conn_close_frame|type:18|err_code:5|" clog`
+    if [ -n "$server_rejected" ] && [ -n "$client_close_code" ]; then
+        echo ">>>>>>>> pass:1"
+        case_print_result "${case_name}" "pass"
+    else
+        echo ">>>>>>>> pass:0"
+        case_print_result "${case_name}" "fail"
+    fi
+    killall test_server 2> /dev/null
+}
+
+wrong_direction_stream_case 705 "reset_stream_on_send_only_stream" \
+    "RESET_STREAM on send-only stream|stream_id:3|"
+
+wrong_direction_stream_case 706 "stop_sending_on_recv_only_stream" \
+    "STOP_SENDING on recv-only stream|stream_id:2|"
+
+wrong_direction_stream_case 707 "stream_frame_on_send_only_stream" \
+    "STREAM frame on send-only stream|stream_id:3|"
+
+wrong_direction_stream_case 708 "stream_frame_on_local_uncreated_stream" \
+    "STREAM frame on locally initiated uncreated stream|stream_id:1|"
+
+killall test_server 2> /dev/null
+
 cd -

--- a/src/transport/xqc_frame.c
+++ b/src/transport/xqc_frame.c
@@ -20,6 +20,23 @@
 #include "src/tls/xqc_tls.h"
 
 
+/*
+ * Whether stream_id denotes a locally initiated bidirectional stream that has
+ * never been created.  xqc_gen_stream_id() assigns each locally initiated
+ * stream its index by post-incrementing cur_stream_id_bidi_local, so indexes
+ * [0, counter) have been created and anything at or above it has not.
+ *
+ * Only locally initiated bidirectional streams reach the caller: locally
+ * initiated unidirectional streams are send-only and are already rejected
+ * while parsing, and peer initiated streams are created passively.
+ */
+static inline xqc_int_t
+xqc_stream_local_bidi_uncreated(xqc_connection_t *conn, xqc_stream_id_t stream_id)
+{
+    return (stream_id >> 2) >= conn->cur_stream_id_bidi_local;
+}
+
+
 
 static const char * const frame_type_2_str[XQC_FRAME_NUM] = {
     [XQC_FRAME_PADDING]              = "PADDING",
@@ -496,6 +513,21 @@ xqc_process_stream_frame(xqc_connection_t *conn, xqc_packet_in_t *packet_in)
             if (!stream) {
                 goto free;
             }
+
+        } else if (xqc_stream_local_bidi_uncreated(conn, stream_id)) {
+            /*
+             * RFC 9000 19.8: receiving a STREAM frame for a locally initiated
+             * stream that has not yet been created MUST be treated as a
+             * connection error of type STREAM_STATE_ERROR.  A stream index
+             * below the local counter was created earlier and has since been
+             * closed, so a retransmitted frame for it is still tolerated below.
+             */
+            xqc_log(conn->log, XQC_LOG_ERROR,
+                    "|STREAM frame on locally initiated uncreated stream|stream_id:%ui|",
+                    stream_id);
+            XQC_CONN_ERR(conn, TRA_STREAM_STATE_ERROR);
+            ret = -XQC_EPROTO;
+            goto error;
 
         } else {
             xqc_log(conn->log, XQC_LOG_WARN, "|cannot find stream|stream_id:%ui|", stream_id);

--- a/src/transport/xqc_frame_parser.c
+++ b/src/transport/xqc_frame_parser.c
@@ -303,6 +303,14 @@ xqc_parse_stream_frame(xqc_packet_in_t *packet_in, xqc_connection_t *conn,
     }
     p += vlen;
 
+    /* RFC 9000 19.8: reject STREAM frame on a send-only stream */
+    if (xqc_stream_is_send_only(conn->conn_type, *stream_id)) {
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|STREAM frame on send-only stream|stream_id:%ui|", *stream_id);
+        XQC_CONN_ERR(conn, TRA_STREAM_STATE_ERROR);
+        return -XQC_EPROTO;
+    }
+
     if (first_byte & 0x04) {
         vlen = xqc_vint_read(p, end, &offset);
         if (vlen < 0) {
@@ -1458,6 +1466,14 @@ xqc_parse_reset_stream_frame(xqc_packet_in_t *packet_in, xqc_stream_id_t *stream
     }
     p += vlen;
 
+    /* RFC 9000 19.4: reject RESET_STREAM on a send-only stream */
+    if (xqc_stream_is_send_only(conn->conn_type, *stream_id)) {
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|RESET_STREAM on send-only stream|stream_id:%ui|", *stream_id);
+        XQC_CONN_ERR(conn, TRA_STREAM_STATE_ERROR);
+        return -XQC_EPROTO;
+    }
+
     vlen = xqc_vint_read(p, end, err_code);
     if (vlen < 0) {
         return -XQC_EVINTREAD;
@@ -1535,6 +1551,14 @@ xqc_parse_stop_sending_frame(xqc_packet_in_t *packet_in, xqc_stream_id_t *stream
         return -XQC_EVINTREAD;
     }
     p += vlen;
+
+    /* RFC 9000 19.5: reject STOP_SENDING on a recv-only stream */
+    if (xqc_stream_is_recv_only(conn->conn_type, *stream_id)) {
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|STOP_SENDING on recv-only stream|stream_id:%ui|", *stream_id);
+        XQC_CONN_ERR(conn, TRA_STREAM_STATE_ERROR);
+        return -XQC_EPROTO;
+    }
 
     vlen = xqc_vint_read(p, end, err_code);
     if (vlen < 0) {

--- a/src/transport/xqc_stream.h
+++ b/src/transport/xqc_stream.h
@@ -221,6 +221,28 @@ xqc_stream_is_uni(xqc_stream_id_t stream_id)
     return stream_id & 0x02;
 }
 
+/*
+ * RFC 9000 2.1: the two low bits of a stream ID identify the initiator and the
+ * directionality.  A unidirectional stream initiated by the local endpoint has
+ * no receive side (send-only); one initiated by the peer has no send side
+ * (recv-only).  Bidirectional streams are neither.
+ */
+static inline xqc_int_t
+xqc_stream_is_send_only(xqc_conn_type_t conn_type, xqc_stream_id_t stream_id)
+{
+    xqc_stream_type_t stype = xqc_get_stream_type(stream_id);
+    return (conn_type == XQC_CONN_TYPE_CLIENT && stype == XQC_CLI_UNI)
+           || (conn_type == XQC_CONN_TYPE_SERVER && stype == XQC_SVR_UNI);
+}
+
+static inline xqc_int_t
+xqc_stream_is_recv_only(xqc_conn_type_t conn_type, xqc_stream_id_t stream_id)
+{
+    xqc_stream_type_t stype = xqc_get_stream_type(stream_id);
+    return (conn_type == XQC_CONN_TYPE_CLIENT && stype == XQC_SVR_UNI)
+           || (conn_type == XQC_CONN_TYPE_SERVER && stype == XQC_CLI_UNI);
+}
+
 void xqc_stream_set_priority(xqc_stream_t *stream, xqc_stream_priority_t priority);
 
 xqc_stream_t *xqc_create_stream_with_conn (xqc_connection_t *conn, xqc_stream_id_t stream_id,

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -19,6 +19,8 @@
 #include <xquic/xqc_http3.h>
 #include "src/http3/xqc_h3_conn.h"
 #include "src/http3/xqc_h3_request.h"
+#include "src/transport/xqc_packet_out.h"
+#include "src/transport/xqc_frame_parser.h"
 #include "platform.h"
 #ifndef XQC_SYS_WINDOWS
 #include <unistd.h>
@@ -1925,6 +1927,73 @@ xqc_client_h3_conn_close_notify(xqc_h3_conn_t *conn, const xqc_cid_t *cid, void 
     return 0;
 }
 
+/*
+ * issues #565 / #566 / #567: emit a frame that names a stream this endpoint
+ * does not own, so the peer must close the connection with STREAM_STATE_ERROR
+ * (RFC 9000 section 19.4, section 19.5 and section 19.8).
+ *
+ * The library never generates such a frame, and the illegal frame lives inside
+ * the encrypted 1-RTT payload, so it cannot be produced by corrupting bytes in
+ * the send callback the way the Initial-header cases do. The frame generators
+ * take a stream ID directly, so they are called on a freshly allocated packet
+ * without going through a stream object.
+ *
+ * Stream IDs, seen from the server that receives the frame:
+ *   2 -> XQC_CLI_UNI  client initiated, unidirectional: recv-only for server
+ *   3 -> XQC_SVR_UNI  server initiated, unidirectional: send-only for server
+ *   1 -> XQC_SVR_BID  server initiated, bidirectional: never created by server
+ */
+static void
+xqc_client_send_wrong_direction_frame(xqc_connection_t *conn)
+{
+    xqc_packet_out_t *packet_out;
+    ssize_t           ret = -1;
+    size_t            written = 0;
+    const unsigned char payload[1] = {0x00};
+
+    packet_out = xqc_write_new_packet(conn, XQC_PTYPE_SHORT_HEADER);
+    if (packet_out == NULL) {
+        printf("test case %d, xqc_write_new_packet error\n", g_test_case);
+        return;
+    }
+
+    switch (g_test_case) {
+    case 705:
+        /* RESET_STREAM on a stream that is send-only for the server */
+        ret = xqc_gen_reset_stream_frame(packet_out, 3, 0, 0);
+        break;
+
+    case 706:
+        /* STOP_SENDING on a stream that is recv-only for the server */
+        ret = xqc_gen_stop_sending_frame(packet_out, 2, 0);
+        break;
+
+    case 707:
+        /* STREAM on a stream that is send-only for the server */
+        ret = xqc_gen_stream_frame(packet_out, 3, 0, 0, payload,
+                                   sizeof(payload), &written);
+        break;
+
+    case 708:
+        /* STREAM on a server initiated stream the server never created */
+        ret = xqc_gen_stream_frame(packet_out, 1, 0, 0, payload,
+                                   sizeof(payload), &written);
+        break;
+
+    default:
+        break;
+    }
+
+    if (ret < 0) {
+        printf("test case %d, frame generation error:%zd\n", g_test_case, ret);
+        xqc_maybe_recycle_packet_out(packet_out, conn);
+        return;
+    }
+
+    packet_out->po_used_size += ret;
+    printf("test case %d, wrong direction frame written\n", g_test_case);
+}
+
 void
 xqc_client_h3_conn_handshake_finished(xqc_h3_conn_t *h3_conn, void *user_data)
 {
@@ -1940,6 +2009,11 @@ xqc_client_h3_conn_handshake_finished(xqc_h3_conn_t *h3_conn, void *user_data)
     if (!g_mp_ping_on) {
         xqc_h3_conn_send_ping(p_ctx->engine, &user_conn->cid, NULL);
         xqc_h3_conn_send_ping(p_ctx->engine, &user_conn->cid, &g_ping_id);
+    }
+
+    /* issues #565/#566/#567: wrong direction frame, 1-RTT is available here */
+    if (g_test_case >= 705 && g_test_case <= 708) {
+        xqc_client_send_wrong_direction_frame(h3_conn->conn);
     }
 
     xqc_conn_stats_t stats = xqc_conn_get_stats(p_ctx->engine, &user_conn->cid);

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -159,6 +159,29 @@ main(int argc, char *argv[])
                         xqc_test_conn_close_transport_error_type_overlap)
         || !CU_add_test(pSuite, "xqc_test_peer_key_update_error_not_0rtt",
                         xqc_test_peer_key_update_error_not_0rtt)
+        /* issues #565/#566/#567: RFC 9000 stream directionality checks */
+        || !CU_add_test(pSuite, "xqc_test_reset_stream_on_send_only_stream",
+                        xqc_test_reset_stream_on_send_only_stream)
+        || !CU_add_test(pSuite, "xqc_test_reset_stream_on_send_only_stream_server",
+                        xqc_test_reset_stream_on_send_only_stream_server)
+        || !CU_add_test(pSuite, "xqc_test_reset_stream_on_recv_only_stream_accepted",
+                        xqc_test_reset_stream_on_recv_only_stream_accepted)
+        || !CU_add_test(pSuite, "xqc_test_stop_sending_on_recv_only_stream",
+                        xqc_test_stop_sending_on_recv_only_stream)
+        || !CU_add_test(pSuite, "xqc_test_stop_sending_on_recv_only_stream_server",
+                        xqc_test_stop_sending_on_recv_only_stream_server)
+        || !CU_add_test(pSuite, "xqc_test_stop_sending_on_send_only_stream_accepted",
+                        xqc_test_stop_sending_on_send_only_stream_accepted)
+        || !CU_add_test(pSuite, "xqc_test_stream_frame_on_send_only_stream",
+                        xqc_test_stream_frame_on_send_only_stream)
+        || !CU_add_test(pSuite, "xqc_test_stream_frame_on_send_only_stream_server",
+                        xqc_test_stream_frame_on_send_only_stream_server)
+        || !CU_add_test(pSuite, "xqc_test_stream_frame_on_recv_only_stream_accepted",
+                        xqc_test_stream_frame_on_recv_only_stream_accepted)
+        || !CU_add_test(pSuite, "xqc_test_stream_frame_on_local_uncreated_stream",
+                        xqc_test_stream_frame_on_local_uncreated_stream)
+        || !CU_add_test(pSuite, "xqc_test_stream_frame_on_local_closed_stream_tolerated",
+                        xqc_test_stream_frame_on_local_closed_stream_tolerated)
         || !CU_add_test(pSuite, "xqc_test_h3_frame", xqc_test_frame)
         || !CU_add_test(pSuite, "xqc_test_h3_single_vint_frame_valid",
                         xqc_test_h3_single_vint_frame_valid)

--- a/tests/unittest/xqc_process_frame_test.c
+++ b/tests/unittest/xqc_process_frame_test.c
@@ -996,3 +996,307 @@ xqc_test_new_conn_id_active_limit_exceeded(void)
 
     xqc_engine_destroy(conn->engine);
 }
+
+
+/* ---- RFC 9000 stream directionality checks (issues #565 / #566 / #567) ----
+ *
+ * RFC 9000 section 2.1: the two low bits of a stream ID carry the initiator and
+ * the directionality, so with test_engine_connect() building a CLIENT
+ * connection:
+ *   stream_id 0 -> XQC_CLI_BID  client initiated, bidirectional
+ *   stream_id 2 -> XQC_CLI_UNI  client initiated, unidirectional: send-only
+ *                               for the client, recv-only for the server
+ *   stream_id 3 -> XQC_SVR_UNI  server initiated, unidirectional: send-only
+ *                               for the server, recv-only for the client
+ *
+ * The parser only reads conn->conn_type, so the server side of each check is
+ * exercised by flipping that field rather than by building a server engine.
+ */
+
+static xqc_connection_t *
+xqc_test_dir_make_conn(xqc_conn_type_t conn_type)
+{
+    xqc_connection_t *conn = test_engine_connect();
+    if (conn == NULL) {
+        return NULL;
+    }
+
+    conn->conn_type = conn_type;
+    conn->conn_err = 0;
+    return conn;
+}
+
+static void
+xqc_test_dir_init_pi(xqc_packet_in_t *pi, unsigned char *buf, size_t len)
+{
+    memset(pi, 0, sizeof(*pi));
+    pi->pos = buf;
+    pi->last = buf + len;
+    pi->pi_pkt.pkt_type = XQC_PTYPE_SHORT_HEADER;
+}
+
+
+/* ---- issue #566: RESET_STREAM on a send-only stream ---- */
+
+void
+xqc_test_reset_stream_on_send_only_stream(void)
+{
+    /* client + CLI_UNI: the client is the sender, so RESET_STREAM is illegal */
+    xqc_connection_t *conn = xqc_test_dir_make_conn(XQC_CONN_TYPE_CLIENT);
+    CU_ASSERT_FATAL(conn != NULL);
+
+    /* type(0x04) + stream_id(2) + err_code(0) + final_size(0) */
+    unsigned char frame_buf[] = {0x04, 0x02, 0x00, 0x00};
+    xqc_stream_id_t stream_id;
+    uint64_t err_code, final_size;
+    xqc_packet_in_t pi;
+    xqc_test_dir_init_pi(&pi, frame_buf, sizeof(frame_buf));
+
+    xqc_int_t ret = xqc_parse_reset_stream_frame(&pi, &stream_id, &err_code, &final_size, conn);
+    CU_ASSERT(ret == -XQC_EPROTO);
+    CU_ASSERT(conn->conn_err == TRA_STREAM_STATE_ERROR);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+void
+xqc_test_reset_stream_on_send_only_stream_server(void)
+{
+    /* server + SVR_UNI: the server is the sender, so RESET_STREAM is illegal */
+    xqc_connection_t *conn = xqc_test_dir_make_conn(XQC_CONN_TYPE_SERVER);
+    CU_ASSERT_FATAL(conn != NULL);
+
+    unsigned char frame_buf[] = {0x04, 0x03, 0x00, 0x00};
+    xqc_stream_id_t stream_id;
+    uint64_t err_code, final_size;
+    xqc_packet_in_t pi;
+    xqc_test_dir_init_pi(&pi, frame_buf, sizeof(frame_buf));
+
+    xqc_int_t ret = xqc_parse_reset_stream_frame(&pi, &stream_id, &err_code, &final_size, conn);
+    CU_ASSERT(ret == -XQC_EPROTO);
+    CU_ASSERT(conn->conn_err == TRA_STREAM_STATE_ERROR);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+void
+xqc_test_reset_stream_on_recv_only_stream_accepted(void)
+{
+    /*
+     * Control case: client + SVR_UNI is recv-only for the client, so the peer
+     * resetting its own sending side is legal and MUST still be accepted.
+     * Without this a check that rejected every unidirectional stream
+     * regardless of conn_type would go unnoticed.
+     */
+    xqc_connection_t *conn = xqc_test_dir_make_conn(XQC_CONN_TYPE_CLIENT);
+    CU_ASSERT_FATAL(conn != NULL);
+
+    /* err_code 10 and final_size 5 so the parsed values can be asserted */
+    unsigned char frame_buf[] = {0x04, 0x03, 0x0a, 0x05};
+    xqc_stream_id_t stream_id;
+    uint64_t err_code, final_size;
+    xqc_packet_in_t pi;
+    xqc_test_dir_init_pi(&pi, frame_buf, sizeof(frame_buf));
+
+    xqc_int_t ret = xqc_parse_reset_stream_frame(&pi, &stream_id, &err_code, &final_size, conn);
+    CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(conn->conn_err == 0);
+    CU_ASSERT(stream_id == 3);
+    CU_ASSERT(err_code == 10);
+    CU_ASSERT(final_size == 5);
+    CU_ASSERT(pi.pi_frame_types & XQC_FRAME_BIT_RESET_STREAM);
+    CU_ASSERT(pi.pos == frame_buf + sizeof(frame_buf));
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
+/* ---- issue #567: STOP_SENDING on a recv-only stream ---- */
+
+void
+xqc_test_stop_sending_on_recv_only_stream(void)
+{
+    /* client + SVR_UNI: the client only receives, so STOP_SENDING is illegal */
+    xqc_connection_t *conn = xqc_test_dir_make_conn(XQC_CONN_TYPE_CLIENT);
+    CU_ASSERT_FATAL(conn != NULL);
+
+    /* type(0x05) + stream_id(3) + err_code(0) */
+    unsigned char frame_buf[] = {0x05, 0x03, 0x00};
+    xqc_stream_id_t stream_id;
+    uint64_t err_code;
+    xqc_packet_in_t pi;
+    xqc_test_dir_init_pi(&pi, frame_buf, sizeof(frame_buf));
+
+    xqc_int_t ret = xqc_parse_stop_sending_frame(&pi, &stream_id, &err_code, conn);
+    CU_ASSERT(ret == -XQC_EPROTO);
+    CU_ASSERT(conn->conn_err == TRA_STREAM_STATE_ERROR);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+void
+xqc_test_stop_sending_on_recv_only_stream_server(void)
+{
+    /* server + CLI_UNI: the server only receives, so STOP_SENDING is illegal */
+    xqc_connection_t *conn = xqc_test_dir_make_conn(XQC_CONN_TYPE_SERVER);
+    CU_ASSERT_FATAL(conn != NULL);
+
+    unsigned char frame_buf[] = {0x05, 0x02, 0x00};
+    xqc_stream_id_t stream_id;
+    uint64_t err_code;
+    xqc_packet_in_t pi;
+    xqc_test_dir_init_pi(&pi, frame_buf, sizeof(frame_buf));
+
+    xqc_int_t ret = xqc_parse_stop_sending_frame(&pi, &stream_id, &err_code, conn);
+    CU_ASSERT(ret == -XQC_EPROTO);
+    CU_ASSERT(conn->conn_err == TRA_STREAM_STATE_ERROR);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+void
+xqc_test_stop_sending_on_send_only_stream_accepted(void)
+{
+    /*
+     * Control case: client + CLI_UNI is send-only for the client, so the peer
+     * asking it to stop sending is legal and MUST still be accepted.  This is
+     * the normal case for an HTTP/3 client control stream.
+     */
+    xqc_connection_t *conn = xqc_test_dir_make_conn(XQC_CONN_TYPE_CLIENT);
+    CU_ASSERT_FATAL(conn != NULL);
+
+    /* err_code 7 so the parsed value can be asserted */
+    unsigned char frame_buf[] = {0x05, 0x02, 0x07};
+    xqc_stream_id_t stream_id;
+    uint64_t err_code;
+    xqc_packet_in_t pi;
+    xqc_test_dir_init_pi(&pi, frame_buf, sizeof(frame_buf));
+
+    xqc_int_t ret = xqc_parse_stop_sending_frame(&pi, &stream_id, &err_code, conn);
+    CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(conn->conn_err == 0);
+    CU_ASSERT(stream_id == 2);
+    CU_ASSERT(err_code == 7);
+    CU_ASSERT(pi.pi_frame_types & XQC_FRAME_BIT_STOP_SENDING);
+    CU_ASSERT(pi.pos == frame_buf + sizeof(frame_buf));
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
+/* ---- issue #565: STREAM frame direction and locally initiated stream ---- */
+
+void
+xqc_test_stream_frame_on_send_only_stream(void)
+{
+    /*
+     * RFC 9000 section 19.8 first MUST: client + CLI_UNI is send-only for the
+     * client, so carrying stream data towards it is illegal.
+     * xqc_process_stream_frame() expects pos at the type byte.
+     */
+    xqc_connection_t *conn = xqc_test_dir_make_conn(XQC_CONN_TYPE_CLIENT);
+    CU_ASSERT_FATAL(conn != NULL);
+
+    /* type(0x0a = STREAM|LEN) + stream_id(2) + len(1) + data */
+    unsigned char frame_buf[] = {0x0a, 0x02, 0x01, 0x00};
+    xqc_packet_in_t pi;
+    xqc_test_dir_init_pi(&pi, frame_buf, sizeof(frame_buf));
+
+    xqc_int_t ret = xqc_process_stream_frame(conn, &pi);
+    CU_ASSERT(ret == -XQC_EPROTO);
+    CU_ASSERT(conn->conn_err == TRA_STREAM_STATE_ERROR);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+void
+xqc_test_stream_frame_on_send_only_stream_server(void)
+{
+    /* server + SVR_UNI is send-only for the server */
+    xqc_connection_t *conn = xqc_test_dir_make_conn(XQC_CONN_TYPE_SERVER);
+    CU_ASSERT_FATAL(conn != NULL);
+
+    unsigned char frame_buf[] = {0x0a, 0x03, 0x01, 0x00};
+    xqc_packet_in_t pi;
+    xqc_test_dir_init_pi(&pi, frame_buf, sizeof(frame_buf));
+
+    xqc_int_t ret = xqc_process_stream_frame(conn, &pi);
+    CU_ASSERT(ret == -XQC_EPROTO);
+    CU_ASSERT(conn->conn_err == TRA_STREAM_STATE_ERROR);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+void
+xqc_test_stream_frame_on_recv_only_stream_accepted(void)
+{
+    /*
+     * Control case: client + SVR_UNI is recv-only for the client, so stream
+     * data on it is legal.  The stream does not exist yet, so it must be
+     * created passively rather than rejected.
+     */
+    xqc_connection_t *conn = xqc_test_dir_make_conn(XQC_CONN_TYPE_CLIENT);
+    CU_ASSERT_FATAL(conn != NULL);
+
+    unsigned char frame_buf[] = {0x0a, 0x03, 0x01, 0x00};
+    xqc_packet_in_t pi;
+    xqc_test_dir_init_pi(&pi, frame_buf, sizeof(frame_buf));
+
+    xqc_int_t ret = xqc_process_stream_frame(conn, &pi);
+    CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(conn->conn_err == 0);
+    CU_ASSERT(xqc_find_stream_by_id(3, conn->streams_hash) != NULL);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+void
+xqc_test_stream_frame_on_local_uncreated_stream(void)
+{
+    /*
+     * RFC 9000 section 19.8 second MUST: a STREAM frame for a locally
+     * initiated stream that has not yet been created must be rejected.
+     *
+     * client + CLI_BID stream_id 4 -> index 1.  With the local counter at 1 no
+     * stream of index 1 has ever been created, so the frame is illegal.
+     */
+    xqc_connection_t *conn = xqc_test_dir_make_conn(XQC_CONN_TYPE_CLIENT);
+    CU_ASSERT_FATAL(conn != NULL);
+
+    conn->cur_stream_id_bidi_local = 1;
+
+    unsigned char frame_buf[] = {0x0a, 0x04, 0x01, 0x00};
+    xqc_packet_in_t pi;
+    xqc_test_dir_init_pi(&pi, frame_buf, sizeof(frame_buf));
+
+    xqc_int_t ret = xqc_process_stream_frame(conn, &pi);
+    CU_ASSERT(ret == -XQC_EPROTO);
+    CU_ASSERT(conn->conn_err == TRA_STREAM_STATE_ERROR);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+void
+xqc_test_stream_frame_on_local_closed_stream_tolerated(void)
+{
+    /*
+     * Control case for the above: same frame, same stream id, only the local
+     * counter differs.  With the counter at 2 index 1 was created earlier and
+     * has since been closed, so this is a retransmission and must still be
+     * tolerated instead of killing the connection.
+     */
+    xqc_connection_t *conn = xqc_test_dir_make_conn(XQC_CONN_TYPE_CLIENT);
+    CU_ASSERT_FATAL(conn != NULL);
+
+    conn->cur_stream_id_bidi_local = 2;
+
+    unsigned char frame_buf[] = {0x0a, 0x04, 0x01, 0x00};
+    xqc_packet_in_t pi;
+    xqc_test_dir_init_pi(&pi, frame_buf, sizeof(frame_buf));
+
+    xqc_int_t ret = xqc_process_stream_frame(conn, &pi);
+    CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(conn->conn_err == 0);
+
+    xqc_engine_destroy(conn->engine);
+}

--- a/tests/unittest/xqc_process_frame_test.h
+++ b/tests/unittest/xqc_process_frame_test.h
@@ -49,4 +49,27 @@ void xqc_test_conn_close_transport_error_type_overlap(void);
 
 void xqc_test_peer_key_update_error_not_0rtt(void);
 
+/* issues #565 / #566 / #567: RFC 9000 stream directionality checks */
+void xqc_test_reset_stream_on_send_only_stream(void);
+
+void xqc_test_reset_stream_on_send_only_stream_server(void);
+
+void xqc_test_reset_stream_on_recv_only_stream_accepted(void);
+
+void xqc_test_stop_sending_on_recv_only_stream(void);
+
+void xqc_test_stop_sending_on_recv_only_stream_server(void);
+
+void xqc_test_stop_sending_on_send_only_stream_accepted(void);
+
+void xqc_test_stream_frame_on_send_only_stream(void);
+
+void xqc_test_stream_frame_on_send_only_stream_server(void);
+
+void xqc_test_stream_frame_on_recv_only_stream_accepted(void);
+
+void xqc_test_stream_frame_on_local_uncreated_stream(void);
+
+void xqc_test_stream_frame_on_local_closed_stream_tolerated(void);
+
 #endif /* _XQC_PROCESS_FRAME_TEST_H_INCLUDED_ */


### PR DESCRIPTION
### Mechanism

A QUIC stream ID encodes its initiator and directionality in its two low bits,
so an endpoint can tell which streams it may only send on and which it may only
receive on. Three frame types were accepted regardless of that direction, and a
STREAM frame naming a locally initiated stream that was never created was
silently ignored. Both are now rejected with STREAM_STATE_ERROR.

The direction test is expressed once as a pair of predicates over the stream ID
and the local role, and reused by all three frame parsers. The uncreated-stream
test compares the stream index against the counter that assigns indexes to
locally initiated streams, so an index below the counter is still treated as a
retransmission for an already closed stream and tolerated as before.

- RFC or draft: `RFC 9000 section 19.4, section 19.5, section 19.8 (stream ID encoding in section 2.1)`

Fixes: #565
Fixes: #566
Fixes: #567

### Validation Cases

- Not executed on the current head — targeted case selectors are unavailable.

### CONTRIBUTING.md

- Overall: `Pending`
- Local regression: `Incomplete — cases 705-708 not rerun on the current head`
- CI: `Pending — checks for the current head`
