### PR TITLE
[~] Fixes: #659 Reject invalid max_ack_delay transport parameter

### DIFF
--- a/harness/spec/validation.md
+++ b/harness/spec/validation.md
@@ -97,7 +97,7 @@ its case is retired so later changes cannot reuse it.
 
 | Range | New-case namespace | Allocated IDs |
 |-------|--------------------|---------------|
-| `[705, 799]` | QUIC Transport core | `705-712` |
+| `[705, 799]` | QUIC Transport core | `705-714` |
 | `[800, 899]` | Recovery and congestion control | None |
 | `[900, 999]` | QUIC-TLS | `902-903` |
 | `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1014` |

--- a/scripts/case_test.sh
+++ b/scripts/case_test.sh
@@ -917,6 +917,51 @@ else
     echo "$cid_limit_err"
 fi
 
+clear_log
+rm -rf tp_localhost test_session xqc_token
+echo -e "max_ack_delay accepts the largest valid value ...\c"
+killall test_server 2> /dev/null
+${SERVER_BIN} -l d -e -x 714 > svr_stdlog &
+sleep 1
+${CLIENT_BIN} -s 1024 -l d -t 1 -E > stdlog 2>&1
+advertised=`grep "advertised_max_ack_delay:16383" svr_stdlog`
+result=`grep ">>>>>>>> pass:1" stdlog`
+tp_err=`grep -E "(conn errno:8|conn_err:8[^0-9])" stdlog`
+errlog=`grep_err_log`
+if [ -z "$errlog" ] && [ -n "$advertised" ] && [ -z "$tp_err" ] \
+    && [ "$result" == ">>>>>>>> pass:1" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "max_ack_delay_valid_boundary" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "max_ack_delay_valid_boundary" "fail"
+    echo "$advertised"
+    echo "$errlog"
+fi
+
+clear_log
+rm -rf tp_localhost test_session xqc_token
+echo -e "max_ack_delay rejects the first invalid value ...\c"
+killall test_server 2> /dev/null
+${SERVER_BIN} -l d -e -x 713 > svr_stdlog &
+sleep 1
+${CLIENT_BIN} -s 1024 -l d -t 2 -E > stdlog 2>&1
+advertised=`grep "advertised_max_ack_delay:16384" svr_stdlog`
+tp_err=`grep -E "(conn errno:8|conn_err:8[^0-9])" stdlog`
+transport_type=`grep "conn_err_type:1" stdlog`
+req_ok=`grep ">>>>>>>> pass:1" stdlog`
+if [ -n "$advertised" ] && [ -n "$tp_err" ] && [ -n "$transport_type" ] \
+    && [ -z "$req_ok" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "max_ack_delay_invalid_boundary" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "max_ack_delay_invalid_boundary" "fail"
+    echo "$advertised"
+    echo "$tp_err"
+    echo "$transport_type"
+fi
+
 rm -rf tp_localhost test_session xqc_token
 killall test_server 2> /dev/null
 ${SERVER_BIN} -l d -e > /dev/null &

--- a/src/transport/xqc_transport_params.c
+++ b/src/transport/xqc_transport_params.c
@@ -21,6 +21,9 @@
 /* ack_delay_exponent above 20 is invalid */
 #define XQC_MAX_ACK_DELAY_EXPONENT          20
 
+/* RFC 9000 Section 18.2: values of 2^14 or greater are invalid */
+#define XQC_MAX_ACK_DELAY                   (1ULL << 14)
+
 /* draft-smith-quic-receive-ts-01: receive_timestamps_exponent above 20 is invalid */
 #define XQC_MAX_RECEIVE_TIMESTAMPS_EXPONENT     20
 #define XQC_MAX_RECEIVE_TIMESTAMPS_PER_ACK      63
@@ -625,7 +628,12 @@ static xqc_int_t
 xqc_decode_max_ack_delay(xqc_transport_params_t *params, xqc_transport_params_type_t exttype,
     const uint8_t *p, const uint8_t *end, uint64_t param_type, uint64_t param_len)
 {
-    XQC_DECODE_VINT_VALUE(&params->max_ack_delay, p, end);
+    ssize_t nread = xqc_vint_read(p, end, &params->max_ack_delay);
+    if (nread < 0 || params->max_ack_delay >= XQC_MAX_ACK_DELAY) {
+        return -XQC_TLS_MALFORMED_TRANSPORT_PARAM;
+    }
+
+    return XQC_OK;
 }
 
 static xqc_int_t

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -281,6 +281,7 @@ uint64_t g_last_sock_op_time;
  * 704 for active_connection_id_limit validation
  * 709/710 for active_connection_id_limit minimum validation
  * 711/712 for PMTUD peer-option omission validation
+ * 713/714 for max_ack_delay boundary validation
  * 902/903 for AEAD confidentiality-limit validation
  * 1000-1014 for HTTP/3 protocol validation
  */

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -970,6 +970,22 @@ xqc_server_h3_conn_create_notify(xqc_h3_conn_t *h3_conn, const xqc_cid_t *cid, v
         }
     }
 
+    /* RFC 9000 Section 18.2: max_ack_delay must be less than 2^14. */
+    if (g_test_case == 713 || g_test_case == 714) {
+        xqc_connection_t *conn = xqc_h3_conn_get_xqc_conn(h3_conn);
+        if (conn == NULL) {
+            printf("[max-ack-delay-boundary-test] conn unavailable\n");
+
+        } else {
+            conn->local_settings.max_ack_delay =
+                (g_test_case == 713) ? (1ULL << 14) : (1ULL << 14) - 1;
+            conn->conn_flag |= XQC_CONN_FLAG_LOCAL_TP_UPDATED;
+            printf("[max-ack-delay-boundary-test] "
+                   "advertised_max_ack_delay:%"PRIu64"\n",
+                   conn->local_settings.max_ack_delay);
+        }
+    }
+
     user_conn->dgram_blk = calloc(1, sizeof(user_dgram_blk_t));
     user_conn->dgram_blk->data_recv = 0;
     user_conn->dgram_blk->data_sent = 0;

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -133,6 +133,12 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite, "xqc_test_empty_pkt", xqc_test_empty_pkt)
         || !CU_add_test(pSuite, "xqc_test_stateless_reset_parse_boundary", xqc_test_stateless_reset_parse_boundary)
         || !CU_add_test(pSuite, "xqc_test_transport_params", xqc_test_transport_params)
+        || !CU_add_test(pSuite, "xqc_test_max_ack_delay_default_when_absent",
+                        xqc_test_max_ack_delay_default_when_absent)
+        || !CU_add_test(pSuite, "xqc_test_max_ack_delay_valid_boundary",
+                        xqc_test_max_ack_delay_valid_boundary)
+        || !CU_add_test(pSuite, "xqc_test_max_ack_delay_invalid_boundary",
+                        xqc_test_max_ack_delay_invalid_boundary)
         || !CU_add_test(pSuite, "xqc_test_tp_cid_overflow", xqc_test_tp_cid_overflow)
         || !CU_add_test(pSuite, "xqc_test_active_cid_limit_minimum", xqc_test_active_cid_limit_minimum)
         || !CU_add_test(pSuite, "xqc_test_check_transport_params_cids", xqc_test_check_transport_params_cids)

--- a/tests/unittest/xqc_tp_test.c
+++ b/tests/unittest/xqc_tp_test.c
@@ -135,6 +135,64 @@ xqc_test_transport_params()
     xqc_test_encrypted_extensions();
 }
 
+/* RFC 9000 Section 18.2: absent max_ack_delay defaults to 25 milliseconds. */
+void
+xqc_test_max_ack_delay_default_when_absent(void)
+{
+    uint8_t tp[] = {
+        XQC_TRANSPORT_PARAM_DISABLE_ACTIVE_MIGRATION, 0x00
+    };
+    xqc_transport_params_t params;
+    xqc_int_t              ret;
+
+    memset(&params, 0, sizeof(params));
+    ret = xqc_decode_transport_params(&params,
+                                      XQC_TP_TYPE_ENCRYPTED_EXTENSIONS,
+                                      tp, sizeof(tp));
+
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    CU_ASSERT_EQUAL(params.disable_active_migration, 1);
+    CU_ASSERT_EQUAL(params.max_ack_delay, XQC_DEFAULT_MAX_ACK_DELAY);
+}
+
+/* RFC 9000 Section 18.2: max_ack_delay values below 2^14 are valid. */
+void
+xqc_test_max_ack_delay_valid_boundary(void)
+{
+    uint8_t tp[] = {
+        XQC_TRANSPORT_PARAM_MAX_ACK_DELAY, 0x02, 0x7f, 0xff
+    };
+    xqc_transport_params_t params;
+    xqc_int_t              ret;
+
+    memset(&params, 0, sizeof(params));
+    ret = xqc_decode_transport_params(&params,
+                                      XQC_TP_TYPE_ENCRYPTED_EXTENSIONS,
+                                      tp, sizeof(tp));
+
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    CU_ASSERT_EQUAL(params.max_ack_delay, 16383);
+}
+
+/* RFC 9000 Section 18.2: max_ack_delay values of 2^14 or more are invalid. */
+void
+xqc_test_max_ack_delay_invalid_boundary(void)
+{
+    uint8_t tp[] = {
+        XQC_TRANSPORT_PARAM_MAX_ACK_DELAY, 0x04,
+        0x80, 0x00, 0x40, 0x00
+    };
+    xqc_transport_params_t params;
+    xqc_int_t              ret;
+
+    memset(&params, 0, sizeof(params));
+    ret = xqc_decode_transport_params(&params,
+                                      XQC_TP_TYPE_ENCRYPTED_EXTENSIONS,
+                                      tp, sizeof(tp));
+
+    CU_ASSERT_EQUAL(ret, -XQC_TLS_MALFORMED_TRANSPORT_PARAM);
+}
+
 /*
  * ============================================================================
  * Tests for xqc_conn_check_transport_params (RFC 9000 Section 7.3)

--- a/tests/unittest/xqc_tp_test.h
+++ b/tests/unittest/xqc_tp_test.h
@@ -6,6 +6,9 @@
 #define _XQC_TP_TEST_H_
 
 void xqc_test_transport_params();
+void xqc_test_max_ack_delay_default_when_absent(void);
+void xqc_test_max_ack_delay_valid_boundary(void);
+void xqc_test_max_ack_delay_invalid_boundary(void);
 void xqc_test_tp_cid_overflow();
 void xqc_test_active_cid_limit_minimum();
 void xqc_test_check_transport_params_cids();


### PR DESCRIPTION
### Mechanism

Reject peer `max_ack_delay` values of 2^14 or greater during
transport-parameter decoding, so the existing connection path emits
`TRANSPORT_PARAMETER_ERROR` as required by RFC 9000 Sections 18.2 and 7.4.

Fixes: #659

- RFC or draft: RFC 9000 Sections 18.2 and 7.4

### Validation Cases

- 714 — accepts the largest valid `max_ack_delay` value and completes the request
- 713 — rejects the first invalid `max_ack_delay` value with `TRANSPORT_PARAMETER_ERROR`

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Complete
- CI: Pending
