### PR TITLE
[~]: Add unilateral PMTUD force mode

### DIFF
--- a/harness/spec/validation.md
+++ b/harness/spec/validation.md
@@ -97,7 +97,7 @@ its case is retired so later changes cannot reuse it.
 
 | Range | New-case namespace | Allocated IDs |
 |-------|--------------------|---------------|
-| `[705, 799]` | QUIC Transport core | `705-710` |
+| `[705, 799]` | QUIC Transport core | `705-712` |
 | `[800, 899]` | Recovery and congestion control | None |
 | `[900, 999]` | QUIC-TLS | `902-903` |
 | `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1014` |

--- a/include/xquic/xquic.h
+++ b/include/xquic/xquic.h
@@ -1446,6 +1446,9 @@ typedef struct xqc_conn_settings_s {
 
     /**
      * PMTUD flags:
+     * Values 0x0 through 0x3 retain their negotiated behavior and transport
+     * parameter encoding. Applications that keep those values unchanged do
+     * not change whether PMTUD is enabled.
      * XQC_PMTUD_DISABLE disables PMTUD.
      * XQC_PMTUD_ENABLE_CLIENT and XQC_PMTUD_ENABLE_SERVER are negotiated
      * role bits. Both endpoints need to advertise a role bit to enable
@@ -1454,6 +1457,8 @@ typedef struct xqc_conn_settings_s {
      * negotiation. It can be combined with the negotiated role bits and is
      * not sent in the transport parameter. This local mode follows the
      * sender-side behavior in RFC 9000 Section 14.3.1.
+     * Values outside XQC_PMTUD_ENABLE_MASK were previously undefined;
+     * XQC_PMTUD_FORCE_ENABLE assigns bit 0x4 as a local-only opt-in.
      */
     uint8_t                     enable_pmtud;
     /** probing interval (us), default: 500000 */

--- a/include/xquic/xquic.h
+++ b/include/xquic/xquic.h
@@ -1255,6 +1255,15 @@ typedef enum {
 } xqc_dgram_red_setting_e;
 
 typedef enum {
+    XQC_PMTUD_DISABLE           = 0,
+    XQC_PMTUD_ENABLE_CLIENT     = 1 << 0,
+    XQC_PMTUD_ENABLE_SERVER     = 1 << 1,
+    XQC_PMTUD_ENABLE_MASK       = XQC_PMTUD_ENABLE_CLIENT
+                                  | XQC_PMTUD_ENABLE_SERVER,
+    XQC_PMTUD_FORCE_ENABLE      = 1 << 2,
+} xqc_pmtud_flag_e;
+
+typedef enum {
     XQC_FEC_CONN_LEVEL      = 0,
     XQC_FEC_STREAM_LEVEL    = 1
 } xqc_fec_level_e;
@@ -1435,16 +1444,17 @@ typedef struct xqc_conn_settings_s {
     uint8_t                     datagram_force_retrans_on;
     uint64_t                    datagram_redundant_probe;
 
-     /**
-     * enable PMTUD: 
-     * 0x0 disbale, 
-     * 0x1 enable client probing, 
-     * 0x2 enable server probing, 
-     * 0x3 enable both ends probing
-     * NOTE: This option needs to be negotiated by both ends. The final decision
-     * is made by the logic AND operation of both ends' options, e.g. client:
-     * 0x3, server: 0x1 --> 0x1 (only enable client probing).
-     **/
+    /**
+     * PMTUD flags:
+     * XQC_PMTUD_DISABLE disables PMTUD.
+     * XQC_PMTUD_ENABLE_CLIENT and XQC_PMTUD_ENABLE_SERVER are negotiated
+     * role bits. Both endpoints need to advertise a role bit to enable
+     * probing for that role.
+     * XQC_PMTUD_FORCE_ENABLE enables probing on this endpoint without peer
+     * negotiation. It can be combined with the negotiated role bits and is
+     * not sent in the transport parameter. This local mode follows the
+     * sender-side behavior in RFC 9000 Section 14.3.1.
+     */
     uint8_t                     enable_pmtud;
     /** probing interval (us), default: 500000 */
     uint64_t                    pmtud_probing_interval; 

--- a/scripts/case_test.sh
+++ b/scripts/case_test.sh
@@ -4228,6 +4228,57 @@ grep_err_log
 
 
 killall test_server
+stdbuf -oL ${SERVER_BIN} -l d -e -Q 65535 -U 1 -x 711 > /dev/null &
+sleep 1
+
+rm -rf tp_localhost test_session xqc_token
+clear_log
+echo -e "PMTUD force enable with peer option omitted...\c"
+sudo ${CLIENT_BIN} -s 1024 -l d -t 1 -E -x 711 -Q 65535 -U 1 -T 1 > stdlog
+sleep 1
+result=`grep "\[dgram\]|recv_dgram_bytes:1024|sent_dgram_bytes:1024|" stdlog`
+probe_res=`grep "\[dgram\]|mss_callback|updated_mss:1404|" stdlog`
+cli_res=`grep -E "xqc_conn_destroy.*enable_pmtud:1" clog`
+svr_res=`grep -E "xqc_conn_destroy.*enable_pmtud:0" slog`
+errlog=`grep_err_log`
+if [ -z "$errlog" ] && [ -n "$result" ] && [ -n "$probe_res" ] \
+    && [ -n "$cli_res" ] && [ -n "$svr_res" ]
+then
+    echo ">>>>>>>> pass:1"
+    case_print_result "PMTUD_force_enable_peer_omits_option" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "PMTUD_force_enable_peer_omits_option" "fail"
+fi
+grep_err_log
+
+killall test_server
+stdbuf -oL ${SERVER_BIN} -l d -e -Q 65535 -U 1 -x 712 > /dev/null &
+sleep 1
+
+rm -rf tp_localhost test_session xqc_token
+clear_log
+echo -e "PMTUD negotiated mode with peer option omitted...\c"
+sudo ${CLIENT_BIN} -s 1024 -l d -t 1 -E -x 712 -Q 65535 -U 1 -T 1 > stdlog
+sleep 1
+result=`grep "\[dgram\]|recv_dgram_bytes:1024|sent_dgram_bytes:1024|" stdlog`
+probe_res=`grep "\[dgram\]|mss_callback|updated_mss:1404|" stdlog`
+cli_res=`grep -E "xqc_conn_destroy.*enable_pmtud:0" clog`
+svr_res=`grep -E "xqc_conn_destroy.*enable_pmtud:0" slog`
+errlog=`grep_err_log`
+if [ -z "$errlog" ] && [ -n "$result" ] && [ -z "$probe_res" ] \
+    && [ -n "$cli_res" ] && [ -n "$svr_res" ]
+then
+    echo ">>>>>>>> pass:1"
+    case_print_result "PMTUD_negotiated_mode_peer_omits_option" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "PMTUD_negotiated_mode_peer_omits_option" "fail"
+fi
+grep_err_log
+
+
+killall test_server
 stdbuf -oL ${SERVER_BIN} -l d -e -M -Q 65535 -U 1 --pmtud 1 -x 200 > svr_stdlog &
 sleep 1
 

--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -1569,7 +1569,7 @@ xqc_conn_destroy(xqc_connection_t *xc)
             fec_mpm_str, conn_stats.send_fec_cnt, xc->fec_ctl ? xc->fec_ctl->fec_recover_pkt_cnt : 0,
             xc->pkt_out_size, xc->max_pkt_out_size, xc->probing_pkt_out_size,
             conn_stats.extern_conn_info, xc->max_acked_po_size, 
-            xc->enable_pmtud, xc->conn_avg_close_delay,
+            (uint64_t) xc->enable_pmtud, xc->conn_avg_close_delay,
             xc->passive_bidi_stream_max
             );
     xqc_log_event(xc->log, CON_CONNECTION_CLOSED, xc);

--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -1569,7 +1569,7 @@ xqc_conn_destroy(xqc_connection_t *xc)
             fec_mpm_str, conn_stats.send_fec_cnt, xc->fec_ctl ? xc->fec_ctl->fec_recover_pkt_cnt : 0,
             xc->pkt_out_size, xc->max_pkt_out_size, xc->probing_pkt_out_size,
             conn_stats.extern_conn_info, xc->max_acked_po_size, 
-            xc->local_settings.enable_pmtud & xc->remote_settings.enable_pmtud, xc->conn_avg_close_delay,
+            xc->enable_pmtud, xc->conn_avg_close_delay,
             xc->passive_bidi_stream_max
             );
     xqc_log_event(xc->log, CON_CONNECTION_CLOSED, xc);
@@ -4367,12 +4367,18 @@ xqc_conn_add_path_cid_sets(xqc_connection_t *conn, uint32_t start, uint32_t end)
     return XQC_OK;
 }
 
-void 
+void
 xqc_conn_try_to_enable_pmtud(xqc_connection_t *conn)
 {
-    uint64_t pmtud_check_bit = conn->conn_type == XQC_CONN_TYPE_SERVER ? 0x2 : 0x1;
+    uint64_t pmtud_check_bit = conn->conn_type == XQC_CONN_TYPE_SERVER
+                               ? XQC_PMTUD_ENABLE_SERVER
+                               : XQC_PMTUD_ENABLE_CLIENT;
     xqc_usec_t now;
-    if (((conn->remote_settings.enable_pmtud & conn->local_settings.enable_pmtud) & pmtud_check_bit) != 0) {
+    if ((conn->local_settings.enable_pmtud & XQC_PMTUD_FORCE_ENABLE)
+        || ((conn->remote_settings.enable_pmtud
+             & conn->local_settings.enable_pmtud
+             & pmtud_check_bit) != 0))
+    {
         conn->enable_pmtud = 1;
         now = xqc_monotonic_timestamp();
         if (conn->enable_multipath) {
@@ -5877,7 +5883,8 @@ xqc_conn_get_local_transport_params(xqc_connection_t *conn, xqc_transport_params
     params->multipath_version = settings->multipath_version;
     params->init_max_path_id = settings->init_max_path_id;
     params->max_datagram_frame_size = settings->max_datagram_frame_size;
-    params->enable_pmtud = settings->enable_pmtud;
+    /* XQC_PMTUD_FORCE_ENABLE is a local-only sender policy. */
+    params->enable_pmtud = settings->enable_pmtud & XQC_PMTUD_ENABLE_MASK;
 
     params->close_dgram_redundancy = settings->close_dgram_redundancy;
 

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -280,6 +280,7 @@ uint64_t g_last_sock_op_time;
  * 703 for CRYPTO_ERROR validation
  * 704 for active_connection_id_limit validation
  * 709/710 for active_connection_id_limit minimum validation
+ * 711/712 for PMTUD peer-option omission validation
  * 902/903 for AEAD confidentiality-limit validation
  * 1000-1014 for HTTP/3 protocol validation
  */
@@ -5066,6 +5067,13 @@ int main(int argc, char *argv[]) {
 
     if (g_pmtud_on) {
         conn_settings.enable_pmtud = 3;
+    }
+
+    if (g_test_case == 711) {
+        conn_settings.enable_pmtud = XQC_PMTUD_FORCE_ENABLE;
+
+    } else if (g_test_case == 712) {
+        conn_settings.enable_pmtud = XQC_PMTUD_ENABLE_CLIENT;
     }
 
     if (g_test_case == 450) {

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -2778,6 +2778,10 @@ int main(int argc, char *argv[]) {
         conn_settings.enable_pmtud = 3;
     }
 
+    if (g_test_case == 711 || g_test_case == 712) {
+        conn_settings.enable_pmtud = XQC_PMTUD_DISABLE;
+    }
+
     if (g_test_case == 6) {
         conn_settings.idle_time_out = 10000;
     }

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -84,8 +84,8 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite, "xqc_test_conn_idle_timeout", xqc_test_conn_idle_timeout)
         || !CU_add_test(pSuite, "xqc_test_conn_pmtud_force_enable",
                         xqc_test_conn_pmtud_force_enable)
-        || !CU_add_test(pSuite, "xqc_test_conn_pmtud_negotiated_mode",
-                        xqc_test_conn_pmtud_negotiated_mode)
+        || !CU_add_test(pSuite, "xqc_test_conn_pmtud_legacy_compatibility",
+                        xqc_test_conn_pmtud_legacy_compatibility)
         || !CU_add_test(pSuite, "xqc_test_conn_early_data_reject", xqc_test_conn_early_data_reject)
         || !CU_add_test(pSuite, "xqc_test_conn_early_data_reject_flow_ctl", xqc_test_conn_early_data_reject_flow_ctl)
         /* RFC 9000 §20.1 CRYPTO_ERROR dynamic construction */

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -82,6 +82,10 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite, "xqc_test_engine_create", xqc_test_engine_create)
         || !CU_add_test(pSuite, "xqc_test_conn_create", xqc_test_conn_create)
         || !CU_add_test(pSuite, "xqc_test_conn_idle_timeout", xqc_test_conn_idle_timeout)
+        || !CU_add_test(pSuite, "xqc_test_conn_pmtud_force_enable",
+                        xqc_test_conn_pmtud_force_enable)
+        || !CU_add_test(pSuite, "xqc_test_conn_pmtud_negotiated_mode",
+                        xqc_test_conn_pmtud_negotiated_mode)
         || !CU_add_test(pSuite, "xqc_test_conn_early_data_reject", xqc_test_conn_early_data_reject)
         || !CU_add_test(pSuite, "xqc_test_conn_early_data_reject_flow_ctl", xqc_test_conn_early_data_reject_flow_ctl)
         /* RFC 9000 §20.1 CRYPTO_ERROR dynamic construction */

--- a/tests/unittest/xqc_conn_test.c
+++ b/tests/unittest/xqc_conn_test.c
@@ -189,38 +189,59 @@ xqc_test_conn_pmtud_force_enable()
 }
 
 void
-xqc_test_conn_pmtud_negotiated_mode()
+xqc_test_conn_pmtud_legacy_compatibility()
 {
+    static const xqc_conn_type_t roles[] = {
+        XQC_CONN_TYPE_CLIENT,
+        XQC_CONN_TYPE_SERVER,
+    };
+    static const uint8_t role_bits[] = {
+        XQC_PMTUD_ENABLE_CLIENT,
+        XQC_PMTUD_ENABLE_SERVER,
+    };
     xqc_connection_t *conn = test_engine_connect();
+    xqc_transport_params_t params;
+    size_t role_idx;
+    uint8_t local_flags, remote_flags, expected;
+
     CU_ASSERT_FATAL(conn != NULL);
 
-    xqc_pmtud_case_set(conn, XQC_CONN_TYPE_CLIENT,
-                       XQC_PMTUD_ENABLE_CLIENT, XQC_PMTUD_ENABLE_CLIENT);
-    xqc_conn_try_to_enable_pmtud(conn);
-    CU_ASSERT(conn->enable_pmtud == 1);
-    CU_ASSERT(xqc_timer_is_set(&conn->conn_timer_manager,
-                               XQC_TIMER_PMTUD_PROBING));
+    CU_ASSERT_EQUAL(XQC_PMTUD_DISABLE, 0x0);
+    CU_ASSERT_EQUAL(XQC_PMTUD_ENABLE_CLIENT, 0x1);
+    CU_ASSERT_EQUAL(XQC_PMTUD_ENABLE_SERVER, 0x2);
+    CU_ASSERT_EQUAL(XQC_PMTUD_ENABLE_MASK, 0x3);
 
-    xqc_pmtud_case_set(conn, XQC_CONN_TYPE_SERVER,
-                       XQC_PMTUD_ENABLE_SERVER, XQC_PMTUD_ENABLE_SERVER);
-    xqc_conn_try_to_enable_pmtud(conn);
-    CU_ASSERT(conn->enable_pmtud == 1);
-    CU_ASSERT(xqc_timer_is_set(&conn->conn_timer_manager,
-                               XQC_TIMER_PMTUD_PROBING));
+    for (role_idx = 0; role_idx < sizeof(roles) / sizeof(roles[0]);
+         role_idx++)
+    {
+        for (local_flags = XQC_PMTUD_DISABLE;
+             local_flags <= XQC_PMTUD_ENABLE_MASK; local_flags++)
+        {
+            for (remote_flags = XQC_PMTUD_DISABLE;
+                 remote_flags <= XQC_PMTUD_ENABLE_MASK; remote_flags++)
+            {
+                expected = (local_flags & remote_flags
+                            & role_bits[role_idx]) != 0;
+                xqc_pmtud_case_set(conn, roles[role_idx], local_flags,
+                                   remote_flags);
+                xqc_conn_try_to_enable_pmtud(conn);
+                CU_ASSERT_EQUAL(conn->enable_pmtud, expected);
+                CU_ASSERT_EQUAL(xqc_timer_is_set(&conn->conn_timer_manager,
+                                                 XQC_TIMER_PMTUD_PROBING),
+                                expected);
+            }
+        }
+    }
 
-    xqc_pmtud_case_set(conn, XQC_CONN_TYPE_CLIENT,
-                       XQC_PMTUD_ENABLE_CLIENT, XQC_PMTUD_DISABLE);
-    xqc_conn_try_to_enable_pmtud(conn);
-    CU_ASSERT(conn->enable_pmtud == 0);
-    CU_ASSERT(!xqc_timer_is_set(&conn->conn_timer_manager,
-                                XQC_TIMER_PMTUD_PROBING));
-
-    xqc_pmtud_case_set(conn, XQC_CONN_TYPE_CLIENT,
-                       XQC_PMTUD_ENABLE_SERVER, XQC_PMTUD_ENABLE_SERVER);
-    xqc_conn_try_to_enable_pmtud(conn);
-    CU_ASSERT(conn->enable_pmtud == 0);
-    CU_ASSERT(!xqc_timer_is_set(&conn->conn_timer_manager,
-                                XQC_TIMER_PMTUD_PROBING));
+    for (local_flags = XQC_PMTUD_DISABLE;
+         local_flags <= XQC_PMTUD_ENABLE_MASK; local_flags++)
+    {
+        xqc_memzero(&params, sizeof(params));
+        conn->local_settings.enable_pmtud = local_flags;
+        CU_ASSERT_EQUAL(xqc_conn_get_local_transport_params(conn, &params),
+                        XQC_OK);
+        CU_ASSERT_EQUAL(params.enable_pmtud, local_flags);
+    }
 
     xqc_engine_destroy(conn->engine);
 }

--- a/tests/unittest/xqc_conn_test.c
+++ b/tests/unittest/xqc_conn_test.c
@@ -10,6 +10,7 @@
 #include "src/transport/xqc_client.h"
 #include "src/transport/xqc_defs.h"
 #include "src/transport/xqc_stream.h"
+#include "src/transport/xqc_timer.h"
 #include "xquic/xquic_typedef.h"
 #include "src/common/xqc_str.h"
 #include "src/common/xqc_list.h"
@@ -142,6 +143,84 @@ xqc_test_conn_idle_timeout()
     xqc_idle_to_set(conn, XQC_CONN_TYPE_SERVER, 30000, 5000, 1, 0);
     got = xqc_conn_get_idle_timeout(conn);
     CU_ASSERT(got == 5000);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
+static void
+xqc_pmtud_case_set(xqc_connection_t *conn, xqc_conn_type_t role,
+    uint64_t local_flags, uint64_t remote_flags)
+{
+    conn->conn_type = role;
+    conn->local_settings.enable_pmtud = local_flags;
+    conn->remote_settings.enable_pmtud = remote_flags;
+    conn->enable_pmtud = 0;
+    xqc_timer_unset(&conn->conn_timer_manager, XQC_TIMER_PMTUD_PROBING);
+}
+
+void
+xqc_test_conn_pmtud_force_enable()
+{
+    xqc_connection_t *conn = test_engine_connect();
+    xqc_transport_params_t params = {0};
+    CU_ASSERT_FATAL(conn != NULL);
+
+    xqc_pmtud_case_set(conn, XQC_CONN_TYPE_CLIENT,
+                       XQC_PMTUD_FORCE_ENABLE, XQC_PMTUD_DISABLE);
+    xqc_conn_try_to_enable_pmtud(conn);
+    CU_ASSERT(conn->enable_pmtud == 1);
+    CU_ASSERT(xqc_timer_is_set(&conn->conn_timer_manager,
+                               XQC_TIMER_PMTUD_PROBING));
+
+    xqc_pmtud_case_set(conn, XQC_CONN_TYPE_SERVER,
+                       XQC_PMTUD_FORCE_ENABLE, XQC_PMTUD_DISABLE);
+    xqc_conn_try_to_enable_pmtud(conn);
+    CU_ASSERT(conn->enable_pmtud == 1);
+    CU_ASSERT(xqc_timer_is_set(&conn->conn_timer_manager,
+                               XQC_TIMER_PMTUD_PROBING));
+
+    conn->local_settings.enable_pmtud = XQC_PMTUD_FORCE_ENABLE
+                                        | XQC_PMTUD_ENABLE_SERVER;
+    CU_ASSERT(xqc_conn_get_local_transport_params(conn, &params) == XQC_OK);
+    CU_ASSERT(params.enable_pmtud == XQC_PMTUD_ENABLE_SERVER);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+void
+xqc_test_conn_pmtud_negotiated_mode()
+{
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_FATAL(conn != NULL);
+
+    xqc_pmtud_case_set(conn, XQC_CONN_TYPE_CLIENT,
+                       XQC_PMTUD_ENABLE_CLIENT, XQC_PMTUD_ENABLE_CLIENT);
+    xqc_conn_try_to_enable_pmtud(conn);
+    CU_ASSERT(conn->enable_pmtud == 1);
+    CU_ASSERT(xqc_timer_is_set(&conn->conn_timer_manager,
+                               XQC_TIMER_PMTUD_PROBING));
+
+    xqc_pmtud_case_set(conn, XQC_CONN_TYPE_SERVER,
+                       XQC_PMTUD_ENABLE_SERVER, XQC_PMTUD_ENABLE_SERVER);
+    xqc_conn_try_to_enable_pmtud(conn);
+    CU_ASSERT(conn->enable_pmtud == 1);
+    CU_ASSERT(xqc_timer_is_set(&conn->conn_timer_manager,
+                               XQC_TIMER_PMTUD_PROBING));
+
+    xqc_pmtud_case_set(conn, XQC_CONN_TYPE_CLIENT,
+                       XQC_PMTUD_ENABLE_CLIENT, XQC_PMTUD_DISABLE);
+    xqc_conn_try_to_enable_pmtud(conn);
+    CU_ASSERT(conn->enable_pmtud == 0);
+    CU_ASSERT(!xqc_timer_is_set(&conn->conn_timer_manager,
+                                XQC_TIMER_PMTUD_PROBING));
+
+    xqc_pmtud_case_set(conn, XQC_CONN_TYPE_CLIENT,
+                       XQC_PMTUD_ENABLE_SERVER, XQC_PMTUD_ENABLE_SERVER);
+    xqc_conn_try_to_enable_pmtud(conn);
+    CU_ASSERT(conn->enable_pmtud == 0);
+    CU_ASSERT(!xqc_timer_is_set(&conn->conn_timer_manager,
+                                XQC_TIMER_PMTUD_PROBING));
 
     xqc_engine_destroy(conn->engine);
 }

--- a/tests/unittest/xqc_conn_test.h
+++ b/tests/unittest/xqc_conn_test.h
@@ -8,7 +8,7 @@
 void xqc_test_conn_create();
 void xqc_test_conn_idle_timeout();
 void xqc_test_conn_pmtud_force_enable();
-void xqc_test_conn_pmtud_negotiated_mode();
+void xqc_test_conn_pmtud_legacy_compatibility();
 void xqc_test_conn_early_data_reject();
 void xqc_test_conn_early_data_reject_flow_ctl();
 

--- a/tests/unittest/xqc_conn_test.h
+++ b/tests/unittest/xqc_conn_test.h
@@ -7,6 +7,8 @@
 
 void xqc_test_conn_create();
 void xqc_test_conn_idle_timeout();
+void xqc_test_conn_pmtud_force_enable();
+void xqc_test_conn_pmtud_negotiated_mode();
 void xqc_test_conn_early_data_reject();
 void xqc_test_conn_early_data_reject_flow_ctl();
 


### PR DESCRIPTION
### Mechanism

Add `XQC_PMTUD_FORCE_ENABLE` as a local-only sender policy so an endpoint can
start PMTUD after the handshake when its peer omits XQUIC's private PMTUD
transport parameter. The existing `uint8_t enable_pmtud` field is unchanged:
external values `0x0` through `0x3` retain their negotiated, role-specific
enablement and transport-parameter encoding. Only the previously undefined
`0x4` bit opts into force mode, and that bit is masked from the wire.
Connection-close reports expose the resulting enabled state for validation.

- RFC or draft: RFC 9000 Sections 14 and 14.3.1

Fixes: #645

### Validation Cases

- 711 — force mode probes successfully when the peer omits the private option
- 712 — negotiated mode remains disabled when the peer omits the private option

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Complete
- CI: Pending — Harness Check; Analyze; platform builds not started
