### PR TITLE
[~]Fixes: #662 Reject negative ACK range packet numbers

### DIFF
--- a/src/transport/xqc_frame_parser.c
+++ b/src/transport/xqc_frame_parser.c
@@ -1163,7 +1163,7 @@ xqc_parse_ack_frame(xqc_packet_in_t *packet_in, xqc_connection_t *conn, xqc_ack_
     uint64_t largest_acked;
     uint64_t ack_range_count;   /* the actual range cnt */
     uint64_t first_ack_range;
-    uint64_t range, gap;
+    uint64_t range, gap, range_high, range_low, previous_low;
 
     unsigned n_ranges = 0;      /* the range cnt stored */
 
@@ -1202,8 +1202,21 @@ xqc_parse_ack_frame(xqc_packet_in_t *packet_in, xqc_connection_t *conn, xqc_ack_
     }
     p += vlen;
 
+    /*
+     * RFC 9000 Section 19.3.1: a negative computed packet number is a
+     * FRAME_ENCODING_ERROR.
+     */
+    if (first_ack_range > largest_acked) {
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|invalid ACK range|largest_acked:%ui|first_ack_range:%ui|",
+                largest_acked, first_ack_range);
+        XQC_CONN_ERR(conn, TRA_FRAME_ENCODING_ERROR);
+        return -XQC_EILLEGAL_FRAME;
+    }
+
     ack_info->ranges[n_ranges].high = largest_acked;
-    ack_info->ranges[n_ranges].low = largest_acked - first_ack_range;
+    previous_low = largest_acked - first_ack_range;
+    ack_info->ranges[n_ranges].low = previous_low;
     n_ranges++;
 
     for (int i = 0; i < ack_range_count; ++i) {
@@ -1219,11 +1232,30 @@ xqc_parse_ack_frame(xqc_packet_in_t *packet_in, xqc_connection_t *conn, xqc_ack_
         }
         p += vlen;
 
+        if (previous_low < 2 || gap > previous_low - 2) {
+            xqc_log(conn->log, XQC_LOG_ERROR,
+                    "|invalid ACK gap|previous_low:%ui|gap:%ui|",
+                    previous_low, gap);
+            XQC_CONN_ERR(conn, TRA_FRAME_ENCODING_ERROR);
+            return -XQC_EILLEGAL_FRAME;
+        }
+
+        range_high = previous_low - gap - 2;
+        if (range > range_high) {
+            xqc_log(conn->log, XQC_LOG_ERROR,
+                    "|invalid ACK range|range_high:%ui|range:%ui|",
+                    range_high, range);
+            XQC_CONN_ERR(conn, TRA_FRAME_ENCODING_ERROR);
+            return -XQC_EILLEGAL_FRAME;
+        }
+
+        range_low = range_high - range;
         if (n_ranges < XQC_MAX_ACK_RANGE_CNT) {
-            ack_info->ranges[n_ranges].high = ack_info->ranges[n_ranges - 1].low - gap - 2;
-            ack_info->ranges[n_ranges].low = ack_info->ranges[n_ranges].high - range;
+            ack_info->ranges[n_ranges].high = range_high;
+            ack_info->ranges[n_ranges].low = range_low;
             n_ranges++;
         }
+        previous_low = range_low;
     }
 
     /* 

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -138,6 +138,11 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite, "xqc_test_process_frame", xqc_test_process_frame)
         || !CU_add_test(pSuite, "xqc_test_parse_padding_frame", xqc_test_parse_padding_frame)
         || !CU_add_test(pSuite, "xqc_test_large_ack_frame", xqc_test_large_ack_frame)
+        /* RFC 9000 Section 19.3.1 ACK packet-number boundaries */
+        || !CU_add_test(pSuite, "xqc_test_ack_range_zero_boundary",
+                        xqc_test_ack_range_zero_boundary)
+        || !CU_add_test(pSuite, "xqc_test_ack_range_negative_rejected",
+                        xqc_test_ack_range_negative_rejected)
         /* issue #632: ACK_ECN frame parsing (RFC 9000 19.3) */
         || !CU_add_test(pSuite, "xqc_test_ack_ecn_normal_parse", xqc_test_ack_ecn_normal_parse)
         || !CU_add_test(pSuite, "xqc_test_ack_plain_regression", xqc_test_ack_plain_regression)

--- a/tests/unittest/xqc_process_frame_test.c
+++ b/tests/unittest/xqc_process_frame_test.c
@@ -20,6 +20,8 @@ char XQC_TEST_STREAM_FRAME[] = {0x0a, 0x00, 0x01, 0x00};
 
 static void xqc_test_conn_close_error_type(unsigned char *frame,
     size_t frame_len, xqc_conn_err_type_t expected_type);
+static void xqc_test_ack_range_rejected(unsigned char *frame,
+    size_t frame_len);
 
 
 static xqc_int_t
@@ -254,6 +256,114 @@ xqc_test_large_ack_frame()
     CU_ASSERT(pi_ack.pi_frame_types == XQC_FRAME_BIT_ACK);
 
     xqc_engine_destroy(conn->engine);
+}
+
+
+void
+xqc_test_ack_range_zero_boundary()
+{
+    unsigned char frame[] = {
+        0x02,       /* ACK */
+        0x0a,       /* largest acknowledged = 10 */
+        0x00,       /* ACK delay */
+        0x02,       /* ACK range count = 2 */
+        0x02,       /* first ACK range: 10..8 */
+        0x01, 0x02, /* gap = 1, ACK range: 5..3 */
+        0x01, 0x00  /* gap = 1, ACK range: 0..0 */
+    };
+    xqc_connection_t *conn;
+    xqc_packet_in_t packet_in;
+    xqc_ack_info_t ack_info;
+    xqc_int_t ret;
+
+    conn = test_engine_connect();
+    CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+
+    memset(&packet_in, 0, sizeof(packet_in));
+    memset(&ack_info, 0, sizeof(ack_info));
+    packet_in.pos = frame;
+    packet_in.last = frame + sizeof(frame);
+
+    ret = xqc_parse_ack_frame(&packet_in, conn, &ack_info);
+
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    CU_ASSERT_EQUAL(ack_info.n_ranges, 3);
+    CU_ASSERT_EQUAL(ack_info.ranges[0].high, 10);
+    CU_ASSERT_EQUAL(ack_info.ranges[0].low, 8);
+    CU_ASSERT_EQUAL(ack_info.ranges[1].high, 5);
+    CU_ASSERT_EQUAL(ack_info.ranges[1].low, 3);
+    CU_ASSERT_EQUAL(ack_info.ranges[2].high, 0);
+    CU_ASSERT_EQUAL(ack_info.ranges[2].low, 0);
+    CU_ASSERT(packet_in.pos == packet_in.last);
+    CU_ASSERT((packet_in.pi_frame_types & XQC_FRAME_BIT_ACK) != 0);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
+static void
+xqc_test_ack_range_rejected(unsigned char *frame, size_t frame_len)
+{
+    xqc_connection_t *conn;
+    xqc_packet_in_t packet_in;
+    xqc_ack_info_t ack_info;
+    xqc_int_t ret;
+
+    conn = test_engine_connect();
+    CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+
+    memset(&packet_in, 0, sizeof(packet_in));
+    memset(&ack_info, 0, sizeof(ack_info));
+    packet_in.pos = frame;
+    packet_in.last = frame + frame_len;
+
+    ret = xqc_parse_ack_frame(&packet_in, conn, &ack_info);
+
+    CU_ASSERT_EQUAL(ret, -XQC_EILLEGAL_FRAME);
+    CU_ASSERT_EQUAL(conn->conn_err, TRA_FRAME_ENCODING_ERROR);
+    CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
+    CU_ASSERT_EQUAL(packet_in.pi_frame_types & XQC_FRAME_BIT_ACK, 0);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
+void
+xqc_test_ack_range_negative_rejected()
+{
+    unsigned char first_range[] = {
+        0x02, 0x00, 0x00, 0x00, 0x01
+    };
+    unsigned char gap[] = {
+        0x02, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00
+    };
+    unsigned char range[] = {
+        0x02, 0x03, 0x00, 0x01, 0x00, 0x00, 0x02
+    };
+    unsigned char after_storage_limit[135];
+    unsigned char *p;
+
+    xqc_test_ack_range_rejected(first_range, sizeof(first_range));
+    xqc_test_ack_range_rejected(gap, sizeof(gap));
+    xqc_test_ack_range_rejected(range, sizeof(range));
+
+    p = after_storage_limit;
+    *p++ = 0x02;       /* ACK */
+    *p++ = 0x40;
+    *p++ = 0x7f;       /* largest acknowledged = 127 */
+    *p++ = 0x00;       /* ACK delay */
+    *p++ = 0x40;
+    *p++ = 0x40;       /* ACK range count = 64 */
+    *p++ = 0x00;       /* first ACK range */
+    for (int i = 0; i < 64; ++i) {
+        *p++ = 0x00;   /* gap */
+        *p++ = 0x00;   /* ACK range length */
+    }
+
+    CU_ASSERT_EQUAL(p - after_storage_limit,
+                    sizeof(after_storage_limit));
+    xqc_test_ack_range_rejected(after_storage_limit,
+                                sizeof(after_storage_limit));
 }
 
 

--- a/tests/unittest/xqc_process_frame_test.h
+++ b/tests/unittest/xqc_process_frame_test.h
@@ -11,6 +11,10 @@ void xqc_test_parse_padding_frame();
 
 void xqc_test_large_ack_frame();
 
+void xqc_test_ack_range_zero_boundary(void);
+
+void xqc_test_ack_range_negative_rejected(void);
+
 void xqc_test_stream_frame_offset_overflow();
 
 void xqc_test_crypto_frame_in_0rtt_rejected();


### PR DESCRIPTION
### Mechanism

Reject ACK ranges before unsigned subtraction when First ACK Range, Gap, or
ACK Range Length would produce a negative packet number. Continue validating
encoded ranges after the local range-storage limit is reached, and generate
`FRAME_ENCODING_ERROR` for every invalid range as required by RFC 9000
Section 19.3.1.

- RFC or draft: RFC 9000 Section 19.3.1

Fixes: #662

### Validation Cases

- Not executed — no targeted client-to-server malformed ACK range injection is available.

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Incomplete — targeted malformed ACK client-to-server coverage unavailable
- CI: Pending
