### PR TITLE
[~]: Align BBR initial window with RFC 9002

### DIFF
--- a/src/congestion_control/xqc_bbr.c
+++ b/src/congestion_control/xqc_bbr.c
@@ -21,11 +21,16 @@
 #define XQC_BBR_MAX_DATAGRAMSIZE    XQC_MSS
 #define XQC_BBR_MIN_WINDOW          (4 * XQC_BBR_MAX_DATAGRAMSIZE)
 #define XQC_BBR_MAX_WINDOW          (100 * XQC_BBR_MAX_DATAGRAMSIZE)
-/* The RECOMMENDED value is the minimum of 10 * kMaxDatagramSize and max(2* kMaxDatagramSize, 14720)) */
-/* same init window as cubic */
-/* 32 is too aggressive. we have observed heavy bufferbloat events from online deployment */
-/* 1440 * 10 / 1200 = 12 */
-#define XQC_BBR_INITIAL_WINDOW  (32 * XQC_BBR_MAX_DATAGRAMSIZE) 
+
+/*
+ * RFC 9002 Section 7.2 RECOMMENDS an initial congestion window of
+ * min(10 * max_datagram_size, max(2 * max_datagram_size, 14720)).
+ */
+#define XQC_BBR_INITIAL_WINDOW_MIN_BYTES 14720
+#define XQC_BBR_INITIAL_WINDOW                                           \
+    xqc_min(10 * XQC_BBR_MAX_DATAGRAMSIZE,                               \
+            xqc_max(2 * XQC_BBR_MAX_DATAGRAMSIZE,                        \
+                    XQC_BBR_INITIAL_WINDOW_MIN_BYTES))
 /* Pacing gain cycle rounds */
 #define XQC_BBR_CYCLE_LENGTH    8
 #define XQC_BBR_INF             0x7fffffff

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -92,6 +92,7 @@ if(HAVE_CUNIT)
         ${UNIT_TEST_DIR}/xqc_recv_record_test.c
         ${UNIT_TEST_DIR}/xqc_reno_test.c
         ${UNIT_TEST_DIR}/xqc_cubic_test.c
+        ${UNIT_TEST_DIR}/xqc_bbr_test.c
         ${UNIT_TEST_DIR}/xqc_stream_frame_test.c
         ${UNIT_TEST_DIR}/xqc_process_frame_test.c
         ${UNIT_TEST_DIR}/xqc_tp_test.c

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -16,6 +16,7 @@
 #include "xqc_recv_record_test.h"
 #include "xqc_reno_test.h"
 #include "xqc_cubic_test.h"
+#include "xqc_bbr_test.h"
 #include "xqc_packet_test.h"
 #include "xqc_stream_frame_test.h"
 #include "xqc_process_frame_test.h"
@@ -98,6 +99,10 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite, "xqc_test_reno_init_cwnd_override", xqc_test_reno_init_cwnd_override)
         || !CU_add_test(pSuite, "xqc_test_cubic", xqc_test_cubic)
         || !CU_add_test(pSuite, "xqc_test_cubic_init_cwnd", xqc_test_cubic_init_cwnd)
+        || !CU_add_test(pSuite, "xqc_test_bbr_init_cwnd",
+                        xqc_test_bbr_init_cwnd)
+        || !CU_add_test(pSuite, "xqc_test_bbr_init_cwnd_override",
+                        xqc_test_bbr_init_cwnd_override)
         || !CU_add_test(pSuite, "xqc_test_short_header_parse_cid", xqc_test_short_header_packet_parse_cid)
         || !CU_add_test(pSuite, "xqc_test_long_header_parse_cid", xqc_test_long_header_packet_parse_cid)
         || !CU_add_test(pSuite, "xqc_test_client_discards_received_zero_rtt",

--- a/tests/unittest/xqc_bbr_test.c
+++ b/tests/unittest/xqc_bbr_test.c
@@ -1,0 +1,110 @@
+/**
+ * @copyright Copyright (c) 2022, Alibaba Group Holding Limited
+ */
+
+#include "xqc_bbr_test.h"
+#include "src/congestion_control/xqc_bbr.h"
+#include "src/congestion_control/xqc_sample.h"
+#include "src/transport/xqc_packet.h"
+#include <CUnit/CUnit.h>
+#include <string.h>
+
+#define XQC_BBR_TEST_MIN_INIT_WIN_PKTS 4
+#define XQC_BBR_TEST_MAX_INIT_WIN_PKTS 100
+
+static uint32_t
+xqc_test_bbr_expected_iw(uint32_t mss)
+{
+    uint32_t ten_mss = 10 * mss;
+    uint32_t two_mss = 2 * mss;
+    uint32_t limit = two_mss > 14720 ? two_mss : 14720;
+
+    return ten_mss < limit ? ten_mss : limit;
+}
+
+static void
+xqc_test_bbr_init(xqc_bbr_t *bbr, xqc_cc_params_t params)
+{
+    xqc_sample_t sampler;
+
+    memset(&sampler, 0, sizeof(sampler));
+    xqc_bbr_cb.xqc_cong_ctl_init_bbr(bbr, &sampler, params);
+}
+
+/*
+ * RFC 9002 Section 7.2 RECOMMENDS an initial congestion window of
+ * min(10 * max_datagram_size, max(2 * max_datagram_size, 14720)).
+ */
+void
+xqc_test_bbr_init_cwnd()
+{
+    xqc_bbr_t       bbr;
+    xqc_cc_params_t params;
+    uint32_t        expected_iw = xqc_test_bbr_expected_iw(XQC_MSS);
+
+    memset(&params, 0, sizeof(params));
+    xqc_test_bbr_init(&bbr, params);
+
+    CU_ASSERT_EQUAL(bbr.initial_congestion_window, expected_iw);
+    CU_ASSERT_EQUAL(bbr.congestion_window, expected_iw);
+    CU_ASSERT_EQUAL(xqc_bbr_cb.xqc_cong_ctl_get_cwnd(&bbr), expected_iw);
+
+    CU_ASSERT_EQUAL(xqc_test_bbr_expected_iw(1200), 12000);
+    CU_ASSERT_EQUAL(xqc_test_bbr_expected_iw(1436), 14360);
+    CU_ASSERT_EQUAL(xqc_test_bbr_expected_iw(1500), 14720);
+    CU_ASSERT_EQUAL(xqc_test_bbr_expected_iw(9000), 18000);
+}
+
+/*
+ * The explicit override remains valid within [4, 100] packets. Invalid
+ * boundary values fall back to the RFC 9002 default.
+ */
+void
+xqc_test_bbr_init_cwnd_override()
+{
+    xqc_bbr_t       bbr;
+    xqc_cc_params_t params;
+    uint32_t        expected_iw = xqc_test_bbr_expected_iw(XQC_MSS);
+
+    memset(&params, 0, sizeof(params));
+    params.customize_on = 1;
+    params.init_cwnd = 20;
+    xqc_test_bbr_init(&bbr, params);
+    CU_ASSERT_EQUAL(bbr.initial_congestion_window, 20 * XQC_MSS);
+    CU_ASSERT_EQUAL(bbr.congestion_window, 20 * XQC_MSS);
+
+    memset(&params, 0, sizeof(params));
+    params.customize_on = 1;
+    params.init_cwnd = XQC_BBR_TEST_MIN_INIT_WIN_PKTS;
+    xqc_test_bbr_init(&bbr, params);
+    CU_ASSERT_EQUAL(bbr.initial_congestion_window,
+                    XQC_BBR_TEST_MIN_INIT_WIN_PKTS * XQC_MSS);
+
+    memset(&params, 0, sizeof(params));
+    params.customize_on = 1;
+    params.init_cwnd = XQC_BBR_TEST_MAX_INIT_WIN_PKTS;
+    xqc_test_bbr_init(&bbr, params);
+    CU_ASSERT_EQUAL(bbr.initial_congestion_window,
+                    XQC_BBR_TEST_MAX_INIT_WIN_PKTS * XQC_MSS);
+
+    memset(&params, 0, sizeof(params));
+    params.customize_on = 1;
+    params.init_cwnd = XQC_BBR_TEST_MIN_INIT_WIN_PKTS - 1;
+    xqc_test_bbr_init(&bbr, params);
+    CU_ASSERT_EQUAL(bbr.initial_congestion_window, expected_iw);
+    CU_ASSERT_EQUAL(bbr.congestion_window, expected_iw);
+
+    memset(&params, 0, sizeof(params));
+    params.customize_on = 1;
+    params.init_cwnd = XQC_BBR_TEST_MAX_INIT_WIN_PKTS + 1;
+    xqc_test_bbr_init(&bbr, params);
+    CU_ASSERT_EQUAL(bbr.initial_congestion_window, expected_iw);
+    CU_ASSERT_EQUAL(bbr.congestion_window, expected_iw);
+
+    memset(&params, 0, sizeof(params));
+    params.customize_on = 1;
+    params.init_cwnd = 0;
+    xqc_test_bbr_init(&bbr, params);
+    CU_ASSERT_EQUAL(bbr.initial_congestion_window, expected_iw);
+    CU_ASSERT_EQUAL(bbr.congestion_window, expected_iw);
+}

--- a/tests/unittest/xqc_bbr_test.h
+++ b/tests/unittest/xqc_bbr_test.h
@@ -1,0 +1,11 @@
+/**
+ * @copyright Copyright (c) 2022, Alibaba Group Holding Limited
+ */
+
+#ifndef _XQC_BBR_TEST_H_INCLUDED_
+#define _XQC_BBR_TEST_H_INCLUDED_
+
+void xqc_test_bbr_init_cwnd ();
+void xqc_test_bbr_init_cwnd_override ();
+
+#endif /* _XQC_BBR_TEST_H_INCLUDED_ */


### PR DESCRIPTION
### Mechanism

Replace BBR's fixed 32-MSS default initial congestion window with
`min(10 * max_datagram_size, max(2 * max_datagram_size, 14720))`. This aligns
the default sender behavior with RFC 9002 while preserving explicitly
configured initial-window values within the existing supported range.

Fixes: #600

- RFC or draft: [RFC 9002 Section 7.2](https://www.rfc-editor.org/rfc/rfc9002.html#section-7.2)

### Validation Cases

- Not applicable — the current case harness cannot independently observe the
  BBR initial congestion window.

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Incomplete — BBR initial-window client/server cases are
  not independently targetable
- CI: Pending
