### PR TITLE
[~]: Track padding packets in flight

### DIFF
--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -2116,6 +2116,30 @@ xqc_conn_log_sent_packet(xqc_connection_t *c, xqc_packet_out_t *po,
     c->snd_pkt_stats.curr_index = (index + 1) % 3;
 }
 
+static void
+xqc_conn_complete_sent_packet(xqc_connection_t *conn, xqc_path_ctx_t *path,
+    xqc_packet_out_t *packet_out)
+{
+    xqc_send_queue_t *send_queue = conn->conn_send_queue;
+
+    xqc_path_send_buffer_remove(path, packet_out);
+
+    /*
+     * RFC 9002 Sections 2 and 3: PADDING-only packets are in flight even
+     * though they are not ack-eliciting. Retain every in-flight packet until
+     * ACK or loss processing removes its congestion-control contribution.
+     */
+    if (XQC_CAN_IN_FLIGHT(packet_out->po_frame_types)) {
+        xqc_send_queue_insert_unacked(packet_out,
+            &send_queue->sndq_unacked_packets[packet_out->po_pkt.pkt_pns],
+            send_queue);
+
+    } else {
+        xqc_send_queue_insert_free(packet_out,
+                                   &send_queue->sndq_free_packets, send_queue);
+    }
+}
+
 void
 xqc_on_packets_send_burst(xqc_connection_t *conn, xqc_path_ctx_t *path, ssize_t sent, xqc_usec_t now, xqc_send_type_t send_type)
 {
@@ -2145,15 +2169,7 @@ xqc_on_packets_send_burst(xqc_connection_t *conn, xqc_path_ctx_t *path, ssize_t 
             }
 
             xqc_send_ctl_on_packet_sent(send_ctl, pn_ctl, packet_out, now);
-            xqc_path_send_buffer_remove(path, packet_out);
-            if (XQC_IS_ACK_ELICITING(packet_out->po_frame_types)) {
-                xqc_send_queue_insert_unacked(packet_out,
-                                              &send_queue->sndq_unacked_packets[packet_out->po_pkt.pkt_pns],
-                                              send_queue);
-
-            } else {
-                xqc_send_queue_insert_free(packet_out, &send_queue->sndq_free_packets, send_queue);
-            }
+            xqc_conn_complete_sent_packet(conn, path, packet_out);
             xqc_log(conn->log, XQC_LOG_INFO,
                     "|<==|conn:%p|path:%ui|pkt_num:%ui|size:%ud|sent:%z|pkt_type:%s|frame:%s|inflight:%ud|now:%ui|",
                     conn, path->path_id, packet_out->po_pkt.pkt_num, packet_out->po_used_size, sent,
@@ -2367,8 +2383,6 @@ xqc_path_send_packets(xqc_connection_t *conn, xqc_path_ctx_t *path,
     xqc_packet_out_t *packet_out;
 
     xqc_send_ctl_t *send_ctl = path->path_send_ctl;
-    xqc_send_queue_t *send_queue = conn->conn_send_queue;
-
     xqc_usec_t now = xqc_monotonic_timestamp();
 
     xqc_list_for_each_safe(pos, next, &path->path_schedule_buf[send_type]) {
@@ -2411,16 +2425,7 @@ xqc_path_send_packets(xqc_connection_t *conn, xqc_path_ctx_t *path,
         }
 
 
-        /* move send list to unacked list */
-        xqc_path_send_buffer_remove(path, packet_out);
-        if (XQC_IS_ACK_ELICITING(packet_out->po_frame_types)) {
-            xqc_send_queue_insert_unacked(packet_out,
-                                          &send_queue->sndq_unacked_packets[packet_out->po_pkt.pkt_pns],
-                                          send_queue);
-
-        } else {
-            xqc_send_queue_insert_free(packet_out, &send_queue->sndq_free_packets, send_queue);
-        }
+        xqc_conn_complete_sent_packet(conn, path, packet_out);
     }
 
     /* @FIXME: in the case of EAGAIN, we should not reschedule packets. */

--- a/src/transport/xqc_conn.h
+++ b/src/transport/xqc_conn.h
@@ -745,6 +745,9 @@ void xqc_conn_encode_mp_settings(xqc_connection_t *conn, char *buf, size_t buf_s
 void xqc_path_send_packets(xqc_connection_t *conn, xqc_path_ctx_t *path,
     xqc_list_head_t *head, int congest, xqc_send_type_t send_type);
 
+void xqc_on_packets_send_burst(xqc_connection_t *conn, xqc_path_ctx_t *path,
+    ssize_t sent, xqc_usec_t now, xqc_send_type_t send_type);
+
 xqc_int_t xqc_conn_try_to_enable_multipath(xqc_connection_t *conn);
 xqc_int_t xqc_conn_add_path_cid_sets(xqc_connection_t *conn, uint32_t start, uint32_t end);
 xqc_msec_t xqc_conn_get_queue_fin_timeout(xqc_connection_t *conn);

--- a/src/transport/xqc_frame.h
+++ b/src/transport/xqc_frame.h
@@ -141,7 +141,7 @@ typedef uint64_t xqc_frame_type_bit_t;
 #define XQC_IS_ACK_ELICITING(types) ((types) & ~(XQC_FRAME_BIT_ACK | XQC_FRAME_BIT_ACK_MP| XQC_FRAME_BIT_PADDING | XQC_FRAME_BIT_CONNECTION_CLOSE))
 
 /*
- * https://tools.ietf.org/html/draft-ietf-quic-recovery-24#section-3
+ * RFC 9002 Section 3
  * Packets containing frames besides ACK or CONNECTION_CLOSE frames
       count toward congestion control limits and are considered in-
       flight.

--- a/src/transport/xqc_multipath.c
+++ b/src/transport/xqc_multipath.c
@@ -848,7 +848,7 @@ xqc_path_send_buffer_append(xqc_path_ctx_t *path, xqc_packet_out_t *packet_out, 
         packet_out->po_flag |= XQC_POF_IN_PATH_BUF_LIST;
 
         packet_out->po_cc_size = packet_out->po_used_size;
-        if (XQC_IS_ACK_ELICITING(packet_out->po_frame_types)) {
+        if (XQC_CAN_IN_FLIGHT(packet_out->po_frame_types)) {
             path->path_schedule_bytes += packet_out->po_cc_size;
         }
     }
@@ -862,7 +862,7 @@ xqc_path_send_buffer_remove(xqc_path_ctx_t *path, xqc_packet_out_t *packet_out)
     if (packet_out->po_flag & XQC_POF_IN_PATH_BUF_LIST) {
         packet_out->po_flag &= ~XQC_POF_IN_PATH_BUF_LIST;
 
-        if (XQC_IS_ACK_ELICITING(packet_out->po_frame_types)) {
+        if (XQC_CAN_IN_FLIGHT(packet_out->po_frame_types)) {
             path->path_schedule_bytes -= packet_out->po_cc_size;
         }
     }

--- a/src/transport/xqc_send_ctl.c
+++ b/src/transport/xqc_send_ctl.c
@@ -552,12 +552,15 @@ xqc_send_ctl_increase_inflight(xqc_connection_t *conn, xqc_packet_out_t *packet_
     }
 
     xqc_send_ctl_t *send_ctl = path->path_send_ctl;
-    if (!(packet_out->po_flag & XQC_POF_IN_FLIGHT) && XQC_CAN_IN_FLIGHT(packet_out->po_frame_types)) {
+    if (!(packet_out->po_flag & XQC_POF_IN_FLIGHT)
+        && XQC_CAN_IN_FLIGHT(packet_out->po_frame_types))
+    {
+        send_ctl->ctl_bytes_in_flight += packet_out->po_used_size;
         if (XQC_IS_ACK_ELICITING(packet_out->po_frame_types)) {
-            send_ctl->ctl_bytes_in_flight += packet_out->po_used_size;
-            send_ctl->ctl_bytes_ack_eliciting_inflight[packet_out->po_pkt.pkt_pns] += packet_out->po_used_size;
-            packet_out->po_flag |= XQC_POF_IN_FLIGHT;
+            send_ctl->ctl_bytes_ack_eliciting_inflight[
+                packet_out->po_pkt.pkt_pns] += packet_out->po_used_size;
         }
+        packet_out->po_flag |= XQC_POF_IN_FLIGHT;
     }
 }
 
@@ -573,10 +576,15 @@ xqc_send_ctl_decrease_inflight(xqc_connection_t *conn, xqc_packet_out_t *packet_
     xqc_send_ctl_t *send_ctl = path->path_send_ctl;
     if (packet_out->po_flag & XQC_POF_IN_FLIGHT) {
         if (XQC_IS_ACK_ELICITING(packet_out->po_frame_types)) {
-            send_ctl->ctl_bytes_ack_eliciting_inflight[packet_out->po_pkt.pkt_pns] = xqc_uint32_bounded_subtract(send_ctl->ctl_bytes_ack_eliciting_inflight[packet_out->po_pkt.pkt_pns], packet_out->po_used_size);
-            send_ctl->ctl_bytes_in_flight = xqc_uint32_bounded_subtract(send_ctl->ctl_bytes_in_flight, packet_out->po_used_size);
-            packet_out->po_flag &= ~XQC_POF_IN_FLIGHT;
+            send_ctl->ctl_bytes_ack_eliciting_inflight[
+                packet_out->po_pkt.pkt_pns] = xqc_uint32_bounded_subtract(
+                    send_ctl->ctl_bytes_ack_eliciting_inflight[
+                        packet_out->po_pkt.pkt_pns],
+                    packet_out->po_used_size);
         }
+        send_ctl->ctl_bytes_in_flight = xqc_uint32_bounded_subtract(
+            send_ctl->ctl_bytes_in_flight, packet_out->po_used_size);
+        packet_out->po_flag &= ~XQC_POF_IN_FLIGHT;
     }
 }
 

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -277,6 +277,14 @@ main(int argc, char *argv[])
                         xqc_test_pto_remote_default_when_unset)
         || !CU_add_test(pSuite, "xqc_test_send_ctl_update_rtt_ack_delay_cap",
                         xqc_test_send_ctl_update_rtt_ack_delay_cap)
+        /* RFC 9002 Sections 2 and 3: PADDING-only in-flight lifecycle */
+        || !CU_add_test(pSuite, "xqc_test_send_ctl_padding_ack_lifecycle",
+                        xqc_test_send_ctl_padding_ack_lifecycle)
+        || !CU_add_test(pSuite, "xqc_test_send_ctl_padding_loss_lifecycle",
+                        xqc_test_send_ctl_padding_loss_lifecycle)
+        || !CU_add_test(pSuite,
+                        "xqc_test_send_ctl_non_inflight_packets_not_tracked",
+                        xqc_test_send_ctl_non_inflight_packets_not_tracked)
         /* issue #739: persistent-congestion RTT reset (RFC 9002 §5.2) */
         || !CU_add_test(pSuite, "xqc_test_send_ctl_persistent_congestion_resets_rtt",
                         xqc_test_send_ctl_persistent_congestion_resets_rtt)

--- a/tests/unittest/xqc_send_ctl_test.c
+++ b/tests/unittest/xqc_send_ctl_test.c
@@ -324,6 +324,206 @@ xqc_test_send_ctl_update_rtt_ack_delay_cap(void)
 }
 
 
+static xqc_packet_out_t *
+xqc_test_send_ctl_schedule_packet(xqc_connection_t *conn,
+    xqc_frame_type_bit_t frame_types, xqc_packet_number_t packet_number,
+    xqc_usec_t sent_time)
+{
+    xqc_packet_out_t *packet_out = xqc_packet_out_get_and_insert_send(
+        conn->conn_send_queue, XQC_PTYPE_SHORT_HEADER);
+    if (packet_out == NULL) {
+        return NULL;
+    }
+
+    packet_out->po_pkt.pkt_pns = XQC_PNS_APP_DATA;
+    packet_out->po_pkt.pkt_num = packet_number;
+    packet_out->po_frame_types = frame_types;
+    packet_out->po_used_size = 1200;
+    packet_out->po_enc_size = 1200;
+    packet_out->po_sent_time = sent_time;
+
+    xqc_path_send_buffer_append(conn->conn_initial_path, packet_out,
+        &conn->conn_initial_path->path_schedule_buf[XQC_SEND_TYPE_NORMAL]);
+    return packet_out;
+}
+
+
+/*
+ * RFC 9002 Sections 2 and 3 require a PADDING-only packet to consume
+ * congestion budget without becoming ack-eliciting. An ACK for a later
+ * ack-eliciting packet can acknowledge it, so the sender must retain enough
+ * state to remove the bytes at that point.
+ */
+void
+xqc_test_send_ctl_padding_ack_lifecycle(void)
+{
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_FATAL(conn != NULL);
+    CU_ASSERT_FATAL(conn->conn_initial_path != NULL);
+
+    xqc_path_ctx_t *path = conn->conn_initial_path;
+    xqc_send_ctl_t *send_ctl = path->path_send_ctl;
+    xqc_send_queue_t *send_queue = conn->conn_send_queue;
+    xqc_pn_ctl_t *pn_ctl = xqc_get_pn_ctl(conn, path);
+    CU_ASSERT_FATAL(send_ctl != NULL);
+    CU_ASSERT_FATAL(send_queue != NULL);
+    CU_ASSERT_FATAL(pn_ctl != NULL);
+    CU_ASSERT_FATAL(xqc_list_empty(
+        &path->path_schedule_buf[XQC_SEND_TYPE_NORMAL]));
+
+    uint32_t scheduled_before = path->path_schedule_bytes;
+    uint32_t inflight_before = send_ctl->ctl_bytes_in_flight;
+    uint32_t ack_inflight_before =
+        send_ctl->ctl_bytes_ack_eliciting_inflight[XQC_PNS_APP_DATA];
+    uint64_t unacked_before = send_queue->sndq_packets_in_unacked_list;
+
+    xqc_packet_out_t *packet_out = xqc_test_send_ctl_schedule_packet(
+        conn, XQC_FRAME_BIT_PADDING, 100, 1000);
+    CU_ASSERT_FATAL(packet_out != NULL);
+    CU_ASSERT_EQUAL(path->path_schedule_bytes, scheduled_before + 1200);
+
+    xqc_on_packets_send_burst(conn, path, 1, 1000,
+                              XQC_SEND_TYPE_NORMAL);
+
+    CU_ASSERT_EQUAL(path->path_schedule_bytes, scheduled_before);
+    CU_ASSERT_EQUAL(send_ctl->ctl_bytes_in_flight, inflight_before + 1200);
+    CU_ASSERT_EQUAL(
+        send_ctl->ctl_bytes_ack_eliciting_inflight[XQC_PNS_APP_DATA],
+        ack_inflight_before);
+    CU_ASSERT(packet_out->po_flag & XQC_POF_IN_FLIGHT);
+    CU_ASSERT(packet_out->po_flag & XQC_POF_IN_UNACK_LIST);
+    CU_ASSERT_EQUAL(send_queue->sndq_packets_in_unacked_list,
+                    unacked_before + 1);
+
+    xqc_ack_info_t ack_info;
+    memset(&ack_info, 0, sizeof(ack_info));
+    ack_info.pns = XQC_PNS_APP_DATA;
+    ack_info.path_id = path->path_id;
+    ack_info.n_ranges = 1;
+    ack_info.ranges[0].low = packet_out->po_pkt.pkt_num;
+    ack_info.ranges[0].high = packet_out->po_pkt.pkt_num;
+    ack_info.largest_acked = packet_out->po_pkt.pkt_num;
+    conn->conn_settings.disable_pn_skipping = 1;
+
+    CU_ASSERT_EQUAL(xqc_send_ctl_on_ack_received(send_ctl, pn_ctl, send_queue,
+                    &ack_info, 2000, XQC_TRUE), XQC_OK);
+    CU_ASSERT_EQUAL(send_ctl->ctl_bytes_in_flight, inflight_before);
+    CU_ASSERT_EQUAL(
+        send_ctl->ctl_bytes_ack_eliciting_inflight[XQC_PNS_APP_DATA],
+        ack_inflight_before);
+    CU_ASSERT((packet_out->po_flag & XQC_POF_IN_FLIGHT) == 0);
+    CU_ASSERT((packet_out->po_flag & XQC_POF_IN_UNACK_LIST) == 0);
+    CU_ASSERT_EQUAL(send_queue->sndq_packets_in_unacked_list,
+                    unacked_before);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
+/*
+ * A lost PADDING-only packet remains an in-flight congestion signal even
+ * though the frame itself does not need retransmission. Loss processing must
+ * subtract its bytes and recycle the retained packet.
+ */
+void
+xqc_test_send_ctl_padding_loss_lifecycle(void)
+{
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_FATAL(conn != NULL);
+    CU_ASSERT_FATAL(conn->conn_initial_path != NULL);
+
+    xqc_path_ctx_t *path = conn->conn_initial_path;
+    xqc_send_ctl_t *send_ctl = path->path_send_ctl;
+    xqc_send_queue_t *send_queue = conn->conn_send_queue;
+    CU_ASSERT_FATAL(send_ctl != NULL);
+    CU_ASSERT_FATAL(send_queue != NULL);
+
+    uint32_t inflight_before = send_ctl->ctl_bytes_in_flight;
+    uint32_t ack_inflight_before =
+        send_ctl->ctl_bytes_ack_eliciting_inflight[XQC_PNS_APP_DATA];
+    uint64_t unacked_before = send_queue->sndq_packets_in_unacked_list;
+    uint64_t losses_before = conn->detected_loss_cnt;
+
+    xqc_packet_out_t *packet_out = xqc_test_send_ctl_schedule_packet(
+        conn, XQC_FRAME_BIT_PADDING, 100, 1);
+    CU_ASSERT_FATAL(packet_out != NULL);
+    xqc_on_packets_send_burst(conn, path, 1, 1, XQC_SEND_TYPE_NORMAL);
+    CU_ASSERT_EQUAL(send_ctl->ctl_bytes_in_flight, inflight_before + 1200);
+    CU_ASSERT(packet_out->po_flag & XQC_POF_IN_UNACK_LIST);
+
+    send_ctl->ctl_largest_acked[XQC_PNS_APP_DATA] =
+        packet_out->po_pkt.pkt_num;
+    send_ctl->ctl_latest_rtt = 1000;
+    send_ctl->ctl_srtt = 1000;
+    xqc_send_ctl_detect_lost(send_ctl, send_queue, XQC_PNS_APP_DATA,
+                             1000000);
+
+    CU_ASSERT_EQUAL(send_ctl->ctl_bytes_in_flight, inflight_before);
+    CU_ASSERT_EQUAL(
+        send_ctl->ctl_bytes_ack_eliciting_inflight[XQC_PNS_APP_DATA],
+        ack_inflight_before);
+    CU_ASSERT((packet_out->po_flag & XQC_POF_IN_FLIGHT) == 0);
+    CU_ASSERT((packet_out->po_flag & XQC_POF_IN_UNACK_LIST) == 0);
+    CU_ASSERT_EQUAL(send_queue->sndq_packets_in_unacked_list,
+                    unacked_before);
+    CU_ASSERT_EQUAL(conn->detected_loss_cnt, losses_before + 1);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
+/*
+ * RFC 9002 excludes ACK and CONNECTION_CLOSE-only packets from in-flight
+ * accounting. ACK_MP has the same role as ACK in XQUIC's multipath extension.
+ */
+void
+xqc_test_send_ctl_non_inflight_packets_not_tracked(void)
+{
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_FATAL(conn != NULL);
+    CU_ASSERT_FATAL(conn->conn_initial_path != NULL);
+
+    xqc_path_ctx_t *path = conn->conn_initial_path;
+    xqc_send_ctl_t *send_ctl = path->path_send_ctl;
+    xqc_send_queue_t *send_queue = conn->conn_send_queue;
+    CU_ASSERT_FATAL(send_ctl != NULL);
+    CU_ASSERT_FATAL(send_queue != NULL);
+
+    xqc_frame_type_bit_t frame_types[] = {
+        XQC_FRAME_BIT_ACK,
+        XQC_FRAME_BIT_ACK_MP,
+        XQC_FRAME_BIT_CONNECTION_CLOSE,
+    };
+    uint32_t scheduled_before = path->path_schedule_bytes;
+    uint32_t inflight_before = send_ctl->ctl_bytes_in_flight;
+    uint32_t ack_inflight_before =
+        send_ctl->ctl_bytes_ack_eliciting_inflight[XQC_PNS_APP_DATA];
+    uint64_t unacked_before = send_queue->sndq_packets_in_unacked_list;
+
+    for (size_t i = 0; i < sizeof(frame_types) / sizeof(frame_types[0]); i++) {
+        xqc_packet_out_t *packet_out = xqc_test_send_ctl_schedule_packet(
+            conn, frame_types[i], 200 + i, 1000 + i);
+        CU_ASSERT_FATAL(packet_out != NULL);
+        CU_ASSERT_EQUAL(path->path_schedule_bytes, scheduled_before);
+
+        xqc_on_packets_send_burst(conn, path, 1, 1000 + i,
+                                  XQC_SEND_TYPE_NORMAL);
+
+        CU_ASSERT_EQUAL(path->path_schedule_bytes, scheduled_before);
+        CU_ASSERT_EQUAL(send_ctl->ctl_bytes_in_flight, inflight_before);
+        CU_ASSERT_EQUAL(
+            send_ctl->ctl_bytes_ack_eliciting_inflight[XQC_PNS_APP_DATA],
+            ack_inflight_before);
+        CU_ASSERT((packet_out->po_flag & XQC_POF_IN_FLIGHT) == 0);
+        CU_ASSERT((packet_out->po_flag & XQC_POF_IN_UNACK_LIST) == 0);
+        CU_ASSERT_EQUAL(send_queue->sndq_packets_in_unacked_list,
+                        unacked_before);
+    }
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
 /*
  * Issue #739 regression tests.
  *

--- a/tests/unittest/xqc_send_ctl_test.h
+++ b/tests/unittest/xqc_send_ctl_test.h
@@ -22,6 +22,14 @@ void xqc_test_pto_remote_default_when_unset(void);
 void xqc_test_send_ctl_update_rtt_ack_delay_cap(void);
 
 /*
+ * RFC 9002 Sections 2 and 3: PADDING-only packets consume congestion budget
+ * and remain tracked until they are acknowledged or declared lost.
+ */
+void xqc_test_send_ctl_padding_ack_lifecycle(void);
+void xqc_test_send_ctl_padding_loss_lifecycle(void);
+void xqc_test_send_ctl_non_inflight_packets_not_tracked(void);
+
+/*
  * Regression tests for issue #739 (RFC 9002 5.2):
  * After persistent congestion is detected the RTT estimator on the
  * affected path must be reset, and the next RTT sample must re-seed


### PR DESCRIPTION
### Mechanism

Count every in-flight packet toward the scheduled and sent congestion budget,
and retain it in the unacked queue until ACK or loss processing removes its
contribution. Ack-eliciting-only counters remain limited to ack-eliciting
packets.

- RFC or draft: [RFC 9002 Sections 2 and 3](https://www.rfc-editor.org/rfc/rfc9002.html#section-3)

Fixes: #722

### Validation Cases

- Not applicable — no targeted client-to-server case selector exists for this transport-internal lifecycle; paired unit regressions cover ACK and loss cleanup.

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Complete
- CI: Pending