### PR TITLE
[~]: Fix GCC 13 BabaSSL build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -228,24 +228,25 @@ jobs:
           "$log_file")
         unit_failed=$(awk '/  Test: .*FAILED/ {count++} END {print count + 0}' \
           "$log_file")
-        case_total=$(awk \
-          '/\[ RUN      \] xquic_case_test\./ {count++} END {print count + 0}' \
+        case_total=$(awk '/pass:/ {count++} END {print count + 0}' \
           "$log_file")
         case_passed=$(awk \
-          '/\[       OK \] xquic_case_test\./ {count++} END {print count + 0}' \
+          '/pass:1([^0-9]|$)/ {count++} END {print count + 0}' \
           "$log_file")
         case_failed=$(awk \
-          '/\[     FAIL \] xquic_case_test\./ {count++} END {print count + 0}' \
+          '/pass:0([^0-9]|$)/ {count++} END {print count + 0}' \
           "$log_file")
+        case_reported=$((case_passed + case_failed))
 
         echo "unit test total:$unit_total passed:$unit_passed failed:$unit_failed"
-        echo "case test total:$case_total passed:$case_passed failed:$case_failed"
+        echo "case test total:$case_total reported:$case_reported" \
+          "passed:$case_passed failed:$case_failed"
 
         if [ "$unit_total" -gt 0 ] \
           && [ "$unit_passed" -eq "$unit_total" ] \
           && [ "$unit_failed" -eq 0 ] \
           && [ "$case_total" -gt 0 ] \
-          && [ "$case_passed" -eq "$case_total" ] \
+          && [ "$case_reported" -eq "$case_total" ] \
           && [ "$case_failed" -eq 0 ]; then
           echo "===== All unit and case tests passed! ====="
         else

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,6 +140,54 @@ jobs:
           echo "No CODACY_PROJECT_TOKEN provided for Codacy report"
         fi
 
+  build-ubuntu-24-babassl:
+
+    name: Build BabaSSL on Ubuntu 24.04 with GCC 13
+
+    needs: harness-check
+
+    runs-on: ubuntu-24.04
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
+        submodules: 'recursive'
+
+    - name: Linux Setup
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential gcc-13
+
+    - name: Build BabaSSL
+      run: |
+        git clone --branch 8.3-stable --depth 1 \
+          https://github.com/Tongsuo-Project/Tongsuo.git \
+          ./third_party/babassl
+        cd ./third_party/babassl
+        CC=gcc-13 ./config --prefix=/usr/local/babassl
+        make -j"$(nproc)" build_libs
+
+    - name: Build XQUIC
+      run: |
+        SSL_PATH_STR="${PWD}/third_party/babassl"
+        SSL_INC_PATH_STR="${SSL_PATH_STR}/include"
+        SSL_LIB_PATH_STR="${SSL_PATH_STR}/libssl.a;${SSL_PATH_STR}/libcrypto.a"
+        cmake -S . -B build/ubuntu-24-babassl \
+          -DCMAKE_C_COMPILER=gcc-13 \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DXQC_ENABLE_TESTING=0 \
+          -DXQC_SUPPORT_SENDMMSG_BUILD=1 \
+          -DXQC_ENABLE_EVENT_LOG=1 \
+          -DXQC_ENABLE_BBR2=1 \
+          -DXQC_ENABLE_RENO=1 \
+          -DSSL_TYPE=babassl \
+          -DSSL_PATH="${SSL_PATH_STR}" \
+          -DSSL_INC_PATH="${SSL_INC_PATH_STR}" \
+          -DSSL_LIB_PATH="${SSL_LIB_PATH_STR}"
+        cmake --build build/ubuntu-24-babassl --parallel
+
   build-macos:
 
     name: Build on macOS

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,7 +142,7 @@ jobs:
 
   build-ubuntu-24-babassl:
 
-    name: Build BabaSSL on Ubuntu 24.04 with GCC 13
+    name: Test BabaSSL on Ubuntu 24.04 with GCC 13
 
     needs: harness-check
 
@@ -158,7 +158,15 @@ jobs:
     - name: Linux Setup
       run: |
         sudo apt-get update
-        sudo apt-get install -y build-essential gcc-13
+        sudo apt-get install -y \
+          build-essential \
+          gcc-13 \
+          libcunit1 \
+          libcunit1-dev \
+          libcunit1-doc \
+          libevent-dev \
+          openssl \
+          psmisc
 
     - name: Build BabaSSL
       run: |
@@ -174,19 +182,76 @@ jobs:
         SSL_PATH_STR="${PWD}/third_party/babassl"
         SSL_INC_PATH_STR="${SSL_PATH_STR}/include"
         SSL_LIB_PATH_STR="${SSL_PATH_STR}/libssl.a;${SSL_PATH_STR}/libcrypto.a"
-        cmake -S . -B build/ubuntu-24-babassl \
+        cmake -S . -B build \
           -DCMAKE_C_COMPILER=gcc-13 \
           -DCMAKE_BUILD_TYPE=Release \
-          -DXQC_ENABLE_TESTING=0 \
+          -DXQC_ENABLE_TESTING=1 \
+          -DXQC_PRINT_SECRET=1 \
           -DXQC_SUPPORT_SENDMMSG_BUILD=1 \
           -DXQC_ENABLE_EVENT_LOG=1 \
           -DXQC_ENABLE_BBR2=1 \
           -DXQC_ENABLE_RENO=1 \
+          -DXQC_ENABLE_UNLIMITED=1 \
+          -DXQC_ENABLE_COPA=1 \
+          -DXQC_COMPAT_DUPLICATE=1 \
+          -DXQC_ENABLE_FEC=1 \
+          -DXQC_ENABLE_XOR=1 \
+          -DXQC_ENABLE_RSC=1 \
+          -DXQC_ENABLE_PKM=1 \
           -DSSL_TYPE=babassl \
           -DSSL_PATH="${SSL_PATH_STR}" \
           -DSSL_INC_PATH="${SSL_INC_PATH_STR}" \
           -DSSL_LIB_PATH="${SSL_LIB_PATH_STR}"
-        cmake --build build/ubuntu-24-babassl --parallel
+        cmake --build build --parallel
+
+    - name: Test
+      run: |
+        set -o pipefail
+        cd build
+        keyfile=server.key
+        certfile=server.crt
+        openssl req -newkey rsa:2048 -x509 -nodes \
+          -keyout "$keyfile" \
+          -new \
+          -out "$certfile" \
+          -subj /CN=test.xquic.com
+        ./tests/run_tests | tee -a ../xquic_test_ubuntu_24_babassl.log
+        ../scripts/case_test.sh \
+          | tee -a ../xquic_test_ubuntu_24_babassl.log
+
+    - name: Check Test Result
+      run: |
+        log_file=xquic_test_ubuntu_24_babassl.log
+        unit_total=$(awk '/  Test: / {count++} END {print count + 0}' \
+          "$log_file")
+        unit_passed=$(awk '/  Test: .*passed/ {count++} END {print count + 0}' \
+          "$log_file")
+        unit_failed=$(awk '/  Test: .*FAILED/ {count++} END {print count + 0}' \
+          "$log_file")
+        case_total=$(awk \
+          '/\[ RUN      \] xquic_case_test\./ {count++} END {print count + 0}' \
+          "$log_file")
+        case_passed=$(awk \
+          '/\[       OK \] xquic_case_test\./ {count++} END {print count + 0}' \
+          "$log_file")
+        case_failed=$(awk \
+          '/\[     FAIL \] xquic_case_test\./ {count++} END {print count + 0}' \
+          "$log_file")
+
+        echo "unit test total:$unit_total passed:$unit_passed failed:$unit_failed"
+        echo "case test total:$case_total passed:$case_passed failed:$case_failed"
+
+        if [ "$unit_total" -gt 0 ] \
+          && [ "$unit_passed" -eq "$unit_total" ] \
+          && [ "$unit_failed" -eq 0 ] \
+          && [ "$case_total" -gt 0 ] \
+          && [ "$case_passed" -eq "$case_total" ] \
+          && [ "$case_failed" -eq 0 ]; then
+          echo "===== All unit and case tests passed! ====="
+        else
+          echo "===== Unit or case test failed! ====="
+          exit 1
+        fi
 
   build-macos:
 

--- a/demo/demo_client.c
+++ b/demo/demo_client.c
@@ -1751,8 +1751,8 @@ xqc_demo_cli_init_conneciton_settings(xqc_conn_settings_t* settings,
         settings->enable_stream_rate_limit = 1;
         settings->recv_rate_bytes_per_sec = 0;
     }
-    strncpy(settings->conn_option_str, args->quic_cfg.co_str, XQC_CO_STR_MAX_LEN - 1);
-    settings->conn_option_str[XQC_CO_STR_MAX_LEN - 1] = '\0';
+    memcpy(settings->conn_option_str, args->quic_cfg.co_str,
+           XQC_CO_STR_MAX_LEN);
 }
 
 /* set client args to default values */

--- a/src/tls/xqc_tls.c
+++ b/src/tls/xqc_tls.c
@@ -377,7 +377,7 @@ fail:
 void
 xqc_tls_process_trans_param(xqc_tls_t *tls)
 {
-    const uint8_t *peer_tp;
+    const uint8_t *peer_tp = NULL;
     size_t tp_len = 0;
 
     if (tls->flag & XQC_TLS_FLAG_TRANSPORT_PARAM_RCVD) {

--- a/src/tls/xqc_tls.c
+++ b/src/tls/xqc_tls.c
@@ -35,6 +35,9 @@ typedef struct xqc_tls_s {
     /* SSL handler */
     SSL                        *ssl;
 
+    /* SSL-owned peer transport parameter buffer */
+    const uint8_t              *peer_tp;
+
     /* tls type. instance of client and server got different behaviour */
     xqc_tls_type_t              type;
 
@@ -377,7 +380,6 @@ fail:
 void
 xqc_tls_process_trans_param(xqc_tls_t *tls)
 {
-    const uint8_t *peer_tp = NULL;
     size_t tp_len = 0;
 
     if (tls->flag & XQC_TLS_FLAG_TRANSPORT_PARAM_RCVD) {
@@ -386,14 +388,15 @@ xqc_tls_process_trans_param(xqc_tls_t *tls)
     }
 
     /* get buffer */
-    SSL_get_peer_quic_transport_params(tls->ssl, &peer_tp, &tp_len);
+    tls->peer_tp = NULL;
+    SSL_get_peer_quic_transport_params(tls->ssl, &tls->peer_tp, &tp_len);
     if (tp_len <= 0) {
         return;
     }
 
     /* callback to Transport layer */
     if (tls->cbs->tp_cb) {
-        tls->cbs->tp_cb(peer_tp, tp_len, tls->user_data);
+        tls->cbs->tp_cb(tls->peer_tp, tp_len, tls->user_data);
     }
 
     tls->flag |= XQC_TLS_FLAG_TRANSPORT_PARAM_RCVD;

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -5045,8 +5045,8 @@ int main(int argc, char *argv[]) {
         .close_dgram_redundancy = XQC_RED_NOT_USE
     };
 
-    strncpy(conn_settings.conn_option_str, conn_options, XQC_CO_STR_MAX_LEN - 1);
-    conn_settings.conn_option_str[XQC_CO_STR_MAX_LEN - 1] = '\0';
+    memcpy(conn_settings.conn_option_str, conn_options,
+           XQC_CO_STR_MAX_LEN);
 
 #ifdef XQC_PROTECT_POOL_MEM
     if (g_test_case == 600) {


### PR DESCRIPTION
### Mechanism

Store the SSL-owned peer transport-parameter pointer in the private TLS object
instead of an automatic output slot, preserving the existing length guard and
callback behavior while satisfying GCC 13's conservative lifetime analysis.
Copy already-normalized connection-option arrays as fixed-size buffers so the
complete Release targets retain their contents without GCC's truncating-string
diagnostic.
Add an explicit Ubuntu 24.04, GCC 13, and TongSuo 8.3-stable Release build to
retain compatibility coverage for this supported backend. That job builds the
full test targets, runs the complete CUnit and client-to-server case suites,
and reuses the existing `pass:1` and `pass:0` case markers to fail closed on
missing, unrecognized, or failed results.

Fixes: #822

- RFC or draft: Not applicable — this is build portability with no wire behavior change.

### Validation Cases

- Not applicable — no endpoint behavior changes; CI runs the complete existing client-to-server suite with BabaSSL.

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Complete
- CI: Pending — GitHub Actions
