### PR TITLE
[~] #630 exclude PATH_RESPONSE from XQC_NEED_REPAIR per RFC 9000 Section 13.3

### DIFF
--- a/harness/spec/validation.md
+++ b/harness/spec/validation.md
@@ -98,7 +98,7 @@ its case is retired so later changes cannot reuse it.
 | Range | New-case namespace | Allocated IDs |
 |-------|--------------------|---------------|
 | `[705, 799]` | QUIC Transport core | `705-714` |
-| `[800, 899]` | Recovery and congestion control | None |
+| `[800, 899]` | Recovery and congestion control | `800` |
 | `[900, 999]` | QUIC-TLS | `902-903` |
 | `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1014` |
 | `[1100, 1149]` | QPACK | None |

--- a/scripts/case_test.sh
+++ b/scripts/case_test.sh
@@ -1986,6 +1986,69 @@ else
 fi
 grep_err_log
 
+clear_log
+rm -f test_session tp_localhost xqc_token
+case800_pwd=`pwd`
+case800_ulimit_core_before=`ulimit -c`
+ulimit -c unlimited 2>/dev/null
+case800_ulimit_core=`ulimit -c`
+case800_files_before=`ls -l test_session tp_localhost xqc_token 2>&1`
+echo -e "NAT rebinding PATH_RESPONSE no repair ...\c"
+sudo ${CLIENT_BIN} -s 2048000 -l d -t 5 -M -i lo -i lo -E -n 2 -x 800 -N > stdlog
+client_ret=$?
+result=`grep -a ">>>>>>>> pass:0" stdlog`
+client_pass=`grep -a ">>>>>>>> pass:1" stdlog`
+errlog=`grep -a "\[error\]" clog; grep -a "\[error\]" slog`
+rebind=`grep -a "|path:0|REBINDING|validate NAT rebinding addr|" slog`
+drop_count=`grep -a -c "\[path-response-e2e\]|drop|path:0|ordinal:1|" stdlog`
+sent_pr=`grep -a "|<==|" clog | grep "|path:0|" | grep "frame:.*PATH_RESPONSE" | head -1`
+pr_pkt=`echo "$sent_pr" | sed -n 's/.*|pkt_num:\([0-9]*\)|.*/\1/p'`
+lost_pr=`grep -a "|mark lost|" clog | grep "|pkt_num:$pr_pkt|" | grep "PATH_RESPONSE"`
+bad_repair=`echo "$lost_pr" | grep -v "|repair:0|"`
+origin_pr=`grep -a -E "origin_pktnum:$pr_pkt|origin_pkt_num:$pr_pkt" clog | grep "PATH_RESPONSE"`
+path_response_cnt=`grep -a "|<==|" clog | grep "|path:0|" | grep "frame:.*PATH_RESPONSE" | wc -l`
+if [ "$client_ret" -eq 0 ] && [ -z "$errlog" ] && [ -z "$result" ] && [ -n "$client_pass" ] \
+    && [ -n "$rebind" ] && [ "$drop_count" -eq 1 ] \
+    && [ -n "$sent_pr" ] && [ -n "$pr_pkt" ] && [ -n "$lost_pr" ] \
+    && [ -z "$bad_repair" ] && [ -z "$origin_pr" ] \
+    && [ "$path_response_cnt" -ge 2 ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "NAT_rebinding_path_response_not_repaired" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    echo $errlog
+    echo $client_ret
+    echo $result
+    echo $client_pass
+    echo $rebind
+    echo $drop_count
+    echo $sent_pr
+    echo $pr_pkt
+    echo $lost_pr
+    echo $bad_repair
+    echo $origin_pr
+    echo $path_response_cnt
+    echo "[case800-debug]|client_ret:$client_ret|pwd:$case800_pwd|ulimit_core_before:$case800_ulimit_core_before|ulimit_core:$case800_ulimit_core"
+    echo "[case800-debug]|files_before:$case800_files_before"
+    echo "[case800-debug]|files_after:`ls -l test_session tp_localhost xqc_token 2>&1`"
+    echo "[case800-debug]|core_files:`ls -l core core.* tests/core tests/core.* 2>&1`"
+    echo "[case800-debug]|markers_begin"
+    grep -a "\[case800-debug\]" stdlog
+    echo "[case800-debug]|markers_end"
+    echo "[case800-debug]|stdlog_tail_begin"
+    tail -n 80 stdlog
+    echo "[case800-debug]|stdlog_tail_end"
+    echo "[case800-debug]|clog_tail_begin"
+    tail -n 120 clog
+    echo "[case800-debug]|clog_tail_end"
+    echo "[case800-debug]|slog_tail_begin"
+    tail -n 120 slog
+    echo "[case800-debug]|slog_tail_end"
+    case_print_result "NAT_rebinding_path_response_not_repaired" "fail"
+fi
+grep_err_log
+rm -f test_session tp_localhost xqc_token
+
 killall test_server
 ${SERVER_BIN} -l d -e -M -y > /dev/null &
 sleep 1

--- a/scripts/case_test.sh
+++ b/scripts/case_test.sh
@@ -1988,11 +1988,6 @@ grep_err_log
 
 clear_log
 rm -f test_session tp_localhost xqc_token
-case800_pwd=`pwd`
-case800_ulimit_core_before=`ulimit -c`
-ulimit -c unlimited 2>/dev/null
-case800_ulimit_core=`ulimit -c`
-case800_files_before=`ls -l test_session tp_localhost xqc_token 2>&1`
 echo -e "NAT rebinding PATH_RESPONSE no repair ...\c"
 sudo ${CLIENT_BIN} -s 2048000 -l d -t 5 -M -i lo -i lo -E -n 2 -x 800 -N > stdlog
 client_ret=$?
@@ -2028,22 +2023,6 @@ else
     echo $bad_repair
     echo $origin_pr
     echo $path_response_cnt
-    echo "[case800-debug]|client_ret:$client_ret|pwd:$case800_pwd|ulimit_core_before:$case800_ulimit_core_before|ulimit_core:$case800_ulimit_core"
-    echo "[case800-debug]|files_before:$case800_files_before"
-    echo "[case800-debug]|files_after:`ls -l test_session tp_localhost xqc_token 2>&1`"
-    echo "[case800-debug]|core_files:`ls -l core core.* tests/core tests/core.* 2>&1`"
-    echo "[case800-debug]|markers_begin"
-    grep -a "\[case800-debug\]" stdlog
-    echo "[case800-debug]|markers_end"
-    echo "[case800-debug]|stdlog_tail_begin"
-    tail -n 80 stdlog
-    echo "[case800-debug]|stdlog_tail_end"
-    echo "[case800-debug]|clog_tail_begin"
-    tail -n 120 clog
-    echo "[case800-debug]|clog_tail_end"
-    echo "[case800-debug]|slog_tail_begin"
-    tail -n 120 slog
-    echo "[case800-debug]|slog_tail_end"
     case_print_result "NAT_rebinding_path_response_not_repaired" "fail"
 fi
 grep_err_log

--- a/src/tls/xqc_crypto.c
+++ b/src/tls/xqc_crypto.c
@@ -7,7 +7,6 @@
 #include "src/common/xqc_str.h"
 #include "src/common/xqc_malloc.h"
 #include "src/common/utils/vint/xqc_variable_len_int.h"
-#include <assert.h>
 
 
 #define XQC_NONCE_LEN        16
@@ -178,8 +177,6 @@ void
 xqc_crypto_create_nonce(uint8_t *dest, const uint8_t *iv, size_t ivlen, uint64_t pktno, uint32_t path_id)
 {
     size_t i;
-
-    assert(ivlen >= 8);
 
     memcpy(dest, iv, ivlen);
 

--- a/src/tls/xqc_crypto.c
+++ b/src/tls/xqc_crypto.c
@@ -7,6 +7,7 @@
 #include "src/common/xqc_str.h"
 #include "src/common/xqc_malloc.h"
 #include "src/common/utils/vint/xqc_variable_len_int.h"
+#include <assert.h>
 
 
 #define XQC_NONCE_LEN        16
@@ -178,6 +179,8 @@ xqc_crypto_create_nonce(uint8_t *dest, const uint8_t *iv, size_t ivlen, uint64_t
 {
     size_t i;
 
+    assert(ivlen >= 8);
+
     memcpy(dest, iv, ivlen);
 
     /* To calculate the nonce, a 96 bit path-and-packet-number is composed of the
@@ -193,9 +196,17 @@ xqc_crypto_create_nonce(uint8_t *dest, const uint8_t *iv, size_t ivlen, uint64_t
         dest[ivlen - 8 + i] ^= ((uint8_t *)&pktno)[i];
     }
 
-    path_id = ntohl(path_id);
-    for (i = 0; i < 4; ++i) {
-        dest[ivlen - 12 + i] ^= ((uint8_t *)&path_id)[i];
+    /* the path id occupies the 32 bits before the packet number, so it can
+     * only be mixed in when the IV is at least 96 bits. shorter IVs occur
+     * with the null AEAD used by no-crypt test mode, where dest[ivlen - 12]
+     * would underflow the nonce buffer. both endpoints skip the path id in
+     * the same way, so the nonce stays symmetric.
+     */
+    if (ivlen >= 12) {
+        path_id = ntohl(path_id);
+        for (i = 0; i < 4; ++i) {
+            dest[ivlen - 12 + i] ^= ((uint8_t *)&path_id)[i];
+        }
     }
 }
 

--- a/src/transport/xqc_frame.h
+++ b/src/transport/xqc_frame.h
@@ -155,8 +155,13 @@ typedef uint64_t xqc_frame_type_bit_t;
 /*
  * PING and PADDING frames contain no information, so lost PING or
  *     PADDING frames do not require repair
+ *
+ * RFC 9000 Section 13.3 / Section 8.2.2: responses to path validation using
+ *     PATH_RESPONSE frames are sent just once and MUST NOT be retransmitted on
+ *     loss; the peer sends additional PATH_CHALLENGE frames to elicit new
+ *     PATH_RESPONSE frames, so PATH_RESPONSE is excluded from repair here.
  */
-#define XQC_NEED_REPAIR(types) ((types) & ~(XQC_FRAME_BIT_ACK| XQC_FRAME_BIT_PADDING | XQC_FRAME_BIT_PING | XQC_FRAME_BIT_CONNECTION_CLOSE | XQC_FRAME_BIT_DATAGRAM | XQC_FRAME_BIT_SID | XQC_FRAME_BIT_REPAIR_SYMBOL))
+#define XQC_NEED_REPAIR(types) ((types) & ~(XQC_FRAME_BIT_ACK| XQC_FRAME_BIT_PADDING | XQC_FRAME_BIT_PING | XQC_FRAME_BIT_CONNECTION_CLOSE | XQC_FRAME_BIT_DATAGRAM | XQC_FRAME_BIT_SID | XQC_FRAME_BIT_REPAIR_SYMBOL | XQC_FRAME_BIT_PATH_RESPONSE))
 
 
 const char *xqc_frame_type_2_str(xqc_engine_t *engine, xqc_frame_type_bit_t type_bit);

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -27,7 +27,6 @@
 #include "platform.h"
 #ifndef XQC_SYS_WINDOWS
 #include <unistd.h>
-#include <execinfo.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>
 #include <net/if.h>
@@ -247,7 +246,6 @@ size_t dgram2_size = 0;
 
 int dgram_drop_pkt1 = 0;
 int path_response_drop_pkt1 = 0;
-int path_response_debug_write_cnt = 0;
 client_ctx_t ctx;
 struct event_base *eb;
 int g_send_dgram;
@@ -332,52 +330,6 @@ char g_priority[64] = {'\0'};
 
 unsigned char g_token[XQC_MAX_TOKEN_LEN];
 int g_token_len = 0;
-
-void
-xqc_client_case800_debug_state(const char *stage)
-{
-    if (g_test_case != 800) {
-        return;
-    }
-
-#ifndef XQC_SYS_WINDOWS
-    printf("[case800-debug]|stage:%s|no_crypt:%d|multipath:%d|"
-           "interfaces:%d|max_paths:%d|send_body:%d|token:%d|"
-           "session:%d|tp:%d|\n",
-           stage, g_no_crypt, g_enable_multipath, g_multi_interface_cnt,
-           XQC_DEMO_MAX_PATH_COUNT, g_send_body_size,
-           access("xqc_token", F_OK) == 0,
-           access("test_session", F_OK) == 0,
-           access("tp_localhost", F_OK) == 0);
-#else
-    printf("[case800-debug]|stage:%s|no_crypt:%d|multipath:%d|"
-           "interfaces:%d|max_paths:%d|send_body:%d|\n",
-           stage, g_no_crypt, g_enable_multipath, g_multi_interface_cnt,
-           XQC_DEMO_MAX_PATH_COUNT, g_send_body_size);
-#endif
-    fflush(stdout);
-}
-
-#ifndef XQC_SYS_WINDOWS
-void
-xqc_client_case800_signal_handler(int sig)
-{
-    void *frames[64];
-    int frame_count;
-
-    if (g_test_case != 800) {
-        _exit(128 + sig);
-    }
-
-    frame_count = backtrace(frames, 64);
-    dprintf(STDOUT_FILENO,
-            "[case800-debug]|signal:%d|stage:signal_handler|frames:%d|\n",
-            sig, frame_count);
-    backtrace_symbols_fd(frames, frame_count, STDOUT_FILENO);
-    fsync(STDOUT_FILENO);
-    _exit(128 + sig);
-}
-#endif
 
 /* 用于路径增删debug */
 int g_debug_path = 0;
@@ -1129,12 +1081,6 @@ xqc_client_get_path_index_by_id(uint64_t path_id)
     }
 
     if (g_multi_interface_cnt > XQC_DEMO_MAX_PATH_COUNT) {
-        if (g_test_case == 800) {
-            printf("[case800-debug]|stage:path_index_bad_count|path:%"PRIu64"|"
-                   "interfaces:%d|max_paths:%d|\n", path_id,
-                   g_multi_interface_cnt, XQC_DEMO_MAX_PATH_COUNT);
-            fflush(stdout);
-        }
         return -1;
     }
 
@@ -1142,16 +1088,6 @@ xqc_client_get_path_index_by_id(uint64_t path_id)
         if (g_client_path[i].path_id == path_id) {
             return i;
         }
-    }
-
-    if (g_test_case == 800) {
-        printf("[case800-debug]|stage:path_index_miss|path:%"PRIu64"|"
-               "interfaces:%d|slot0_id:%"PRIu64"|slot0_used:%d|"
-               "slot1_id:%"PRIu64"|slot1_used:%d|\n", path_id,
-               g_multi_interface_cnt, g_client_path[0].path_id,
-               g_client_path[0].is_in_used, g_client_path[1].path_id,
-               g_client_path[1].is_in_used);
-        fflush(stdout);
     }
 
     return -1;
@@ -1189,18 +1125,6 @@ xqc_client_write_socket_ex(uint64_t path_id,
     int fd = 0;
     int header_type;
     int path_idx = -1;
-
-    if (g_test_case == 800
-        && (user_data == NULL || buf == NULL
-            || g_multi_interface_cnt > XQC_DEMO_MAX_PATH_COUNT))
-    {
-        printf("[case800-debug]|stage:write_socket_ex_bad_arg|user:%p|"
-               "buf:%p|interfaces:%d|max_paths:%d|path:%"PRIu64"|size:%zu|\n",
-               user_data, buf, g_multi_interface_cnt,
-               XQC_DEMO_MAX_PATH_COUNT, path_id, size);
-        fflush(stdout);
-        return XQC_SOCKET_ERROR;
-    }
 
     if (user_conn == NULL || buf == NULL) {
         return XQC_SOCKET_ERROR;
@@ -1314,19 +1238,6 @@ xqc_client_write_socket_ex(uint64_t path_id,
         {
             fd = g_client_path[path_idx].rebinding_path_fd;
         }
-    }
-
-    if (g_test_case == 800 && path_response_debug_write_cnt < 32) {
-        int byte0 = send_buf_size > 0 ? send_buf[0] : -1;
-        int byte13 = send_buf_size > 13 ? send_buf[13] : -1;
-        size_t path_send_size = path_idx >= 0 ? g_client_path[path_idx].send_size : 0;
-
-        printf("[case800-debug]|stage:write_socket_ex|cnt:%d|path:%"PRIu64"|"
-               "idx:%d|fd:%d|hsk:%d|size:%zu|send_size:%zu|b0:%d|b13:%d|\n",
-               path_response_debug_write_cnt, path_id, path_idx, fd,
-               hsk_completed, send_buf_size, path_send_size, byte0, byte13);
-        fflush(stdout);
-        path_response_debug_write_cnt++;
     }
 
     do {
@@ -1480,11 +1391,6 @@ xqc_client_write_mmsg(const struct iovec *msg_iov, unsigned int vlen,
     unsigned int send_vlen = vlen > MAX_SEG ? MAX_SEG : vlen;
     struct mmsghdr mmsg[MAX_SEG];
     memset(&mmsg, 0, sizeof(mmsg));
-    if (g_test_case == 800 && vlen > MAX_SEG) {
-        printf("[case800-debug]|stage:write_mmsg_cap|vlen:%u|max:%d|\n",
-               vlen, MAX_SEG);
-        fflush(stdout);
-    }
     for (int i = 0; i < send_vlen; i++) {
         mmsg[i].msg_hdr.msg_iov = (struct iovec *)&msg_iov[i];
         mmsg[i].msg_hdr.msg_iovlen = 1;
@@ -1537,12 +1443,6 @@ xqc_client_mp_write_mmsg(uint64_t path_id,
     struct mmsghdr mmsg[MAX_SEG];
     unsigned int send_vlen = vlen > MAX_SEG ? MAX_SEG : vlen;
     memset(&mmsg, 0, sizeof(mmsg));
-    if (g_test_case == 800 && vlen > MAX_SEG) {
-        printf("[case800-debug]|stage:mp_write_mmsg_cap|path:%"PRIu64"|"
-               "vlen:%u|max:%d|fd:%d|idx:%d|\n", path_id, vlen,
-               MAX_SEG, fd, path_idx);
-        fflush(stdout);
-    }
     for (int i = 0; i < send_vlen; i++) {
         mmsg[i].msg_hdr.msg_iov = (struct iovec *)&msg_iov[i];
         mmsg[i].msg_hdr.msg_iovlen = 1;
@@ -1730,14 +1630,6 @@ xqc_client_create_path_socket(xqc_user_path_t *path,
             printf("|xqc_client_create_path_socket error|");
             return XQC_ERROR;
         }
-
-        if (g_test_case == 800) {
-            printf("[case800-debug]|stage:create_path_socket|path_fd:%d|"
-                   "rebinding_fd:%d|if:%s|\n", path->path_fd,
-                   path->rebinding_path_fd,
-                   path_interface == NULL ? "null" : path_interface);
-            fflush(stdout);
-        }
     }
 #endif
 
@@ -1764,17 +1656,9 @@ xqc_client_create_path(xqc_user_path_t *path,
     path->ev_socket = event_new(eb, path->path_fd, 
                 EV_READ | EV_PERSIST, xqc_client_socket_event_callback, user_conn);
     if (path->ev_socket == NULL) {
-        printf("[case800-debug]|stage:create_path_event_fail|path_fd:%d|\n",
-               path->path_fd);
-        fflush(stdout);
         return XQC_ERROR;
     }
     int path_event_ret = event_add(path->ev_socket, NULL);
-    if (g_test_case == 800) {
-        printf("[case800-debug]|stage:create_path_event_add|ret:%d|fd:%d|\n",
-               path_event_ret, path->path_fd);
-        fflush(stdout);
-    }
     if (path_event_ret != 0) {
         return XQC_ERROR;
     }
@@ -1784,24 +1668,10 @@ xqc_client_create_path(xqc_user_path_t *path,
     {
         path->rebinding_ev_socket = event_new(eb, path->rebinding_path_fd, EV_READ | EV_PERSIST,
                                               xqc_client_socket_event_callback, user_conn);
-        if (g_test_case == 800) {
-            printf("[case800-debug]|stage:create_path_event|path_fd:%d|"
-                   "rebinding_fd:%d|ev:%p|rebinding_ev:%p|\n",
-                   path->path_fd, path->rebinding_path_fd,
-                   (void *) path->ev_socket,
-                   (void *) path->rebinding_ev_socket);
-            fflush(stdout);
-        }
         if (path->rebinding_ev_socket == NULL) {
             return XQC_ERROR;
         }
         int rebinding_event_ret = event_add(path->rebinding_ev_socket, NULL);
-        if (g_test_case == 800) {
-            printf("[case800-debug]|stage:create_rebinding_event_add|"
-                   "ret:%d|fd:%d|\n", rebinding_event_ret,
-                   path->rebinding_path_fd);
-            fflush(stdout);
-        }
         if (rebinding_event_ret != 0) {
             return XQC_ERROR;
         }
@@ -1896,22 +1766,10 @@ xqc_client_create_conn_socket(user_conn_t *user_conn)
 
     user_conn->ev_socket = event_new(eb, user_conn->fd, EV_READ | EV_PERSIST, 
                                      xqc_client_socket_event_callback, user_conn);
-    if (g_test_case == 800) {
-        printf("[case800-debug]|stage:create_conn_socket|fd:%d|ev:%p|"
-               "eb:%p|user:%p|\n", user_conn->fd,
-               (void *) user_conn->ev_socket, (void *) eb,
-               (void *) user_conn);
-        fflush(stdout);
-    }
     if (user_conn->ev_socket == NULL) {
         return -1;
     }
     int event_ret = event_add(user_conn->ev_socket, NULL);
-    if (g_test_case == 800) {
-        printf("[case800-debug]|stage:create_conn_socket_event_add|"
-               "ret:%d|fd:%d|\n", event_ret, user_conn->fd);
-        fflush(stdout);
-    }
     if (event_ret != 0) {
         return -1;
     }
@@ -1965,18 +1823,7 @@ xqc_client_conn_create_notify(xqc_connection_t *conn, const xqc_cid_t *cid, void
     DEBUG;
 
     user_conn_t *user_conn = (user_conn_t *)user_data;
-    if (g_test_case == 800) {
-        printf("[case800-debug]|stage:conn_create_notify|conn:%p|cid:%p|"
-               "user:%p|proto:%p|\n", (void *) conn, (void *) cid,
-               user_data, conn_proto_data);
-        fflush(stdout);
-    }
-
     if (conn == NULL || user_conn == NULL) {
-        if (g_test_case == 800) {
-            printf("[case800-debug]|stage:conn_create_notify_bad_arg|\n");
-            fflush(stdout);
-        }
         return XQC_ERROR;
     }
 
@@ -2051,23 +1898,9 @@ xqc_client_conn_update_cid_notify(xqc_connection_t *conn, const xqc_cid_t *retir
     DEBUG;
 
     user_conn_t *user_conn = (user_conn_t *) user_data;
-    if (g_test_case == 800) {
-        printf("[case800-debug]|stage:conn_update_cid|conn:%p|retire:%p|"
-               "new:%p|user:%p|\n", (void *) conn, (void *) retire_cid,
-               (void *) new_cid, user_data);
-        fflush(stdout);
-    }
-
     if (user_conn == NULL || new_cid == NULL || retire_cid == NULL
         || ctx.engine == NULL)
     {
-        if (g_test_case == 800) {
-            printf("[case800-debug]|stage:conn_update_cid_bad_arg|"
-                   "user:%p|engine:%p|retire:%p|new:%p|\n",
-                   (void *) user_conn, (void *) ctx.engine,
-                   (void *) retire_cid, (void *) new_cid);
-            fflush(stdout);
-        }
         return;
     }
 
@@ -2084,17 +1917,7 @@ xqc_client_conn_handshake_finished(xqc_connection_t *conn, void *user_data, void
 {
     DEBUG;
     user_conn_t *user_conn = (user_conn_t *) user_data;
-    if (g_test_case == 800) {
-        printf("[case800-debug]|stage:handshake_finished|conn:%p|user:%p|\n",
-               (void *) conn, user_data);
-        fflush(stdout);
-    }
-
     if (user_conn == NULL) {
-        if (g_test_case == 800) {
-            printf("[case800-debug]|stage:handshake_finished_bad_arg|\n");
-            fflush(stdout);
-        }
         return;
     }
 
@@ -2133,18 +1956,7 @@ xqc_client_h3_conn_create_notify(xqc_h3_conn_t *conn, const xqc_cid_t *cid, void
     DEBUG;
 
     user_conn_t *user_conn = (user_conn_t *) user_data;
-    if (g_test_case == 800) {
-        printf("[case800-debug]|stage:h3_conn_create_notify|conn:%p|"
-               "cid:%p|user:%p|\n", (void *) conn, (void *) cid,
-               user_data);
-        fflush(stdout);
-    }
-
     if (conn == NULL || user_conn == NULL) {
-        if (g_test_case == 800) {
-            printf("[case800-debug]|stage:h3_conn_create_notify_bad_arg|\n");
-            fflush(stdout);
-        }
         return XQC_ERROR;
     }
 
@@ -4442,24 +4254,9 @@ xqc_client_ready_to_create_path(const xqc_cid_t *cid,
     uint64_t path_id = 0;
     user_conn_t *user_conn = (user_conn_t *) conn_user_data;
 
-    if (g_test_case == 800) {
-        printf("[case800-debug]|stage:ready_to_create_path|cid:%p|"
-               "user:%p|engine:%p|interfaces:%d|max_paths:%d|\n",
-               (void *) cid, conn_user_data, (void *) ctx.engine,
-               g_multi_interface_cnt, XQC_DEMO_MAX_PATH_COUNT);
-        fflush(stdout);
-    }
-
     if (user_conn == NULL || ctx.engine == NULL
         || g_multi_interface_cnt > XQC_DEMO_MAX_PATH_COUNT)
     {
-        if (g_test_case == 800) {
-            printf("[case800-debug]|stage:ready_to_create_path_bad_state|"
-                   "user:%p|engine:%p|interfaces:%d|max_paths:%d|\n",
-                   (void *) user_conn, (void *) ctx.engine,
-                   g_multi_interface_cnt, XQC_DEMO_MAX_PATH_COUNT);
-            fflush(stdout);
-        }
         return;
     }
 
@@ -4473,21 +4270,7 @@ xqc_client_ready_to_create_path(const xqc_cid_t *cid,
                 continue;
             }
         
-            if (g_test_case == 800) {
-                printf("[case800-debug]|stage:before_create_path|idx:%d|"
-                       "used:%d|old_path:%"PRIu64"|\n", i,
-                       g_client_path[i].is_in_used,
-                       g_client_path[i].path_id);
-                fflush(stdout);
-            }
-
             int ret = xqc_conn_create_path(ctx.engine, &(user_conn->cid), &path_id, 0);
-
-            if (g_test_case == 800) {
-                printf("[case800-debug]|stage:after_create_path|idx:%d|"
-                       "ret:%d|path:%"PRIu64"|\n", i, ret, path_id);
-                fflush(stdout);
-            }
 
             if (ret < 0) {
                 printf("not support mp, xqc_conn_create_path err = %d\n", ret);
@@ -5248,15 +5031,6 @@ int main(int argc, char *argv[]) {
         exit(1);
     }
 
-#ifndef XQC_SYS_WINDOWS
-    if (g_test_case == 800) {
-        signal(SIGSEGV, xqc_client_case800_signal_handler);
-        signal(SIGABRT, xqc_client_case800_signal_handler);
-    }
-#endif
-
-    xqc_client_case800_debug_state("after_args");
-    
     memset(g_header_key, 'k', sizeof(g_header_key));
     memset(g_header_value, 'v', sizeof(g_header_value));
     memset(&ctx, 0, sizeof(ctx));
@@ -5265,7 +5039,6 @@ int main(int argc, char *argv[]) {
     xqc_client_open_log_file(&ctx);
 
     g_token_len = xqc_client_read_token(g_token, XQC_MAX_TOKEN_LEN);
-    xqc_client_case800_debug_state("after_token");
  
     xqc_platform_init_env();
 

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -27,6 +27,7 @@
 #include "platform.h"
 #ifndef XQC_SYS_WINDOWS
 #include <unistd.h>
+#include <execinfo.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>
 #include <net/if.h>
@@ -245,6 +246,8 @@ size_t dgram1_size = 0;
 size_t dgram2_size = 0;
 
 int dgram_drop_pkt1 = 0;
+int path_response_drop_pkt1 = 0;
+int path_response_debug_write_cnt = 0;
 client_ctx_t ctx;
 struct event_base *eb;
 int g_send_dgram;
@@ -272,6 +275,7 @@ uint64_t g_last_sock_op_time;
  * please keep this comment updated if you are adding more test cases. :-D
  * 55 for RFC 9114 Section 4.2 forbidden header e2e validation
  * 99 for pure fin
+ * 800 for PATH_RESPONSE no-repair e2e validation
  * 2XX for datagram testcases
  * 3XX for h3 ext bytestream testcases
  * 4XX for conn_settings configuration
@@ -328,6 +332,52 @@ char g_priority[64] = {'\0'};
 
 unsigned char g_token[XQC_MAX_TOKEN_LEN];
 int g_token_len = 0;
+
+void
+xqc_client_case800_debug_state(const char *stage)
+{
+    if (g_test_case != 800) {
+        return;
+    }
+
+#ifndef XQC_SYS_WINDOWS
+    printf("[case800-debug]|stage:%s|no_crypt:%d|multipath:%d|"
+           "interfaces:%d|max_paths:%d|send_body:%d|token:%d|"
+           "session:%d|tp:%d|\n",
+           stage, g_no_crypt, g_enable_multipath, g_multi_interface_cnt,
+           XQC_DEMO_MAX_PATH_COUNT, g_send_body_size,
+           access("xqc_token", F_OK) == 0,
+           access("test_session", F_OK) == 0,
+           access("tp_localhost", F_OK) == 0);
+#else
+    printf("[case800-debug]|stage:%s|no_crypt:%d|multipath:%d|"
+           "interfaces:%d|max_paths:%d|send_body:%d|\n",
+           stage, g_no_crypt, g_enable_multipath, g_multi_interface_cnt,
+           XQC_DEMO_MAX_PATH_COUNT, g_send_body_size);
+#endif
+    fflush(stdout);
+}
+
+#ifndef XQC_SYS_WINDOWS
+void
+xqc_client_case800_signal_handler(int sig)
+{
+    void *frames[64];
+    int frame_count;
+
+    if (g_test_case != 800) {
+        _exit(128 + sig);
+    }
+
+    frame_count = backtrace(frames, 64);
+    dprintf(STDOUT_FILENO,
+            "[case800-debug]|signal:%d|stage:signal_handler|frames:%d|\n",
+            sig, frame_count);
+    backtrace_symbols_fd(frames, frame_count, STDOUT_FILENO);
+    fsync(STDOUT_FILENO);
+    _exit(128 + sig);
+}
+#endif
 
 /* 用于路径增删debug */
 int g_debug_path = 0;
@@ -1072,19 +1122,55 @@ xqc_client_write_socket(const unsigned char *buf, size_t size,
 }
 
 int
+xqc_client_get_path_index_by_id(uint64_t path_id)
+{
+    if (!g_enable_multipath) {
+        return -1;
+    }
+
+    if (g_multi_interface_cnt > XQC_DEMO_MAX_PATH_COUNT) {
+        if (g_test_case == 800) {
+            printf("[case800-debug]|stage:path_index_bad_count|path:%"PRIu64"|"
+                   "interfaces:%d|max_paths:%d|\n", path_id,
+                   g_multi_interface_cnt, XQC_DEMO_MAX_PATH_COUNT);
+            fflush(stdout);
+        }
+        return -1;
+    }
+
+    for (int i = 0; i < g_multi_interface_cnt; i++) {
+        if (g_client_path[i].path_id == path_id) {
+            return i;
+        }
+    }
+
+    if (g_test_case == 800) {
+        printf("[case800-debug]|stage:path_index_miss|path:%"PRIu64"|"
+               "interfaces:%d|slot0_id:%"PRIu64"|slot0_used:%d|"
+               "slot1_id:%"PRIu64"|slot1_used:%d|\n", path_id,
+               g_multi_interface_cnt, g_client_path[0].path_id,
+               g_client_path[0].is_in_used, g_client_path[1].path_id,
+               g_client_path[1].is_in_used);
+        fflush(stdout);
+    }
+
+    return -1;
+}
+
+
+int
 xqc_client_get_path_fd_by_id(user_conn_t *user_conn, uint64_t path_id)
 {
     int fd = user_conn->fd;
+    int path_idx;
 
     if (!g_enable_multipath) {
         return fd;
     }
 
-    for (int i = 0; i < g_multi_interface_cnt; i++) {
-        if (g_client_path[i].path_id == path_id) {
-            fd = g_client_path[i].path_fd;
-            break;
-        }
+    path_idx = xqc_client_get_path_index_by_id(path_id);
+    if (path_idx >= 0) {
+        fd = g_client_path[path_idx].path_fd;
     }
 
     return fd;
@@ -1102,6 +1188,23 @@ xqc_client_write_socket_ex(uint64_t path_id,
     ssize_t res;
     int fd = 0;
     int header_type;
+    int path_idx = -1;
+
+    if (g_test_case == 800
+        && (user_data == NULL || buf == NULL
+            || g_multi_interface_cnt > XQC_DEMO_MAX_PATH_COUNT))
+    {
+        printf("[case800-debug]|stage:write_socket_ex_bad_arg|user:%p|"
+               "buf:%p|interfaces:%d|max_paths:%d|path:%"PRIu64"|size:%zu|\n",
+               user_data, buf, g_multi_interface_cnt,
+               XQC_DEMO_MAX_PATH_COUNT, path_id, size);
+        fflush(stdout);
+        return XQC_SOCKET_ERROR;
+    }
+
+    if (user_conn == NULL || buf == NULL) {
+        return XQC_SOCKET_ERROR;
+    }
 
     /* test stateless reset after handshake completed */
     if (g_test_case == 41) {
@@ -1164,6 +1267,7 @@ xqc_client_write_socket_ex(uint64_t path_id,
 
     /* get path fd */
     fd = xqc_client_get_path_fd_by_id(user_conn, path_id);
+    path_idx = xqc_client_get_path_index_by_id(path_id);
 
     /* COPY to run corruption test cases */
     unsigned char send_buf[XQC_PACKET_TMP_BUF_LEN];
@@ -1194,17 +1298,35 @@ xqc_client_write_socket_ex(uint64_t path_id,
         }
     }
 
-    if (g_enable_multipath) {
-        g_client_path[path_id].send_size += size;
+    if (g_enable_multipath && path_idx >= 0) {
+        g_client_path[path_idx].send_size += size;
     }
 
     if (hsk_completed) {
-        if (g_test_case == 103 && path_id == 0 && g_client_path[0].send_size > g_send_body_size/10) {
-            fd = g_client_path[0].rebinding_path_fd;
+        if ((g_test_case == 103 || g_test_case == 800)
+            && path_id == 0 && path_idx >= 0
+            && g_client_path[path_idx].send_size > g_send_body_size/10)
+        {
+            fd = g_client_path[path_idx].rebinding_path_fd;
         }
-        else if (g_test_case == 104 && path_id == 1 && g_client_path[1].send_size > 10240) {
-            fd = g_client_path[1].rebinding_path_fd;
+        else if (g_test_case == 104 && path_id == 1 && path_idx >= 0
+                 && g_client_path[path_idx].send_size > 10240)
+        {
+            fd = g_client_path[path_idx].rebinding_path_fd;
         }
+    }
+
+    if (g_test_case == 800 && path_response_debug_write_cnt < 32) {
+        int byte0 = send_buf_size > 0 ? send_buf[0] : -1;
+        int byte13 = send_buf_size > 13 ? send_buf[13] : -1;
+        size_t path_send_size = path_idx >= 0 ? g_client_path[path_idx].send_size : 0;
+
+        printf("[case800-debug]|stage:write_socket_ex|cnt:%d|path:%"PRIu64"|"
+               "idx:%d|fd:%d|hsk:%d|size:%zu|send_size:%zu|b0:%d|b13:%d|\n",
+               path_response_debug_write_cnt, path_id, path_idx, fd,
+               hsk_completed, send_buf_size, path_send_size, byte0, byte13);
+        fflush(stdout);
+        path_response_debug_write_cnt++;
     }
 
     do {
@@ -1271,6 +1393,19 @@ xqc_client_write_socket_ex(uint64_t path_id,
                     return send_buf_size;
                 }
             }
+        }
+
+        if (g_test_case == 800 && g_no_crypt && !path_response_drop_pkt1
+            && hsk_completed && path_id == 0 && path_idx >= 0
+            && g_client_path[path_idx].send_size > g_send_body_size/10
+            && send_buf_size > 13
+            && (send_buf[0] & 0x80) == 0 && send_buf[13] == 0x1b)
+        {
+            path_response_drop_pkt1 = 1;
+            printf("[path-response-e2e]|drop|path:%"PRIu64"|ordinal:1|\n",
+                   path_id);
+            fflush(stdout);
+            return send_buf_size;
         }
 
         res = sendto(fd, send_buf, send_buf_size, 0, peer_addr, peer_addrlen);
@@ -1342,9 +1477,15 @@ xqc_client_write_mmsg(const struct iovec *msg_iov, unsigned int vlen,
     user_conn_t *user_conn = (user_conn_t *) user;
     ssize_t res = 0;
     int fd = user_conn->fd;
+    unsigned int send_vlen = vlen > MAX_SEG ? MAX_SEG : vlen;
     struct mmsghdr mmsg[MAX_SEG];
     memset(&mmsg, 0, sizeof(mmsg));
-    for (int i = 0; i < vlen; i++) {
+    if (g_test_case == 800 && vlen > MAX_SEG) {
+        printf("[case800-debug]|stage:write_mmsg_cap|vlen:%u|max:%d|\n",
+               vlen, MAX_SEG);
+        fflush(stdout);
+    }
+    for (int i = 0; i < send_vlen; i++) {
         mmsg[i].msg_hdr.msg_iov = (struct iovec *)&msg_iov[i];
         mmsg[i].msg_hdr.msg_iovlen = 1;
     }
@@ -1358,7 +1499,7 @@ xqc_client_write_mmsg(const struct iovec *msg_iov, unsigned int vlen,
             return XQC_SOCKET_EAGAIN;
         }
 
-        res = sendmmsg(fd, mmsg, vlen, 0);
+        res = sendmmsg(fd, mmsg, send_vlen, 0);
         if (res < 0) {
             printf("sendmmsg err %zd %s\n", res, strerror(errno));
             if (errno == EAGAIN) {
@@ -1379,17 +1520,30 @@ xqc_client_mp_write_mmsg(uint64_t path_id,
     user_conn_t *user_conn = (user_conn_t *) user;
     ssize_t res = 0;
     int fd = 0;
+    int path_idx = -1;
 
     /* check whether it's initial path */
     if (path_id == 0) {
         fd = user_conn->fd;
     } else {
-        fd = g_client_path[path_id].path_fd;
+        path_idx = xqc_client_get_path_index_by_id(path_id);
+        if (path_idx >= 0) {
+            fd = g_client_path[path_idx].path_fd;
+        } else {
+            fd = xqc_client_get_path_fd_by_id(user_conn, path_id);
+        }
     }
 
     struct mmsghdr mmsg[MAX_SEG];
+    unsigned int send_vlen = vlen > MAX_SEG ? MAX_SEG : vlen;
     memset(&mmsg, 0, sizeof(mmsg));
-    for (int i = 0; i < vlen; i++) {
+    if (g_test_case == 800 && vlen > MAX_SEG) {
+        printf("[case800-debug]|stage:mp_write_mmsg_cap|path:%"PRIu64"|"
+               "vlen:%u|max:%d|fd:%d|idx:%d|\n", path_id, vlen,
+               MAX_SEG, fd, path_idx);
+        fflush(stdout);
+    }
+    for (int i = 0; i < send_vlen; i++) {
         mmsg[i].msg_hdr.msg_iov = (struct iovec *)&msg_iov[i];
         mmsg[i].msg_hdr.msg_iovlen = 1;
     }
@@ -1403,7 +1557,7 @@ xqc_client_mp_write_mmsg(uint64_t path_id,
             return XQC_SOCKET_EAGAIN;
         }
 
-        res = sendmmsg(fd, mmsg, vlen, 0);
+        res = sendmmsg(fd, mmsg, send_vlen, 0);
         if (res < 0) {
             printf("sendmmsg err %zd %s\n", res, strerror(errno));
             if (errno == EAGAIN) {
@@ -1567,12 +1721,22 @@ xqc_client_create_path_socket(xqc_user_path_t *path,
         return XQC_ERROR;
     }
 
-    if (g_test_case == 103 || g_test_case == 104) {
+    if (g_test_case == 103 || g_test_case == 104
+        || g_test_case == 800)
+    {
         path->rebinding_path_fd = xqc_client_create_socket((g_ipv6 ? AF_INET6 : AF_INET), 
                                         path->peer_addr, path->peer_addrlen, path_interface);
         if (path->rebinding_path_fd < 0) {
             printf("|xqc_client_create_path_socket error|");
             return XQC_ERROR;
+        }
+
+        if (g_test_case == 800) {
+            printf("[case800-debug]|stage:create_path_socket|path_fd:%d|"
+                   "rebinding_fd:%d|if:%s|\n", path->path_fd,
+                   path->rebinding_path_fd,
+                   path_interface == NULL ? "null" : path_interface);
+            fflush(stdout);
         }
     }
 #endif
@@ -1599,12 +1763,48 @@ xqc_client_create_path(xqc_user_path_t *path,
     
     path->ev_socket = event_new(eb, path->path_fd, 
                 EV_READ | EV_PERSIST, xqc_client_socket_event_callback, user_conn);
-    event_add(path->ev_socket, NULL);
+    if (path->ev_socket == NULL) {
+        printf("[case800-debug]|stage:create_path_event_fail|path_fd:%d|\n",
+               path->path_fd);
+        fflush(stdout);
+        return XQC_ERROR;
+    }
+    int path_event_ret = event_add(path->ev_socket, NULL);
+    if (g_test_case == 800) {
+        printf("[case800-debug]|stage:create_path_event_add|ret:%d|fd:%d|\n",
+               path_event_ret, path->path_fd);
+        fflush(stdout);
+    }
+    if (path_event_ret != 0) {
+        return XQC_ERROR;
+    }
 
-    if (g_test_case == 103 || g_test_case == 104) {
+    if (g_test_case == 103 || g_test_case == 104
+        || g_test_case == 800)
+    {
         path->rebinding_ev_socket = event_new(eb, path->rebinding_path_fd, EV_READ | EV_PERSIST,
                                               xqc_client_socket_event_callback, user_conn);
-        event_add(path->rebinding_ev_socket, NULL);
+        if (g_test_case == 800) {
+            printf("[case800-debug]|stage:create_path_event|path_fd:%d|"
+                   "rebinding_fd:%d|ev:%p|rebinding_ev:%p|\n",
+                   path->path_fd, path->rebinding_path_fd,
+                   (void *) path->ev_socket,
+                   (void *) path->rebinding_ev_socket);
+            fflush(stdout);
+        }
+        if (path->rebinding_ev_socket == NULL) {
+            return XQC_ERROR;
+        }
+        int rebinding_event_ret = event_add(path->rebinding_ev_socket, NULL);
+        if (g_test_case == 800) {
+            printf("[case800-debug]|stage:create_rebinding_event_add|"
+                   "ret:%d|fd:%d|\n", rebinding_event_ret,
+                   path->rebinding_path_fd);
+            fflush(stdout);
+        }
+        if (rebinding_event_ret != 0) {
+            return XQC_ERROR;
+        }
     }
 
     return XQC_OK;
@@ -1696,7 +1896,25 @@ xqc_client_create_conn_socket(user_conn_t *user_conn)
 
     user_conn->ev_socket = event_new(eb, user_conn->fd, EV_READ | EV_PERSIST, 
                                      xqc_client_socket_event_callback, user_conn);
-    event_add(user_conn->ev_socket, NULL);
+    if (g_test_case == 800) {
+        printf("[case800-debug]|stage:create_conn_socket|fd:%d|ev:%p|"
+               "eb:%p|user:%p|\n", user_conn->fd,
+               (void *) user_conn->ev_socket, (void *) eb,
+               (void *) user_conn);
+        fflush(stdout);
+    }
+    if (user_conn->ev_socket == NULL) {
+        return -1;
+    }
+    int event_ret = event_add(user_conn->ev_socket, NULL);
+    if (g_test_case == 800) {
+        printf("[case800-debug]|stage:create_conn_socket_event_add|"
+               "ret:%d|fd:%d|\n", event_ret, user_conn->fd);
+        fflush(stdout);
+    }
+    if (event_ret != 0) {
+        return -1;
+    }
 
     return 0;
 }
@@ -1747,6 +1965,21 @@ xqc_client_conn_create_notify(xqc_connection_t *conn, const xqc_cid_t *cid, void
     DEBUG;
 
     user_conn_t *user_conn = (user_conn_t *)user_data;
+    if (g_test_case == 800) {
+        printf("[case800-debug]|stage:conn_create_notify|conn:%p|cid:%p|"
+               "user:%p|proto:%p|\n", (void *) conn, (void *) cid,
+               user_data, conn_proto_data);
+        fflush(stdout);
+    }
+
+    if (conn == NULL || user_conn == NULL) {
+        if (g_test_case == 800) {
+            printf("[case800-debug]|stage:conn_create_notify_bad_arg|\n");
+            fflush(stdout);
+        }
+        return XQC_ERROR;
+    }
+
     xqc_conn_set_alp_user_data(conn, user_conn);
 
     user_conn->dgram_mss = xqc_datagram_get_mss(conn);
@@ -1818,6 +2051,25 @@ xqc_client_conn_update_cid_notify(xqc_connection_t *conn, const xqc_cid_t *retir
     DEBUG;
 
     user_conn_t *user_conn = (user_conn_t *) user_data;
+    if (g_test_case == 800) {
+        printf("[case800-debug]|stage:conn_update_cid|conn:%p|retire:%p|"
+               "new:%p|user:%p|\n", (void *) conn, (void *) retire_cid,
+               (void *) new_cid, user_data);
+        fflush(stdout);
+    }
+
+    if (user_conn == NULL || new_cid == NULL || retire_cid == NULL
+        || ctx.engine == NULL)
+    {
+        if (g_test_case == 800) {
+            printf("[case800-debug]|stage:conn_update_cid_bad_arg|"
+                   "user:%p|engine:%p|retire:%p|new:%p|\n",
+                   (void *) user_conn, (void *) ctx.engine,
+                   (void *) retire_cid, (void *) new_cid);
+            fflush(stdout);
+        }
+        return;
+    }
 
     memcpy(&user_conn->cid, new_cid, sizeof(*new_cid));
 
@@ -1832,6 +2084,20 @@ xqc_client_conn_handshake_finished(xqc_connection_t *conn, void *user_data, void
 {
     DEBUG;
     user_conn_t *user_conn = (user_conn_t *) user_data;
+    if (g_test_case == 800) {
+        printf("[case800-debug]|stage:handshake_finished|conn:%p|user:%p|\n",
+               (void *) conn, user_data);
+        fflush(stdout);
+    }
+
+    if (user_conn == NULL) {
+        if (g_test_case == 800) {
+            printf("[case800-debug]|stage:handshake_finished_bad_arg|\n");
+            fflush(stdout);
+        }
+        return;
+    }
+
     if (!g_test_qch_mode) {
         if (!g_mp_ping_on) {
             xqc_conn_send_ping(ctx.engine, &user_conn->cid, NULL);
@@ -1867,6 +2133,20 @@ xqc_client_h3_conn_create_notify(xqc_h3_conn_t *conn, const xqc_cid_t *cid, void
     DEBUG;
 
     user_conn_t *user_conn = (user_conn_t *) user_data;
+    if (g_test_case == 800) {
+        printf("[case800-debug]|stage:h3_conn_create_notify|conn:%p|"
+               "cid:%p|user:%p|\n", (void *) conn, (void *) cid,
+               user_data);
+        fflush(stdout);
+    }
+
+    if (conn == NULL || user_conn == NULL) {
+        if (g_test_case == 800) {
+            printf("[case800-debug]|stage:h3_conn_create_notify_bad_arg|\n");
+            fflush(stdout);
+        }
+        return XQC_ERROR;
+    }
 
     user_conn->dgram_mss = xqc_h3_ext_datagram_get_mss(conn);
     user_conn->h3_conn = conn;
@@ -4162,6 +4442,27 @@ xqc_client_ready_to_create_path(const xqc_cid_t *cid,
     uint64_t path_id = 0;
     user_conn_t *user_conn = (user_conn_t *) conn_user_data;
 
+    if (g_test_case == 800) {
+        printf("[case800-debug]|stage:ready_to_create_path|cid:%p|"
+               "user:%p|engine:%p|interfaces:%d|max_paths:%d|\n",
+               (void *) cid, conn_user_data, (void *) ctx.engine,
+               g_multi_interface_cnt, XQC_DEMO_MAX_PATH_COUNT);
+        fflush(stdout);
+    }
+
+    if (user_conn == NULL || ctx.engine == NULL
+        || g_multi_interface_cnt > XQC_DEMO_MAX_PATH_COUNT)
+    {
+        if (g_test_case == 800) {
+            printf("[case800-debug]|stage:ready_to_create_path_bad_state|"
+                   "user:%p|engine:%p|interfaces:%d|max_paths:%d|\n",
+                   (void *) user_conn, (void *) ctx.engine,
+                   g_multi_interface_cnt, XQC_DEMO_MAX_PATH_COUNT);
+            fflush(stdout);
+        }
+        return;
+    }
+
     if (!g_enable_multipath) {
         return;
     }
@@ -4172,7 +4473,21 @@ xqc_client_ready_to_create_path(const xqc_cid_t *cid,
                 continue;
             }
         
+            if (g_test_case == 800) {
+                printf("[case800-debug]|stage:before_create_path|idx:%d|"
+                       "used:%d|old_path:%"PRIu64"|\n", i,
+                       g_client_path[i].is_in_used,
+                       g_client_path[i].path_id);
+                fflush(stdout);
+            }
+
             int ret = xqc_conn_create_path(ctx.engine, &(user_conn->cid), &path_id, 0);
+
+            if (g_test_case == 800) {
+                printf("[case800-debug]|stage:after_create_path|idx:%d|"
+                       "ret:%d|path:%"PRIu64"|\n", i, ret, path_id);
+                fflush(stdout);
+            }
 
             if (ret < 0) {
                 printf("not support mp, xqc_conn_create_path err = %d\n", ret);
@@ -4927,6 +5242,20 @@ int main(int argc, char *argv[]) {
         }
 
     }
+
+    if (g_test_case == 800 && !g_no_crypt) {
+        printf("test case 800 requires -N to inspect short-header frame type\n");
+        exit(1);
+    }
+
+#ifndef XQC_SYS_WINDOWS
+    if (g_test_case == 800) {
+        signal(SIGSEGV, xqc_client_case800_signal_handler);
+        signal(SIGABRT, xqc_client_case800_signal_handler);
+    }
+#endif
+
+    xqc_client_case800_debug_state("after_args");
     
     memset(g_header_key, 'k', sizeof(g_header_key));
     memset(g_header_value, 'v', sizeof(g_header_value));
@@ -4936,6 +5265,7 @@ int main(int argc, char *argv[]) {
     xqc_client_open_log_file(&ctx);
 
     g_token_len = xqc_client_read_token(g_token, XQC_MAX_TOKEN_LEN);
+    xqc_client_case800_debug_state("after_token");
  
     xqc_platform_init_env();
 

--- a/tests/unittest/xqc_frame_type_bit_test.c
+++ b/tests/unittest/xqc_frame_type_bit_test.c
@@ -141,11 +141,23 @@ xqc_test_need_repair_with_high_bit()
     types = XQC_FRAME_BIT_STREAM | XQC_FRAME_BIT_REPAIR_SYMBOL;
     CU_ASSERT(XQC_NEED_REPAIR(types) != 0);
 
-    /* ACK + PADDING + PING + CONN_CLOSE + DATAGRAM + SID + REPAIR_SYMBOL:
-     * all are excluded from repair; result should be 0 */
+    /* PATH_RESPONSE alone: should NOT need repair. RFC 9000 Section 13.3 /
+     * Section 8.2.2 require PATH_RESPONSE to be sent just once and not
+     * retransmitted on loss. */
+    types = XQC_FRAME_BIT_PATH_RESPONSE;
+    CU_ASSERT(XQC_NEED_REPAIR(types) == 0);
+
+    /* STREAM + PATH_RESPONSE: should need repair (STREAM triggers it, other
+     * repairable frames sharing the packet are still retransmitted) */
+    types = XQC_FRAME_BIT_STREAM | XQC_FRAME_BIT_PATH_RESPONSE;
+    CU_ASSERT(XQC_NEED_REPAIR(types) != 0);
+
+    /* ACK + PADDING + PING + CONN_CLOSE + DATAGRAM + SID + REPAIR_SYMBOL +
+     * PATH_RESPONSE: all are excluded from repair; result should be 0 */
     types = XQC_FRAME_BIT_ACK | XQC_FRAME_BIT_PADDING | XQC_FRAME_BIT_PING
           | XQC_FRAME_BIT_CONNECTION_CLOSE | XQC_FRAME_BIT_DATAGRAM
-          | XQC_FRAME_BIT_SID | XQC_FRAME_BIT_REPAIR_SYMBOL;
+          | XQC_FRAME_BIT_SID | XQC_FRAME_BIT_REPAIR_SYMBOL
+          | XQC_FRAME_BIT_PATH_RESPONSE;
     CU_ASSERT(XQC_NEED_REPAIR(types) == 0);
 }
 


### PR DESCRIPTION
Fixes: #630

## Mechanism

RFC 9000 Section 13.3 / Section 8.2.2: responses to path validation using
PATH_RESPONSE frames are sent just once and MUST NOT be retransmitted on loss.
The peer sends additional PATH_CHALLENGE frames to elicit new PATH_RESPONSE
frames. Therefore PATH_RESPONSE must be excluded from the XQC_NEED_REPAIR
macro so that lost PATH_RESPONSE frames are not retransmitted.

No RFC applies to the test-only commit.

## Validation Cases

Unit tests (CUnit):
- Positive: STREAM + PATH_RESPONSE still needs repair (STREAM triggers it)
- Negative: PATH_RESPONSE alone does not need repair
- Negative: all excluded types combined (ACK + PADDING + PING + CONN_CLOSE + DATAGRAM + SID + REPAIR_SYMBOL + PATH_RESPONSE) result in 0

Endpoint-visible client-to-server coverage: documented gap. The current test
harness lacks frame-selective packet loss injection during path validation;
existing drop mechanisms operate at packet type granularity only.

## CONTRIBUTING.md

Overall: Pending
Local regression: Complete (CUnit 165/165, Failed=0); client-to-server case-test gap documented above
CI: Pending