### PR TITLE
[~] Fix #581: Ignore coalesced packets with mismatched DCID

### DIFF
--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -5095,9 +5095,11 @@ xqc_conn_process_packet(xqc_connection_t *c,
     const unsigned char *end = packet_in_buf + packet_in_size;  /* end of udp datagram */
     xqc_packet_in_t packet;
     unsigned char decrypt_payload[XQC_MAX_PACKET_IN_LEN];
+    xqc_cid_t first_dcid;
 
     /* process all QUIC packets in UDP datagram */
     while (pos < end) {
+        xqc_bool_t dcid_mismatch = XQC_FALSE;
         last_pos = pos;
 
         /* init packet in */
@@ -5107,13 +5109,29 @@ xqc_conn_process_packet(xqc_connection_t *c,
 
         packet_in->pi_path_id = XQC_UNKNOWN_PATH_ID;
 
+        if (pos != packet_in_buf) {
+            ret = xqc_packet_check_coalesced_dcid(c, packet_in,
+                                                  &first_dcid,
+                                                  &dcid_mismatch);
+        }
+
         /* packet_in->pos will update inside */
-        ret = xqc_packet_process_single(c, packet_in);
+        if (ret == XQC_OK) {
+            ret = xqc_packet_process_single(c, packet_in);
+            if (ret == XQC_OK && pos == packet_in_buf) {
+                xqc_cid_copy(&first_dcid, &packet_in->pi_pkt.pkt_dcid);
+            }
+        }
 
         xqc_conn_log_recvd_packet(c, packet_in, packet_in_size, ret, recv_time);
 
         if (ret == XQC_OK) {
             ret = xqc_conn_on_pkt_processed(c, packet_in, recv_time);
+
+        } else if (dcid_mismatch) {
+            pos = packet_in->last;
+            ret = XQC_OK;
+            continue;
 
         } else if (xqc_conn_tolerant_error(ret)) {
             /* ignore the remain bytes */

--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -5096,10 +5096,11 @@ xqc_conn_process_packet(xqc_connection_t *c,
     xqc_packet_in_t packet;
     unsigned char decrypt_payload[XQC_MAX_PACKET_IN_LEN];
     xqc_cid_t first_dcid;
+    xqc_bool_t dcid_mismatch;
 
     /* process all QUIC packets in UDP datagram */
     while (pos < end) {
-        xqc_bool_t dcid_mismatch = XQC_FALSE;
+        dcid_mismatch = XQC_FALSE;
         last_pos = pos;
 
         /* init packet in */

--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -5110,18 +5110,12 @@ xqc_conn_process_packet(xqc_connection_t *c,
 
         packet_in->pi_path_id = XQC_UNKNOWN_PATH_ID;
 
-        if (pos != packet_in_buf) {
-            ret = xqc_packet_check_coalesced_dcid(c, packet_in,
-                                                  &first_dcid,
-                                                  &dcid_mismatch);
-        }
-
         /* packet_in->pos will update inside */
-        if (ret == XQC_OK) {
-            ret = xqc_packet_process_single(c, packet_in);
-            if (ret == XQC_OK && pos == packet_in_buf) {
-                xqc_cid_copy(&first_dcid, &packet_in->pi_pkt.pkt_dcid);
-            }
+        ret = xqc_packet_process_single(
+            c, packet_in, pos == packet_in_buf ? NULL : &first_dcid,
+            &dcid_mismatch);
+        if (ret == XQC_OK && pos == packet_in_buf) {
+            xqc_cid_copy(&first_dcid, &packet_in->pi_pkt.pkt_dcid);
         }
 
         xqc_conn_log_recvd_packet(c, packet_in, packet_in_size, ret, recv_time);
@@ -5130,6 +5124,9 @@ xqc_conn_process_packet(xqc_connection_t *c,
             ret = xqc_conn_on_pkt_processed(c, packet_in, recv_time);
 
         } else if (dcid_mismatch) {
+            xqc_log(c->log, XQC_LOG_INFO,
+                    "|ignore coalesced packet with different DCID|skip:%uz|",
+                    (size_t)(packet_in->last - packet_in->buf));
             pos = packet_in->last;
             ret = XQC_OK;
             continue;

--- a/src/transport/xqc_packet.c
+++ b/src/transport/xqc_packet.c
@@ -12,10 +12,15 @@
 #include "src/transport/xqc_send_ctl.h"
 #include "src/transport/xqc_recv_record.h"
 #include "src/transport/xqc_packet_parser.h"
+#include "src/transport/xqc_cid.h"
 #include "src/transport/xqc_utils.h"
 #include "src/transport/xqc_engine.h"
 #include "src/tls/xqc_tls.h"
 #include "src/tls/xqc_crypto.h"
+
+
+static xqc_int_t xqc_packet_parse_size(const unsigned char *buf, size_t size,
+    uint8_t cid_len, size_t *packet_size);
 
 
 
@@ -293,4 +298,163 @@ xqc_packet_process_single(xqc_connection_t *c,
 }
 
 
+static xqc_int_t
+xqc_packet_parse_size(const unsigned char *buf, size_t size,
+    uint8_t cid_len, size_t *packet_size)
+{
+    const unsigned char *pos;
+    const unsigned char *end;
+    uint32_t version;
+    uint64_t length;
+    uint64_t token_len;
+    ssize_t len;
+    uint8_t parsed_cid_len;
+    uint8_t type;
 
+    if (buf == NULL || packet_size == NULL || size == 0) {
+        return -XQC_EPARAM;
+    }
+
+    end = buf + size;
+
+    if (XQC_PACKET_IS_SHORT_HEADER(buf)) {
+        if (size < 1 + cid_len) {
+            return -XQC_EILLPKT;
+        }
+
+        /* A short-header packet can only be the last packet. */
+        *packet_size = size;
+        return XQC_OK;
+    }
+
+    if (!XQC_PACKET_IS_LONG_HEADER(buf)
+        || size < XQC_PACKET_LONG_HEADER_PREFIX_LENGTH + 2)
+    {
+        return -XQC_EILLPKT;
+    }
+
+    type = XQC_PACKET_LONG_HEADER_GET_TYPE(buf);
+    version = xqc_parse_uint32(buf + 1);
+    pos = buf + XQC_PACKET_LONG_HEADER_PREFIX_LENGTH;
+
+    parsed_cid_len = *pos++;
+    if (parsed_cid_len > XQC_MAX_CID_LEN
+        || XQC_BUFF_LEFT_SIZE(pos, end) < parsed_cid_len + 1)
+    {
+        return -XQC_EILLPKT;
+    }
+    pos += parsed_cid_len;
+
+    parsed_cid_len = *pos++;
+    if (parsed_cid_len > XQC_MAX_CID_LEN
+        || XQC_BUFF_LEFT_SIZE(pos, end) < parsed_cid_len)
+    {
+        return -XQC_EILLPKT;
+    }
+    pos += parsed_cid_len;
+
+    /* These packets cannot be followed by another coalesced packet. */
+    if (version == 0 || type == XQC_PTYPE_RETRY) {
+        *packet_size = size;
+        return XQC_OK;
+    }
+
+    /* The packet type and Length encoding are version-specific. */
+    if (version != XQC_VERSION_V1_VALUE
+        && version != XQC_IDRAFT_VER_29_VALUE)
+    {
+        *packet_size = size;
+        return XQC_OK;
+    }
+
+    if (type == XQC_PTYPE_INIT) {
+        len = xqc_vint_read(pos, end, &token_len);
+        if (len < 0 || XQC_BUFF_LEFT_SIZE(pos, end) < len) {
+            return -XQC_EILLPKT;
+        }
+        pos += len;
+
+        if (token_len > (uint64_t)XQC_BUFF_LEFT_SIZE(pos, end)) {
+            return -XQC_EILLPKT;
+        }
+        pos += token_len;
+    }
+
+    len = xqc_vint_read(pos, end, &length);
+    if (len < 0 || XQC_BUFF_LEFT_SIZE(pos, end) < len) {
+        return -XQC_EILLPKT;
+    }
+    pos += len;
+
+    if (length > (uint64_t)XQC_BUFF_LEFT_SIZE(pos, end)) {
+        return -XQC_EILLPKT;
+    }
+
+    *packet_size = pos - buf + (size_t)length;
+    return XQC_OK;
+}
+
+
+xqc_int_t
+xqc_packet_check_coalesced_dcid(xqc_connection_t *c,
+    xqc_packet_in_t *packet_in, const xqc_cid_t *first_dcid,
+    xqc_bool_t *dcid_mismatch)
+{
+    xqc_cid_t packet_dcid;
+    xqc_cid_t packet_scid;
+    size_t packet_size;
+    xqc_int_t ret;
+
+    if (first_dcid == NULL || dcid_mismatch == NULL) {
+        return -XQC_EPARAM;
+    }
+
+    *dcid_mismatch = XQC_FALSE;
+    xqc_cid_init_zero(&packet_dcid);
+    xqc_cid_init_zero(&packet_scid);
+
+    ret = xqc_packet_parse_cid(&packet_dcid, &packet_scid,
+                               c->engine->config->cid_len,
+                               packet_in->buf, packet_in->buf_size);
+    if (ret != XQC_OK) {
+        return ret;
+    }
+
+    if (xqc_cid_is_equal(first_dcid, &packet_dcid) == XQC_OK) {
+        return XQC_OK;
+    }
+
+    ret = xqc_packet_parse_size(packet_in->buf, packet_in->buf_size,
+                                c->engine->config->cid_len, &packet_size);
+    if (ret != XQC_OK) {
+        return ret;
+    }
+
+    packet_in->last = packet_in->pos + packet_size;
+    packet_in->pi_pkt.length = packet_size;
+    xqc_cid_set(&packet_in->pi_pkt.pkt_dcid, packet_dcid.cid_buf,
+                packet_dcid.cid_len);
+
+    if (XQC_PACKET_IS_SHORT_HEADER(packet_in->buf)) {
+        packet_in->pi_pkt.pkt_type = XQC_PTYPE_SHORT_HEADER;
+
+    } else if (xqc_parse_uint32(packet_in->buf + 1) == 0) {
+        packet_in->pi_pkt.pkt_type = XQC_PTYPE_VERSION_NEGOTIATION;
+
+    } else {
+        packet_in->pi_pkt.pkt_type =
+            XQC_PACKET_LONG_HEADER_GET_TYPE(packet_in->buf);
+    }
+
+    /* RFC 9000 Section 12.2: ignore a later packet with another DCID. */
+    xqc_log(c->log, XQC_LOG_WARN,
+            "|ignore coalesced packet with different DCID|first:%s|current:%s|",
+            xqc_dcid_str(c->engine, first_dcid),
+            xqc_scid_str(c->engine, &packet_dcid));
+    xqc_log_event(c->log, TRA_PACKET_DROPPED,
+                  "coalesced packet with different DCID", -XQC_EIGNORE_PKT,
+                  xqc_pkt_type_2_str(packet_in->pi_pkt.pkt_type), 0);
+
+    *dcid_mismatch = XQC_TRUE;
+    return -XQC_EIGNORE_PKT;
+}

--- a/src/transport/xqc_packet.c
+++ b/src/transport/xqc_packet.c
@@ -7,7 +7,6 @@
 #include "src/transport/xqc_packet_out.h"
 #include "src/transport/xqc_conn.h"
 #include "src/common/xqc_algorithm.h"
-#include "src/common/utils/vint/xqc_variable_len_int.h"
 #include "src/transport/xqc_defs.h"
 #include "src/transport/xqc_send_ctl.h"
 #include "src/transport/xqc_recv_record.h"
@@ -17,11 +16,6 @@
 #include "src/transport/xqc_engine.h"
 #include "src/tls/xqc_tls.h"
 #include "src/tls/xqc_crypto.h"
-
-
-static xqc_int_t xqc_packet_parse_size(const unsigned char *buf, size_t size,
-    uint8_t cid_len, size_t *packet_size);
-
 
 
 static const char * const pkt_type_2_str[XQC_PTYPE_NUM] = {
@@ -273,14 +267,27 @@ xqc_packet_decrypt_single(xqc_connection_t *c, xqc_packet_in_t *packet_in)
 
 xqc_int_t
 xqc_packet_process_single(xqc_connection_t *c,
-    xqc_packet_in_t *packet_in)
+    xqc_packet_in_t *packet_in, const xqc_cid_t *first_dcid,
+    xqc_bool_t *dcid_mismatch)
 {
     xqc_int_t ret = XQC_ERROR;
+
+    if (first_dcid != NULL && dcid_mismatch == NULL) {
+        return -XQC_EPARAM;
+    }
 
     /* parse packet */
     ret = xqc_packet_parse_single(c, packet_in);
     if (XQC_OK != ret) {
         return ret;
+    }
+
+    if (first_dcid != NULL) {
+        ret = xqc_packet_check_coalesced_dcid(c, packet_in, first_dcid);
+        if (ret != XQC_OK) {
+            *dcid_mismatch = XQC_TRUE;
+            return ret;
+        }
     }
 
     /* those packets with no packet number, don't need to be decrypt or put into CC */
@@ -298,163 +305,29 @@ xqc_packet_process_single(xqc_connection_t *c,
 }
 
 
-static xqc_int_t
-xqc_packet_parse_size(const unsigned char *buf, size_t size,
-    uint8_t cid_len, size_t *packet_size)
-{
-    const unsigned char *pos;
-    const unsigned char *end;
-    uint32_t version;
-    uint64_t length;
-    uint64_t token_len;
-    ssize_t len;
-    uint8_t parsed_cid_len;
-    uint8_t type;
-
-    if (buf == NULL || packet_size == NULL || size == 0) {
-        return -XQC_EPARAM;
-    }
-
-    end = buf + size;
-
-    if (XQC_PACKET_IS_SHORT_HEADER(buf)) {
-        if (size < 1 + cid_len) {
-            return -XQC_EILLPKT;
-        }
-
-        /* A short-header packet can only be the last packet. */
-        *packet_size = size;
-        return XQC_OK;
-    }
-
-    if (!XQC_PACKET_IS_LONG_HEADER(buf)
-        || size < XQC_PACKET_LONG_HEADER_PREFIX_LENGTH + 2)
-    {
-        return -XQC_EILLPKT;
-    }
-
-    type = XQC_PACKET_LONG_HEADER_GET_TYPE(buf);
-    version = xqc_parse_uint32(buf + 1);
-    pos = buf + XQC_PACKET_LONG_HEADER_PREFIX_LENGTH;
-
-    parsed_cid_len = *pos++;
-    if (parsed_cid_len > XQC_MAX_CID_LEN
-        || XQC_BUFF_LEFT_SIZE(pos, end) < parsed_cid_len + 1)
-    {
-        return -XQC_EILLPKT;
-    }
-    pos += parsed_cid_len;
-
-    parsed_cid_len = *pos++;
-    if (parsed_cid_len > XQC_MAX_CID_LEN
-        || XQC_BUFF_LEFT_SIZE(pos, end) < parsed_cid_len)
-    {
-        return -XQC_EILLPKT;
-    }
-    pos += parsed_cid_len;
-
-    /* These packets cannot be followed by another coalesced packet. */
-    if (version == 0 || type == XQC_PTYPE_RETRY) {
-        *packet_size = size;
-        return XQC_OK;
-    }
-
-    /* The packet type and Length encoding are version-specific. */
-    if (version != XQC_VERSION_V1_VALUE
-        && version != XQC_IDRAFT_VER_29_VALUE)
-    {
-        *packet_size = size;
-        return XQC_OK;
-    }
-
-    if (type == XQC_PTYPE_INIT) {
-        len = xqc_vint_read(pos, end, &token_len);
-        if (len < 0 || XQC_BUFF_LEFT_SIZE(pos, end) < len) {
-            return -XQC_EILLPKT;
-        }
-        pos += len;
-
-        if (token_len > (uint64_t)XQC_BUFF_LEFT_SIZE(pos, end)) {
-            return -XQC_EILLPKT;
-        }
-        pos += token_len;
-    }
-
-    len = xqc_vint_read(pos, end, &length);
-    if (len < 0 || XQC_BUFF_LEFT_SIZE(pos, end) < len) {
-        return -XQC_EILLPKT;
-    }
-    pos += len;
-
-    if (length > (uint64_t)XQC_BUFF_LEFT_SIZE(pos, end)) {
-        return -XQC_EILLPKT;
-    }
-
-    *packet_size = pos - buf + (size_t)length;
-    return XQC_OK;
-}
-
-
 xqc_int_t
 xqc_packet_check_coalesced_dcid(xqc_connection_t *c,
-    xqc_packet_in_t *packet_in, const xqc_cid_t *first_dcid,
-    xqc_bool_t *dcid_mismatch)
+    xqc_packet_in_t *packet_in, const xqc_cid_t *first_dcid)
 {
-    xqc_cid_t packet_dcid;
-    xqc_cid_t packet_scid;
-    size_t packet_size;
-    xqc_int_t ret;
-
-    if (first_dcid == NULL || dcid_mismatch == NULL) {
+    if (first_dcid == NULL) {
         return -XQC_EPARAM;
     }
 
-    *dcid_mismatch = XQC_FALSE;
-    xqc_cid_init_zero(&packet_dcid);
-    xqc_cid_init_zero(&packet_scid);
-
-    ret = xqc_packet_parse_cid(&packet_dcid, &packet_scid,
-                               c->engine->config->cid_len,
-                               packet_in->buf, packet_in->buf_size);
-    if (ret != XQC_OK) {
-        return ret;
-    }
-
-    if (xqc_cid_is_equal(first_dcid, &packet_dcid) == XQC_OK) {
+    if (xqc_cid_is_equal(first_dcid,
+                         &packet_in->pi_pkt.pkt_dcid) == XQC_OK)
+    {
         return XQC_OK;
-    }
-
-    ret = xqc_packet_parse_size(packet_in->buf, packet_in->buf_size,
-                                c->engine->config->cid_len, &packet_size);
-    if (ret != XQC_OK) {
-        return ret;
-    }
-
-    packet_in->last = packet_in->pos + packet_size;
-    packet_in->pi_pkt.length = packet_size;
-    xqc_cid_set(&packet_in->pi_pkt.pkt_dcid, packet_dcid.cid_buf,
-                packet_dcid.cid_len);
-
-    if (XQC_PACKET_IS_SHORT_HEADER(packet_in->buf)) {
-        packet_in->pi_pkt.pkt_type = XQC_PTYPE_SHORT_HEADER;
-
-    } else if (xqc_parse_uint32(packet_in->buf + 1) == 0) {
-        packet_in->pi_pkt.pkt_type = XQC_PTYPE_VERSION_NEGOTIATION;
-
-    } else {
-        packet_in->pi_pkt.pkt_type =
-            XQC_PACKET_LONG_HEADER_GET_TYPE(packet_in->buf);
     }
 
     /* RFC 9000 Section 12.2: ignore a later packet with another DCID. */
     xqc_log(c->log, XQC_LOG_WARN,
             "|ignore coalesced packet with different DCID|first:%s|current:%s|",
             xqc_dcid_str(c->engine, first_dcid),
-            xqc_scid_str(c->engine, &packet_dcid));
+            xqc_scid_str(c->engine, &packet_in->pi_pkt.pkt_dcid));
     xqc_log_event(c->log, TRA_PACKET_DROPPED,
                   "coalesced packet with different DCID", -XQC_EIGNORE_PKT,
                   xqc_pkt_type_2_str(packet_in->pi_pkt.pkt_type), 0);
 
-    *dcid_mismatch = XQC_TRUE;
+    packet_in->pos = packet_in->last;
     return -XQC_EIGNORE_PKT;
 }

--- a/src/transport/xqc_packet.h
+++ b/src/transport/xqc_packet.h
@@ -100,5 +100,13 @@ xqc_pkt_type_t xqc_state_to_pkt_type(xqc_connection_t *conn);
  */
 xqc_int_t xqc_packet_process_single(xqc_connection_t *c, xqc_packet_in_t *packet_in);
 
+/**
+ * Check a subsequent packet in a coalesced datagram against the first DCID.
+ * A mismatch is delimited and returned with dcid_mismatch set to XQC_TRUE.
+ */
+xqc_int_t xqc_packet_check_coalesced_dcid(xqc_connection_t *c,
+    xqc_packet_in_t *packet_in, const xqc_cid_t *first_dcid,
+    xqc_bool_t *dcid_mismatch);
+
 
 #endif /* _XQC_PACKET_H_INCLUDED_ */

--- a/src/transport/xqc_packet.h
+++ b/src/transport/xqc_packet.h
@@ -98,15 +98,15 @@ xqc_pkt_type_t xqc_state_to_pkt_type(xqc_connection_t *conn);
 /**
  * process a single QUIC packet from packet_in
  */
-xqc_int_t xqc_packet_process_single(xqc_connection_t *c, xqc_packet_in_t *packet_in);
-
-/**
- * Check a subsequent packet in a coalesced datagram against the first DCID.
- * A mismatch is delimited and returned with dcid_mismatch set to XQC_TRUE.
- */
-xqc_int_t xqc_packet_check_coalesced_dcid(xqc_connection_t *c,
+xqc_int_t xqc_packet_process_single(xqc_connection_t *c,
     xqc_packet_in_t *packet_in, const xqc_cid_t *first_dcid,
     xqc_bool_t *dcid_mismatch);
+
+/**
+ * Check a parsed coalesced packet against the first DCID.
+ */
+xqc_int_t xqc_packet_check_coalesced_dcid(xqc_connection_t *c,
+    xqc_packet_in_t *packet_in, const xqc_cid_t *first_dcid);
 
 
 #endif /* _XQC_PACKET_H_INCLUDED_ */

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -147,6 +147,10 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite, "xqc_test_packet_encrypt_hp_sample_boundary", xqc_test_packet_encrypt_hp_sample_boundary)
         || !CU_add_test(pSuite, "xqc_test_empty_pkt", xqc_test_empty_pkt)
         || !CU_add_test(pSuite, "xqc_test_stateless_reset_parse_boundary", xqc_test_stateless_reset_parse_boundary)
+        || !CU_add_test(pSuite, "xqc_test_coalesced_matching_dcid_processed",
+                        xqc_test_coalesced_matching_dcid_processed)
+        || !CU_add_test(pSuite, "xqc_test_coalesced_mismatching_dcid_ignored",
+                        xqc_test_coalesced_mismatching_dcid_ignored)
         || !CU_add_test(pSuite, "xqc_test_transport_params", xqc_test_transport_params)
         || !CU_add_test(pSuite, "xqc_test_max_ack_delay_default_when_absent",
                         xqc_test_max_ack_delay_default_when_absent)

--- a/tests/unittest/xqc_packet_test.c
+++ b/tests/unittest/xqc_packet_test.c
@@ -86,7 +86,7 @@ xqc_test_client_discards_received_zero_rtt(void)
                        (unsigned char *)XQC_TEST_ZERO_RTT_PACKET,
                        sizeof(XQC_TEST_ZERO_RTT_PACKET) - 1, NULL, 0, 0);
 
-    ret = xqc_packet_process_single(conn, &packet_in);
+    ret = xqc_packet_process_single(conn, &packet_in, NULL, NULL);
 
     /*
      * RFC 9001 Section 5.6 requires discard before decryption. The receive
@@ -114,7 +114,7 @@ xqc_test_server_buffers_received_zero_rtt(void)
                        (unsigned char *)XQC_TEST_ZERO_RTT_PACKET,
                        sizeof(XQC_TEST_ZERO_RTT_PACKET) - 1, NULL, 0, 0);
 
-    ret = xqc_packet_process_single(conn, &packet_in);
+    ret = xqc_packet_process_single(conn, &packet_in, NULL, NULL);
 
     CU_ASSERT_EQUAL(ret, -XQC_EWAITING);
     CU_ASSERT_EQUAL(conn->undecrypt_count[XQC_ENC_LEV_0RTT], 1);

--- a/tests/unittest/xqc_packet_test.c
+++ b/tests/unittest/xqc_packet_test.c
@@ -7,6 +7,7 @@
 #include "xqc_packet_test.h"
 #include "src/transport/xqc_packet.h"
 #include "src/transport/xqc_packet_parser.h"
+#include "src/transport/xqc_frame_parser.h"
 #include "src/common/xqc_log.h"
 #include "src/transport/xqc_engine.h"
 #include "src/transport/xqc_cid.h"
@@ -24,6 +25,7 @@
     "\x08\xAB\x3f\x12\x0a\xcd\xef\x00\x89\x01\x00"
 
 #define XQC_TEST_CHECK_CID "ab3f120acdef0089"
+#define XQC_TEST_COALESCED_PACKET_SIZE 1250
 
 void
 xqc_test_packet_parse_cid(unsigned char *buf, size_t size, int is_short)
@@ -465,4 +467,260 @@ xqc_test_stateless_reset_parse_boundary(void)
     CU_ASSERT(ret == XQC_OK);
     CU_ASSERT(sr_token != NULL);
     CU_ASSERT(sr_token == pkt + 22 - XQC_STATELESS_RESET_TOKENLEN);
+}
+
+
+static xqc_int_t
+xqc_test_coalesced_setup(test_ctx *cli, test_ctx *svr)
+{
+    struct sockaddr_in6 peer_addr;
+    struct sockaddr_in6 local_addr;
+    xqc_conn_settings_t conn_settings;
+    xqc_conn_ssl_config_t conn_ssl_config;
+    const xqc_cid_t *cid;
+
+    svr->engine = test_create_engine_buf_server(svr);
+    cli->engine = test_create_engine_buf_client(cli);
+    if (svr->engine == NULL || cli->engine == NULL) {
+        return XQC_ERROR;
+    }
+
+    memset(&conn_settings, 0, sizeof(conn_settings));
+    conn_settings.proto_version = XQC_VERSION_V1;
+    memset(&conn_ssl_config, 0, sizeof(conn_ssl_config));
+
+    cid = xqc_connect(cli->engine, &conn_settings, NULL, 0, "", 0,
+                      &conn_ssl_config, NULL, 0, "transport", cli);
+    if (cid == NULL || cli->c == NULL) {
+        return XQC_ERROR;
+    }
+
+    memset(&peer_addr, 0, sizeof(peer_addr));
+    memset(&local_addr, 0, sizeof(local_addr));
+    xqc_engine_packet_process(svr->engine, cli->buf, cli->buf_len,
+                              (struct sockaddr *)&local_addr,
+                              sizeof(local_addr),
+                              (struct sockaddr *)&peer_addr,
+                              sizeof(peer_addr), xqc_now(), svr);
+
+    return svr->c == NULL ? XQC_ERROR : XQC_OK;
+}
+
+
+static void
+xqc_test_coalesced_teardown(test_ctx *cli, test_ctx *svr)
+{
+    if (cli->engine != NULL) {
+        if (cli->c != NULL) {
+            xqc_conn_close(cli->engine, &cli->cid);
+        }
+        xqc_engine_destroy(cli->engine);
+    }
+
+    if (svr->engine != NULL) {
+        if (svr->c != NULL) {
+            xqc_conn_close(svr->engine, &svr->cid);
+        }
+        xqc_engine_destroy(svr->engine);
+    }
+}
+
+
+static size_t
+xqc_test_build_initial(test_ctx *cli, const xqc_cid_t *dcid,
+    xqc_packet_number_t packet_number, xqc_bool_t connection_close,
+    unsigned char *buf, size_t buf_cap)
+{
+    xqc_packet_out_t *packet_out;
+    size_t encrypted_size = 0;
+    size_t padding_size;
+    ssize_t written;
+    xqc_int_t ret;
+
+    packet_out = xqc_packet_out_create(2048);
+    if (packet_out == NULL) {
+        return 0;
+    }
+
+    packet_out->po_pkt.pkt_type = XQC_PTYPE_INIT;
+    packet_out->po_pkt.pkt_pns = XQC_PNS_INIT;
+    packet_out->po_pkt.pkt_num = packet_number;
+    xqc_cid_set(&packet_out->po_pkt.pkt_scid,
+                cli->c->scid_set.user_scid.cid_buf,
+                cli->c->scid_set.user_scid.cid_len);
+    xqc_cid_set(&packet_out->po_pkt.pkt_dcid, dcid->cid_buf, dcid->cid_len);
+
+    written = xqc_gen_long_packet_header(
+        packet_out, packet_out->po_pkt.pkt_dcid.cid_buf,
+        packet_out->po_pkt.pkt_dcid.cid_len,
+        packet_out->po_pkt.pkt_scid.cid_buf,
+        packet_out->po_pkt.pkt_scid.cid_len, NULL, 0, XQC_VERSION_V1,
+        XQC_PKTNO_BITS);
+    if (written <= 0) {
+        goto end;
+    }
+    packet_out->po_used_size += written;
+
+    if (connection_close) {
+        written = xqc_gen_conn_close_frame(packet_out,
+                                           TRA_PROTOCOL_VIOLATION, 0, 0);
+        if (written <= 0) {
+            goto end;
+        }
+        packet_out->po_used_size += written;
+    }
+
+    if (packet_out->po_used_size + XQC_TLS_AEAD_OVERHEAD_MAX_LEN
+        >= XQC_TEST_COALESCED_PACKET_SIZE)
+    {
+        goto end;
+    }
+
+    padding_size = XQC_TEST_COALESCED_PACKET_SIZE
+                   - packet_out->po_used_size
+                   - XQC_TLS_AEAD_OVERHEAD_MAX_LEN;
+    memset(packet_out->po_buf + packet_out->po_used_size, 0, padding_size);
+    packet_out->po_used_size += padding_size;
+
+    ret = xqc_packet_encrypt_buf(cli->c, packet_out, buf, buf_cap,
+                                 &encrypted_size);
+    if (ret != XQC_OK) {
+        encrypted_size = 0;
+    }
+
+end:
+    xqc_packet_out_destroy(packet_out);
+    return encrypted_size;
+}
+
+
+void
+xqc_test_coalesced_matching_dcid_processed(void)
+{
+    test_ctx cli = {0};
+    test_ctx svr = {0};
+    unsigned char first[2048];
+    unsigned char second[2048];
+    unsigned char datagram[4096];
+    size_t first_size;
+    size_t second_size;
+    xqc_int_t ret;
+
+    ret = xqc_test_coalesced_setup(&cli, &svr);
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    if (ret != XQC_OK) {
+        xqc_test_coalesced_teardown(&cli, &svr);
+        return;
+    }
+
+    first_size = xqc_test_build_initial(
+        &cli, &cli.c->dcid_set.current_dcid, 1, XQC_FALSE,
+        first, sizeof(first));
+    second_size = xqc_test_build_initial(
+        &cli, &cli.c->dcid_set.current_dcid, 2, XQC_TRUE,
+        second, sizeof(second));
+    CU_ASSERT_NOT_EQUAL(first_size, 0);
+    CU_ASSERT_NOT_EQUAL(second_size, 0);
+    if (first_size == 0 || second_size == 0) {
+        xqc_test_coalesced_teardown(&cli, &svr);
+        return;
+    }
+
+    memcpy(datagram, first, first_size);
+    memcpy(datagram + first_size, second, second_size);
+    ret = xqc_conn_process_packet(svr.c, datagram,
+                                  first_size + second_size, xqc_now());
+
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    CU_ASSERT_NOT_EQUAL(svr.c->conn_close_recv_time, 0);
+    CU_ASSERT(svr.c->conn_state >= XQC_CONN_STATE_DRAINING);
+
+    xqc_test_coalesced_teardown(&cli, &svr);
+}
+
+
+void
+xqc_test_coalesced_mismatching_dcid_ignored(void)
+{
+    test_ctx cli = {0};
+    test_ctx svr = {0};
+    xqc_cid_t matching_dcid;
+    xqc_cid_t mismatching_dcid;
+    unsigned char first[2048];
+    unsigned char second[2048];
+    unsigned char third[2048];
+    unsigned char datagram[6144];
+    size_t first_size;
+    size_t second_size;
+    size_t third_size;
+    size_t offset;
+    uint64_t dropped_count;
+    xqc_conn_state_t state;
+    xqc_int_t ret;
+
+    ret = xqc_test_coalesced_setup(&cli, &svr);
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    if (ret != XQC_OK) {
+        xqc_test_coalesced_teardown(&cli, &svr);
+        return;
+    }
+
+    xqc_cid_set(&matching_dcid, cli.c->dcid_set.current_dcid.cid_buf,
+                cli.c->dcid_set.current_dcid.cid_len);
+    xqc_cid_set(&mismatching_dcid, matching_dcid.cid_buf,
+                matching_dcid.cid_len);
+    mismatching_dcid.cid_buf[0] ^= 0xff;
+    state = svr.c->conn_state;
+    dropped_count = svr.c->packet_dropped_count;
+
+    first_size = xqc_test_build_initial(&cli, &matching_dcid, 1,
+                                        XQC_FALSE, first, sizeof(first));
+    second_size = xqc_test_build_initial(&cli, &mismatching_dcid, 2,
+                                         XQC_TRUE, second, sizeof(second));
+    CU_ASSERT_NOT_EQUAL(first_size, 0);
+    CU_ASSERT_NOT_EQUAL(second_size, 0);
+    if (first_size == 0 || second_size == 0) {
+        xqc_test_coalesced_teardown(&cli, &svr);
+        return;
+    }
+
+    memcpy(datagram, first, first_size);
+    memcpy(datagram + first_size, second, second_size);
+    ret = xqc_conn_process_packet(svr.c, datagram,
+                                  first_size + second_size, xqc_now());
+
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    CU_ASSERT_EQUAL(svr.c->conn_close_recv_time, 0);
+    CU_ASSERT_EQUAL(svr.c->conn_state, state);
+    CU_ASSERT_EQUAL(svr.c->packet_dropped_count, dropped_count);
+
+    first_size = xqc_test_build_initial(&cli, &matching_dcid, 3,
+                                        XQC_FALSE, first, sizeof(first));
+    second_size = xqc_test_build_initial(&cli, &mismatching_dcid, 4,
+                                         XQC_FALSE, second, sizeof(second));
+    third_size = xqc_test_build_initial(&cli, &matching_dcid, 5,
+                                        XQC_TRUE, third, sizeof(third));
+    CU_ASSERT_NOT_EQUAL(first_size, 0);
+    CU_ASSERT_NOT_EQUAL(second_size, 0);
+    CU_ASSERT_NOT_EQUAL(third_size, 0);
+    if (first_size == 0 || second_size == 0 || third_size == 0) {
+        xqc_test_coalesced_teardown(&cli, &svr);
+        return;
+    }
+
+    offset = 0;
+    memcpy(datagram + offset, first, first_size);
+    offset += first_size;
+    memcpy(datagram + offset, second, second_size);
+    offset += second_size;
+    memcpy(datagram + offset, third, third_size);
+    offset += third_size;
+
+    ret = xqc_conn_process_packet(svr.c, datagram, offset, xqc_now());
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    CU_ASSERT_NOT_EQUAL(svr.c->conn_close_recv_time, 0);
+    CU_ASSERT(svr.c->conn_state >= XQC_CONN_STATE_DRAINING);
+    CU_ASSERT_EQUAL(svr.c->packet_dropped_count, dropped_count);
+
+    xqc_test_coalesced_teardown(&cli, &svr);
 }

--- a/tests/unittest/xqc_packet_test.h
+++ b/tests/unittest/xqc_packet_test.h
@@ -12,6 +12,8 @@ void xqc_test_server_buffers_received_zero_rtt(void);
 void xqc_test_packet_encrypt_hp_sample_boundary();
 void xqc_test_empty_pkt();
 void xqc_test_stateless_reset_parse_boundary(void);
+void xqc_test_coalesced_matching_dcid_processed(void);
+void xqc_test_coalesced_mismatching_dcid_ignored(void);
 
 
 #endif


### PR DESCRIPTION
### Mechanism

Parse every packet exactly once through the existing single-packet path and
retain the first packet's parsed Destination Connection ID as the UDP datagram
anchor. After the existing parser supplies each later packet's DCID and
boundary, a narrow helper only compares that DCID with the anchor. A mismatch
is logged and ignored before decryption or frame application, then processing
continues at the parser-provided boundary. No separate CID or Length parser is
introduced. This follows
[RFC 9000 Section 12.2](https://www.rfc-editor.org/rfc/rfc9000.html#section-12.2).

- RFC or draft: RFC 9000 Section 12.2

Fixes: #581

### Validation Cases

- Complete unit suite: 205/205 CUnit tests passed, 0 failed.
- Packet endpoint group: 18/18 cases passed, including adjacent wrong-CID
  handling. The group cannot inject the precise raw coalesced datagram, so that
  exact endpoint path remains an explicit gap covered by paired unit tests.

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Incomplete — complete unit and packet endpoint suites pass;
  exact raw coalesced-datagram endpoint injection is unavailable
- CI: Pending — Harness Check; Analyze. Passed: Codacy
  Static Code Analysis; license/cla
