### PR TITLE
[~]: Reject invalid max_udp_payload_size

### DIFF
--- a/src/transport/xqc_transport_params.c
+++ b/src/transport/xqc_transport_params.c
@@ -567,7 +567,17 @@ static xqc_int_t
 xqc_decode_max_udp_payload_size(xqc_transport_params_t *params, xqc_transport_params_type_t exttype,
     const uint8_t *p, const uint8_t *end, uint64_t param_type, uint64_t param_len)
 {
-    XQC_DECODE_VINT_VALUE(&params->max_udp_payload_size, p, end);
+    ssize_t nread = xqc_vint_read(p, end, &params->max_udp_payload_size);
+    if (nread < 0) {
+        return -XQC_TLS_MALFORMED_TRANSPORT_PARAM;
+    }
+
+    /* RFC 9000 Section 18.2: values below 1200 are invalid. */
+    if (params->max_udp_payload_size < XQC_MIN_UDP_PAYLOAD_SIZE) {
+        return -XQC_TLS_MALFORMED_TRANSPORT_PARAM;
+    }
+
+    return XQC_OK;
 }
 
 static xqc_int_t

--- a/src/transport/xqc_transport_params.h
+++ b/src/transport/xqc_transport_params.h
@@ -17,6 +17,9 @@
 /* default value for max_udp_payload_size */
 #define XQC_DEFAULT_MAX_UDP_PAYLOAD_SIZE        65527
 
+/* minimum valid value for max_udp_payload_size */
+#define XQC_MIN_UDP_PAYLOAD_SIZE                1200
+
 /* default value for active_connection_id_limit */
 #define XQC_DEFAULT_ACTIVE_CONNECTION_ID_LIMIT  2
 

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -139,6 +139,12 @@ main(int argc, char *argv[])
                         xqc_test_max_ack_delay_valid_boundary)
         || !CU_add_test(pSuite, "xqc_test_max_ack_delay_invalid_boundary",
                         xqc_test_max_ack_delay_invalid_boundary)
+        || !CU_add_test(pSuite,
+                        "xqc_test_max_udp_payload_size_valid_boundary",
+                        xqc_test_max_udp_payload_size_valid_boundary)
+        || !CU_add_test(pSuite,
+                        "xqc_test_max_udp_payload_size_invalid_boundary",
+                        xqc_test_max_udp_payload_size_invalid_boundary)
         || !CU_add_test(pSuite, "xqc_test_tp_cid_overflow", xqc_test_tp_cid_overflow)
         || !CU_add_test(pSuite, "xqc_test_active_cid_limit_minimum", xqc_test_active_cid_limit_minimum)
         || !CU_add_test(pSuite, "xqc_test_check_transport_params_cids", xqc_test_check_transport_params_cids)

--- a/tests/unittest/xqc_tp_test.c
+++ b/tests/unittest/xqc_tp_test.c
@@ -193,6 +193,63 @@ xqc_test_max_ack_delay_invalid_boundary(void)
     CU_ASSERT_EQUAL(ret, -XQC_TLS_MALFORMED_TRANSPORT_PARAM);
 }
 
+/* RFC 9000 Section 18.2: max_udp_payload_size is at least 1200. */
+void
+xqc_test_max_udp_payload_size_valid_boundary(void)
+{
+    uint8_t tp_absent[] = {
+        XQC_TRANSPORT_PARAM_DISABLE_ACTIVE_MIGRATION, 0x00
+    };
+    uint8_t tp_minimum[] = {
+        XQC_TRANSPORT_PARAM_MAX_UDP_PAYLOAD_SIZE, 0x02, 0x44, 0xb0
+    };
+    xqc_transport_params_t params;
+    xqc_int_t              ret;
+
+    memset(&params, 0, sizeof(params));
+    ret = xqc_decode_transport_params(&params,
+                                      XQC_TP_TYPE_ENCRYPTED_EXTENSIONS,
+                                      tp_absent, sizeof(tp_absent));
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    CU_ASSERT_EQUAL(params.max_udp_payload_size,
+                    XQC_DEFAULT_MAX_UDP_PAYLOAD_SIZE);
+
+    memset(&params, 0, sizeof(params));
+    ret = xqc_decode_transport_params(&params,
+                                      XQC_TP_TYPE_ENCRYPTED_EXTENSIONS,
+                                      tp_minimum, sizeof(tp_minimum));
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    CU_ASSERT_EQUAL(params.max_udp_payload_size,
+                    XQC_MIN_UDP_PAYLOAD_SIZE);
+}
+
+/* RFC 9000 Section 18.2: max_udp_payload_size below 1200 is invalid. */
+void
+xqc_test_max_udp_payload_size_invalid_boundary(void)
+{
+    uint8_t tp_below_minimum[] = {
+        XQC_TRANSPORT_PARAM_MAX_UDP_PAYLOAD_SIZE, 0x02, 0x44, 0xaf
+    };
+    uint8_t tp_zero[] = {
+        XQC_TRANSPORT_PARAM_MAX_UDP_PAYLOAD_SIZE, 0x01, 0x00
+    };
+    xqc_transport_params_t params;
+    xqc_int_t              ret;
+
+    memset(&params, 0, sizeof(params));
+    ret = xqc_decode_transport_params(&params,
+                                      XQC_TP_TYPE_ENCRYPTED_EXTENSIONS,
+                                      tp_below_minimum,
+                                      sizeof(tp_below_minimum));
+    CU_ASSERT_EQUAL(ret, -XQC_TLS_MALFORMED_TRANSPORT_PARAM);
+
+    memset(&params, 0, sizeof(params));
+    ret = xqc_decode_transport_params(&params,
+                                      XQC_TP_TYPE_ENCRYPTED_EXTENSIONS,
+                                      tp_zero, sizeof(tp_zero));
+    CU_ASSERT_EQUAL(ret, -XQC_TLS_MALFORMED_TRANSPORT_PARAM);
+}
+
 /*
  * ============================================================================
  * Tests for xqc_conn_check_transport_params (RFC 9000 Section 7.3)

--- a/tests/unittest/xqc_tp_test.h
+++ b/tests/unittest/xqc_tp_test.h
@@ -9,6 +9,8 @@ void xqc_test_transport_params();
 void xqc_test_max_ack_delay_default_when_absent(void);
 void xqc_test_max_ack_delay_valid_boundary(void);
 void xqc_test_max_ack_delay_invalid_boundary(void);
+void xqc_test_max_udp_payload_size_valid_boundary(void);
+void xqc_test_max_udp_payload_size_invalid_boundary(void);
 void xqc_test_tp_cid_overflow();
 void xqc_test_active_cid_limit_minimum();
 void xqc_test_check_transport_params_cids();


### PR DESCRIPTION
### Mechanism

Reject an explicitly encoded `max_udp_payload_size` below 1200 during
transport-parameter decoding, so the existing TLS callback reports
`TRANSPORT_PARAMETER_ERROR`. An omitted parameter continues to use the RFC
default of 65527.

- RFC or draft: RFC 9000 Sections 18.2 and 7.4

Fixes: #658

### Validation Cases

- Not run — targeted client-to-server injection of an invalid transport parameter is unavailable.

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Complete
- CI: Pending — required checks