### PR TITLE
[~] Fix #473: Preserve CONNECTION_CLOSE error namespaces

### DIFF
--- a/case_test/tls/handshake.sh
+++ b/case_test/tls/handshake.sh
@@ -87,7 +87,9 @@ ${CLIENT_BIN} -l e -t 1 -T 1 -x 43 > stdlog
 alpn_res=`grep "xqc_ssl_alpn_select_cb|select proto error" slog`
 alert_res=`grep -E "(alert:120|NO_APPLICATION_PROTOCOL|no_application_protocol)" slog`
 conn_err_178=`grep -E "(conn_err:376([^0-9]|$)|err:0x178([^0-9a-fA-F]|$))" stdlog clog slog`
-if [ -n "$alpn_res" ] && [ -n "$alert_res" ] && [ -n "$conn_err_178" ]; then
+transport_type=`grep "conn_err_type:1" stdlog`
+if [ -n "$alpn_res" ] && [ -n "$alert_res" ] \
+    && [ -n "$conn_err_178" ] && [ -n "$transport_type" ]; then
     echo ">>>>>>>> pass:1"
     case_print_result "alpn_negotiation_failure_0x178" "pass"
 else
@@ -97,6 +99,7 @@ else
     echo "  server select proto error: ${alpn_res:-missing}"
     echo "  TLS alert 120/no_application_protocol: ${alert_res:-missing}"
     echo "  conn_err 0x178/376: ${conn_err_178:-missing}"
+    echo "  transport error type: ${transport_type:-missing}"
     grep -E "(select proto error|alert:|NO_APPLICATION_PROTOCOL|no_application_protocol|conn_err:|err:0x)" stdlog clog slog 2>/dev/null || true
 fi
 

--- a/include/xquic/xquic.h
+++ b/include/xquic/xquic.h
@@ -1889,7 +1889,7 @@ XQC_EXPORT_PUBLIC_API
 xqc_int_t xqc_conn_close(xqc_engine_t *engine, const xqc_cid_t *cid);
 
 /**
- * @brief close connection with error code
+ * @brief close connection with an application error code
  */
 XQC_EXPORT_PUBLIC_API
 xqc_int_t xqc_conn_close_with_error(xqc_connection_t *conn, uint64_t err_code);

--- a/src/common/xqc_log_event_callback.c
+++ b/src/common/xqc_log_event_callback.c
@@ -73,12 +73,16 @@ xqc_log_CON_CONNECTION_CLOSED_callback(xqc_log_t *log, const char *func, xqc_con
         }
         xqc_qlog_implement(log, CON_CONNECTION_CLOSED, func,
                             "|err_code:%d|mtu_updatad_count:%d|pkt_dropped:%d|recent_congestion:%s|", 
-                            conn->conn_err, conn->MTU_updated_count, conn->packet_dropped_count, log_buf);
+                            XQC_CONN_ERR_CODE(conn->conn_err),
+                            conn->MTU_updated_count,
+                            conn->packet_dropped_count, log_buf);
     }
     else{
         xqc_qlog_implement(log, CON_CONNECTION_CLOSED, func,
                             "|err_code:%d|mtu_updatad_count:%d|pkt_dropped:%d|", 
-                            conn->conn_err, conn->MTU_updated_count, conn->packet_dropped_count);
+                            XQC_CONN_ERR_CODE(conn->conn_err),
+                            conn->MTU_updated_count,
+                            conn->packet_dropped_count);
     }
 }
 

--- a/src/http3/xqc_h3_conn.h
+++ b/src/http3/xqc_h3_conn.h
@@ -17,10 +17,11 @@
 /* Send CONNECTION_CLOSE with err if ret is an h3 retcode */
 #define XQC_H3_CONN_ERR(h3_conn, err, ret) do {                     \
     if (h3_conn->conn->conn_err == 0 && ret <= -XQC_H3_EMALLOC) {   \
-        h3_conn->conn->conn_err = err;                              \
+        h3_conn->conn->conn_err =                                   \
+            XQC_CONN_ERR_ENCODE_APPLICATION(err);                   \
         h3_conn->conn->conn_flag |= XQC_CONN_FLAG_ERROR;            \
         xqc_log(h3_conn->conn->log, XQC_LOG_ERROR, "|conn:%p|err:0x%xi|ret:%i|%s|", \
-                h3_conn->conn, h3_conn->conn->conn_err, (int64_t)ret,   \
+                h3_conn->conn, (uint64_t) (err), (int64_t)ret,         \
                 xqc_conn_addr_str(h3_conn->conn));                  \
     }                                                               \
 } while(0)                                                          \

--- a/src/http3/xqc_h3_request.c
+++ b/src/http3/xqc_h3_request.c
@@ -401,7 +401,8 @@ xqc_h3_request_get_stats(xqc_h3_request_t *h3_request)
     /* try to update stats */
     xqc_h3_stream_update_stats(h3_request->h3_stream);
 
-    uint64_t conn_err       = h3_request->h3_stream->h3c->conn->conn_err;
+    uint64_t conn_err       = XQC_CONN_ERR_CODE(
+        h3_request->h3_stream->h3c->conn->conn_err);
     stats.recv_body_size    = h3_request->body_recvd;
     stats.send_body_size    = h3_request->body_sent;
     stats.recv_header_size  = h3_request->header_recvd;

--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -1552,7 +1552,9 @@ xqc_conn_destroy(xqc_connection_t *xc)
             (xc->handshake_complete_time > xc->conn_create_time) ? (xc->handshake_complete_time - xc->conn_create_time) : 0,
             (xc->first_data_send_time > xc->conn_create_time) ? (xc->first_data_send_time - xc->conn_create_time) : 0,
             xqc_monotonic_timestamp() - xc->conn_create_time, xc->key_update_ctx.key_update_cnt,
-            xc->conn_err, xc->conn_close_msg ? xc->conn_close_msg : "", xqc_conn_addr_str(xc),
+            XQC_CONN_ERR_CODE(xc->conn_err),
+            xc->conn_close_msg ? xc->conn_close_msg : "",
+            xqc_conn_addr_str(xc),
             xqc_calc_delay(xc->conn_hsk_recv_time, xc->conn_create_time),
             xqc_calc_delay(xc->conn_close_recv_time, xc->conn_create_time),
             xqc_calc_delay(xc->conn_close_send_time, xc->conn_create_time),
@@ -3212,14 +3214,14 @@ end:
 xqc_int_t
 xqc_conn_close_with_error(xqc_connection_t *conn, uint64_t err_code)
 {
-    XQC_CONN_ERR(conn, err_code);
+    XQC_CONN_APP_ERR(conn, err_code);
     return XQC_OK;
 }
 
 xqc_int_t
 xqc_conn_get_errno(xqc_connection_t *conn)
 {
-    return conn->conn_err;
+    return XQC_CONN_ERR_CODE(conn->conn_err);
 }
 
 xqc_conn_err_type_t
@@ -3688,7 +3690,7 @@ xqc_conn_get_stats_internal(xqc_connection_t *conn, xqc_conn_stats_t *conn_stats
         conn_stats->alpn[1] = '1';
     }
 
-    conn_stats->conn_err = (int)conn->conn_err;
+    conn_stats->conn_err = (int)XQC_CONN_ERR_CODE(conn->conn_err);
     conn_stats->early_data_flag = XQC_0RTT_NONE;
     conn_stats->enable_multipath = conn->enable_multipath;
     conn_stats->enable_fec = conn->conn_settings.fec_params.fec_encoder_scheme ? 1 : 0;
@@ -6974,7 +6976,9 @@ xqc_conn_closing_notify(xqc_connection_t *conn)
 
         if (!(conn->conn_flag & XQC_CONN_FLAG_CLOSING_NOTIFIED)) {
             conn->conn_flag |= XQC_CONN_FLAG_CLOSING_NOTIFIED;
-            conn->transport_cbs.conn_closing(conn, &conn->scid_set.user_scid, conn->conn_err, conn->user_data);
+            conn->transport_cbs.conn_closing(conn,
+                &conn->scid_set.user_scid,
+                XQC_CONN_ERR_CODE(conn->conn_err), conn->user_data);
         }
     }
 }

--- a/src/transport/xqc_conn.h
+++ b/src/transport/xqc_conn.h
@@ -66,16 +66,39 @@ static const uint32_t MAX_RSP_CONN_CLOSE_CNT = 3;
     }                                               \
 } while(0)                                          \
 
+/*
+ * RFC 9000 Section 16 limits QUIC variable-length integers to 62 bits.
+ * Reserve bit 63 internally so conn_err itself preserves whether the stored
+ * error belongs to the application namespace. Public and wire boundaries
+ * strip this bit before exposing the error code.
+ */
+#define XQC_CONN_ERR_APPLICATION_FLAG ((uint64_t) 1 << 63)
+#define XQC_CONN_ERR_CODE(err) \
+    ((uint64_t) (err) & ~XQC_CONN_ERR_APPLICATION_FLAG)
+#define XQC_CONN_ERR_IS_APPLICATION(err) \
+    (((uint64_t) (err) & XQC_CONN_ERR_APPLICATION_FLAG) != 0)
+#define XQC_CONN_ERR_ENCODE_APPLICATION(err) \
+    ((uint64_t) (err) | XQC_CONN_ERR_APPLICATION_FLAG)
+
 /* send CONNECTION_CLOSE with err */
-#define XQC_CONN_ERR(conn, err) do {                \
+#define XQC_CONN_ERR_INTERNAL(conn, err) do {       \
     if ((conn)->conn_err == 0) {                    \
         (conn)->conn_err = (err);                   \
         XQC_CONN_CLOSE_MSG(conn, "local error");    \
         (conn)->conn_flag |= XQC_CONN_FLAG_ERROR;   \
         xqc_conn_closing(conn);                     \
-        xqc_log((conn)->log, XQC_LOG_ERROR, "|conn:%p|err:0x%xi|%s|", (conn), (uint64_t)(err), xqc_conn_addr_str(conn)); \
+        xqc_log((conn)->log, XQC_LOG_ERROR,                    \
+                "|conn:%p|err:0x%xi|%s|", (conn),             \
+                XQC_CONN_ERR_CODE(err),                        \
+                xqc_conn_addr_str(conn));                      \
     }                                               \
 } while(0)                                          \
+
+#define XQC_CONN_ERR(conn, err)                     \
+    XQC_CONN_ERR_INTERNAL(conn, err)
+
+#define XQC_CONN_APP_ERR(conn, err)                 \
+    XQC_CONN_ERR_INTERNAL(conn, XQC_CONN_ERR_ENCODE_APPLICATION(err))
 
 extern xqc_conn_settings_t internal_default_conn_settings;
 extern const xqc_tls_callbacks_t xqc_conn_tls_cbs;

--- a/src/transport/xqc_frame.c
+++ b/src/transport/xqc_frame.c
@@ -1216,7 +1216,12 @@ xqc_process_conn_close_frame(xqc_connection_t *conn, xqc_packet_in_t *packet_in)
         xqc_log(conn->log, XQC_LOG_ERROR,
                 "|with err:0x%xi|", err_code);
         XQC_CONN_CLOSE_MSG(conn, "remote error");
-        XQC_CONN_ERR(conn, err_code);
+        if (conn->conn_err_type == XQC_CONN_ERR_TYPE_APPLICATION) {
+            XQC_CONN_APP_ERR(conn, err_code);
+
+        } else {
+            XQC_CONN_ERR(conn, err_code);
+        }
     } else {
         XQC_CONN_CLOSE_MSG(conn, "remote close");
     }

--- a/src/transport/xqc_packet_out.c
+++ b/src/transport/xqc_packet_out.c
@@ -792,6 +792,7 @@ xqc_write_conn_close_to_packet(xqc_connection_t *conn, uint64_t err_code)
     ssize_t ret;
     xqc_packet_out_t *packet_out;
     xqc_pkt_type_t pkt_type = XQC_PTYPE_INIT;
+    xqc_bool_t is_app;
 
     /* select packet type */
     if (xqc_tls_is_key_ready(conn->tls, XQC_ENC_LEV_HSK, XQC_KEY_TYPE_TX_WRITE)) {
@@ -811,9 +812,22 @@ xqc_write_conn_close_to_packet(xqc_connection_t *conn, uint64_t err_code)
         return -XQC_EWRITE_PKT;
     }
 
+    is_app = XQC_CONN_ERR_IS_APPLICATION(err_code);
+    err_code = XQC_CONN_ERR_CODE(err_code);
     err_code = xqc_conn_close_wire_error_code(err_code);
-    ret = xqc_gen_conn_close_frame(packet_out, err_code,
-                                   err_code >= H3_NO_ERROR ? 1 : 0, 0);
+
+    /*
+     * RFC 9000 Section 10.2.3: application close frames sent in Initial or
+     * Handshake packets use transport APPLICATION_ERROR instead.
+     */
+    if (is_app && (pkt_type == XQC_PTYPE_INIT
+                   || pkt_type == XQC_PTYPE_HSK))
+    {
+        is_app = XQC_FALSE;
+        err_code = TRA_APPLICATION_ERROR;
+    }
+
+    ret = xqc_gen_conn_close_frame(packet_out, err_code, is_app, 0);
     if (ret < 0) {
         xqc_log(conn->log, XQC_LOG_ERROR, "|xqc_gen_conn_close_frame error|");
         goto error;

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -1855,6 +1855,7 @@ xqc_client_conn_close_notify(xqc_connection_t *conn, const xqc_cid_t *cid, void 
     }
 
     xqc_int_t err = xqc_conn_get_errno(conn);
+    printf("conn_err_type:%d\n", (int)xqc_conn_get_err_type(conn));
     printf("should_clear_0rtt_ticket, conn_err:%d, clear_0rtt_ticket:%d\n", err, xqc_conn_should_clear_0rtt_ticket(err));
 
     xqc_conn_stats_t stats = xqc_conn_get_stats(p_ctx->engine, cid);

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -96,6 +96,12 @@ main(int argc, char *argv[])
                         xqc_test_transport_error_code_passthrough)
         || !CU_add_test(pSuite, "xqc_test_0rtt_error_wire_codes",
                         xqc_test_0rtt_error_wire_codes)
+        || !CU_add_test(pSuite,
+                        "xqc_test_conn_close_transport_crypto_namespace",
+                        xqc_test_conn_close_transport_crypto_namespace)
+        || !CU_add_test(pSuite,
+                        "xqc_test_conn_close_application_namespace",
+                        xqc_test_conn_close_application_namespace)
         || !CU_add_test(pSuite, "xqc_test_conn_tls_error_first_writer_wins", xqc_test_conn_tls_error_first_writer_wins)
         || !CU_add_test(pSuite, "xqc_test_conn_tls_error_cb_alert_zero", xqc_test_conn_tls_error_cb_alert_zero)
         || !CU_add_test(pSuite, "xqc_test_conn_tls_error_cb_max_alert", xqc_test_conn_tls_error_cb_max_alert)

--- a/tests/unittest/xqc_conn_test.c
+++ b/tests/unittest/xqc_conn_test.c
@@ -23,13 +23,61 @@
 #include "src/transport/xqc_frame_parser.h"
 #include "src/transport/xqc_packet_in.h"
 #include "src/transport/xqc_packet_out.h"
+#include "src/transport/xqc_send_queue.h"
 #include "src/transport/xqc_recv_record.h"
+#include "src/common/utils/vint/xqc_variable_len_int.h"
 
 extern void xqc_conn_tls_error_cb(xqc_int_t tls_err, void *user_data);
 
 /* forward-declare: defined in xqc_conn.c, exposed via xqc_conn_tls_cbs */
 xqc_int_t xqc_conn_tls_alpn_select_cb(const char *alpn,
     size_t alpn_len, void *user_data);
+
+static xqc_packet_out_t *xqc_test_get_conn_close_packet(
+    xqc_connection_t *conn);
+static void xqc_test_conn_close_packet_value(xqc_connection_t *conn,
+    xqc_pkt_type_t pkt_type, unsigned char frame_type, uint64_t err_code);
+
+
+static xqc_packet_out_t *
+xqc_test_get_conn_close_packet(xqc_connection_t *conn)
+{
+    xqc_list_head_t *head;
+
+    head = &conn->conn_send_queue->sndq_send_packets_high_pri;
+    if (xqc_list_empty(head)) {
+        return NULL;
+    }
+
+    return xqc_list_entry(head->prev, xqc_packet_out_t, po_list);
+}
+
+
+static void
+xqc_test_conn_close_packet_value(xqc_connection_t *conn,
+    xqc_pkt_type_t pkt_type, unsigned char frame_type, uint64_t err_code)
+{
+    xqc_packet_out_t *packet_out;
+    unsigned char *pos;
+    uint64_t parsed_err_code;
+    ssize_t len;
+
+    packet_out = xqc_test_get_conn_close_packet(conn);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(packet_out);
+    CU_ASSERT_EQUAL(packet_out->po_pkt.pkt_type, pkt_type);
+
+    pos = packet_out->po_payload;
+    CU_ASSERT_FATAL(pos < packet_out->po_buf + packet_out->po_used_size);
+    CU_ASSERT_EQUAL(*pos, frame_type);
+
+    len = xqc_vint_read(pos + 1,
+                        packet_out->po_buf + packet_out->po_used_size,
+                        &parsed_err_code);
+    CU_ASSERT(len > 0);
+    if (len > 0) {
+        CU_ASSERT_EQUAL(parsed_err_code, err_code);
+    }
+}
 
 void
 xqc_test_conn_create()
@@ -671,6 +719,82 @@ xqc_test_0rtt_error_wire_codes(void)
     CU_ASSERT_EQUAL(
         xqc_conn_close_wire_error_code(TRA_0RTT_DGRAM_PARAMS_ERROR),
         TRA_PROTOCOL_VIOLATION);
+}
+
+
+void
+xqc_test_conn_close_transport_crypto_namespace(void)
+{
+    xqc_connection_t *conn;
+
+    conn = test_engine_connect();
+    CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+
+    xqc_conn_tls_error_cb(120, conn);
+    CU_ASSERT_EQUAL(conn->conn_err, TRA_NO_APPLICATION_PROTOCOL);
+    CU_ASSERT_FALSE(XQC_CONN_ERR_IS_APPLICATION(conn->conn_err));
+    CU_ASSERT_EQUAL(xqc_conn_get_errno(conn),
+                    TRA_NO_APPLICATION_PROTOCOL);
+    CU_ASSERT_EQUAL(xqc_conn_get_err_type(conn),
+                    XQC_CONN_ERR_TYPE_UNKNOWN);
+    CU_ASSERT_EQUAL(xqc_write_conn_close_to_packet(conn, conn->conn_err),
+                    XQC_OK);
+
+    /*
+     * RFC 9000 Section 11.1: CRYPTO_ERROR is a transport error and uses
+     * CONNECTION_CLOSE type 0x1c even though its value overlaps HTTP/3.
+     */
+    xqc_test_conn_close_packet_value(conn, XQC_PTYPE_INIT, 0x1c,
+                                     TRA_NO_APPLICATION_PROTOCOL);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
+void
+xqc_test_conn_close_application_namespace(void)
+{
+    xqc_connection_t *conn;
+
+    conn = test_engine_connect();
+    CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+    conn->conn_flag |= XQC_CONN_FLAG_HANDSHAKE_COMPLETED
+                       | XQC_CONN_FLAG_HSK_ACKED;
+
+    /*
+     * Use the same numeric value as the transport CRYPTO_ERROR test above.
+     * conn_err must preserve the namespace without changing the code exposed
+     * by xqc_conn_get_errno or the peer-error-only conn_err_type API.
+     */
+    xqc_conn_close_with_error(conn, TRA_NO_APPLICATION_PROTOCOL);
+    CU_ASSERT_TRUE(XQC_CONN_ERR_IS_APPLICATION(conn->conn_err));
+    CU_ASSERT_EQUAL(xqc_conn_get_errno(conn),
+                    TRA_NO_APPLICATION_PROTOCOL);
+    CU_ASSERT_EQUAL(xqc_conn_get_err_type(conn),
+                    XQC_CONN_ERR_TYPE_UNKNOWN);
+    CU_ASSERT_EQUAL(xqc_write_conn_close_to_packet(conn, conn->conn_err),
+                    XQC_OK);
+    xqc_test_conn_close_packet_value(conn, XQC_PTYPE_SHORT_HEADER, 0x1d,
+                                     TRA_NO_APPLICATION_PROTOCOL);
+    xqc_engine_destroy(conn->engine);
+
+    conn = test_engine_connect();
+    CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+
+    xqc_conn_close_with_error(conn, H3_GENERAL_PROTOCOL_ERROR);
+    CU_ASSERT_TRUE(XQC_CONN_ERR_IS_APPLICATION(conn->conn_err));
+    CU_ASSERT_EQUAL(xqc_conn_get_errno(conn),
+                    H3_GENERAL_PROTOCOL_ERROR);
+    CU_ASSERT_EQUAL(xqc_write_conn_close_to_packet(conn, conn->conn_err),
+                    XQC_OK);
+
+    /*
+     * RFC 9000 Section 10.2.3: replace an application close in an Initial
+     * or Handshake packet with transport APPLICATION_ERROR.
+     */
+    xqc_test_conn_close_packet_value(conn, XQC_PTYPE_INIT, 0x1c,
+                                     TRA_APPLICATION_ERROR);
+    xqc_engine_destroy(conn->engine);
 }
 
 

--- a/tests/unittest/xqc_conn_test.h
+++ b/tests/unittest/xqc_conn_test.h
@@ -17,6 +17,8 @@ void xqc_test_conn_tls_error_cb_constructs_crypto_error();
 void xqc_test_conn_crypto_error_base_value();
 void xqc_test_transport_error_code_passthrough(void);
 void xqc_test_0rtt_error_wire_codes(void);
+void xqc_test_conn_close_transport_crypto_namespace(void);
+void xqc_test_conn_close_application_namespace(void);
 void xqc_test_conn_tls_error_first_writer_wins();
 void xqc_test_conn_tls_error_cb_alert_zero();
 void xqc_test_conn_tls_error_cb_max_alert();

--- a/tests/unittest/xqc_h3_test.c
+++ b/tests/unittest/xqc_h3_test.c
@@ -618,9 +618,11 @@ xqc_h3_critical_run_case(xqc_connection_t *conn, xqc_h3_conn_t *h3c,
     CU_ASSERT(ret == XQC_OK);
 
     if (tc->expected_conn_err == H3_CLOSED_CRITICAL_STREAM) {
-        CU_ASSERT(conn->conn_err == H3_CLOSED_CRITICAL_STREAM);
+        CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err)
+                  == H3_CLOSED_CRITICAL_STREAM);
     } else {
-        CU_ASSERT(conn->conn_err == tc->expected_conn_err);
+        CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err)
+                  == tc->expected_conn_err);
     }
 
     if (tc->expect_error_flag) {
@@ -740,8 +742,8 @@ xqc_test_h3_second_stream_one(uint64_t stype, uint64_t expected_err_second)
     /* second instance: must be rejected */
     ret = xqc_h3_conn_on_uni_stream_created(h3c, stype);
     CU_ASSERT(ret == -XQC_H3_INVALID_STREAM);
-    CU_ASSERT(conn->conn_err == expected_err_second);
-    CU_ASSERT(conn->conn_err == 0x103);  /* literal H3_STREAM_CREATION_ERROR */
+    CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err) == expected_err_second);
+    CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err) == 0x103);
     CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
 
     xqc_h3_conn_destroy(h3c);
@@ -773,7 +775,7 @@ xqc_test_h3_push_stream_rejected(xqc_conn_type_t conn_type,
     xqc_int_t ret = xqc_h3_conn_on_uni_stream_created(h3c,
             XQC_H3_STREAM_TYPE_PUSH);
     CU_ASSERT(ret == -XQC_H3_INVALID_STREAM);
-    CU_ASSERT(conn->conn_err == expected_err);
+    CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err) == expected_err);
     CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
 
     xqc_h3_conn_destroy(h3c);
@@ -1231,8 +1233,9 @@ xqc_test_h3_headers_capacity_uses_internal_error()
             XQC_TRUE);
 
     CU_ASSERT(ret == -XQC_H3_EPROC_REQUEST);
-    CU_ASSERT(conn->conn_err == H3_INTERNAL_ERROR);
-    CU_ASSERT(conn->conn_err == 0x102);
+    CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err) == H3_INTERNAL_ERROR);
+    CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err) == 0x102);
+    CU_ASSERT(XQC_CONN_ERR_IS_APPLICATION(conn->conn_err));
     CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
 
     xqc_h3_msgerr_teardown(h3s, h3c, conn);
@@ -1305,8 +1308,8 @@ xqc_test_h3_frame_parse_error_uses_frame_error()
             XQC_TRUE);
 
     CU_ASSERT(ret < 0);
-    CU_ASSERT(conn->conn_err == H3_FRAME_ERROR);
-    CU_ASSERT(conn->conn_err != H3_MESSAGE_ERROR);
+    CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err) == H3_FRAME_ERROR);
+    CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err) != H3_MESSAGE_ERROR);
     CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
 
     xqc_h3_msgerr_teardown(h3s, h3c, conn);
@@ -1447,7 +1450,7 @@ xqc_test_h3_cancel_push_rejected()
      */
     CU_ASSERT(xqc_h3_ctrl_feed_cancel_push(h3s, 0)
               == -XQC_H3_INVALID_CANCEL_PUSH_ID);
-    CU_ASSERT(conn->conn_err == H3_ID_ERROR);
+    CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err) == H3_ID_ERROR);
     CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
 
     xqc_h3_ctrl_test_teardown(h3s, h3c, conn);
@@ -1468,7 +1471,7 @@ xqc_test_h3_cancel_push_rejected()
      */
     CU_ASSERT(xqc_h3_ctrl_feed_cancel_push(h3s, 0)
               == -XQC_H3_INVALID_CANCEL_PUSH_ID);
-    CU_ASSERT(conn->conn_err == H3_ID_ERROR);
+    CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err) == H3_ID_ERROR);
     CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
 
     xqc_h3_ctrl_test_teardown(h3s, h3c, conn);
@@ -1517,7 +1520,7 @@ xqc_test_h3_max_push_id_errors()
     /* A client cannot receive MAX_PUSH_ID from a server. */
     CU_ASSERT(xqc_h3_ctrl_feed_max_push_id(h3s, 1)
               == -XQC_H3_INVALID_MAX_PUSH_ID);
-    CU_ASSERT(conn->conn_err == H3_FRAME_UNEXPECTED);
+    CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err) == H3_FRAME_UNEXPECTED);
     CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
     CU_ASSERT(h3c->max_stream_id_recvd == 0);
 
@@ -1535,7 +1538,7 @@ xqc_test_h3_max_push_id_errors()
     /* A decreasing value is H3_ID_ERROR and cannot replace the maximum. */
     CU_ASSERT(xqc_h3_ctrl_feed_max_push_id(h3s, 4)
               == -XQC_H3_INVALID_MAX_PUSH_ID);
-    CU_ASSERT(conn->conn_err == H3_ID_ERROR);
+    CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err) == H3_ID_ERROR);
     CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
     CU_ASSERT(h3c->max_stream_id_recvd == 5);
 
@@ -1564,7 +1567,7 @@ xqc_test_h3_ctrl_reject_data(void)
             sizeof(data_frame));
 
     CU_ASSERT(processed == -XQC_H3_CONTROL_FRAME_UNEXPECTED);
-    CU_ASSERT(conn->conn_err == H3_FRAME_UNEXPECTED);
+    CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err) == H3_FRAME_UNEXPECTED);
     CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
     CU_ASSERT(h3s->pctx.frame_pctx.state == XQC_H3_FRM_STATE_TYPE);
 
@@ -1592,7 +1595,7 @@ xqc_test_h3_ctrl_reject_zero_len_data(void)
             sizeof(zero_data));
 
     CU_ASSERT(processed == -XQC_H3_CONTROL_FRAME_UNEXPECTED);
-    CU_ASSERT(conn->conn_err == H3_FRAME_UNEXPECTED);
+    CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err) == H3_FRAME_UNEXPECTED);
     CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
     CU_ASSERT(h3s->pctx.frame_pctx.state == XQC_H3_FRM_STATE_TYPE);
 
@@ -1620,7 +1623,7 @@ xqc_test_h3_ctrl_reject_headers(void)
             sizeof(headers_frame));
 
     CU_ASSERT(processed == -XQC_H3_CONTROL_FRAME_UNEXPECTED);
-    CU_ASSERT(conn->conn_err == H3_FRAME_UNEXPECTED);
+    CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err) == H3_FRAME_UNEXPECTED);
     CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
     CU_ASSERT(h3s->pctx.frame_pctx.state == XQC_H3_FRM_STATE_TYPE);
 
@@ -1648,7 +1651,7 @@ xqc_test_h3_ctrl_reject_push_promise(void)
             sizeof(push_promise));
 
     CU_ASSERT(processed == -XQC_H3_CONTROL_FRAME_UNEXPECTED);
-    CU_ASSERT(conn->conn_err == H3_FRAME_UNEXPECTED);
+    CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err) == H3_FRAME_UNEXPECTED);
     CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
     CU_ASSERT(h3s->pctx.frame_pctx.state == XQC_H3_FRM_STATE_TYPE);
 
@@ -1676,7 +1679,7 @@ xqc_test_h3_ctrl_reject_data_before_settings(void)
             sizeof(data_frame));
 
     CU_ASSERT(processed == -XQC_H3_CONTROL_FRAME_UNEXPECTED);
-    CU_ASSERT(conn->conn_err == H3_FRAME_UNEXPECTED);
+    CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err) == H3_FRAME_UNEXPECTED);
     CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
     CU_ASSERT(h3s->pctx.frame_pctx.state == XQC_H3_FRM_STATE_TYPE);
 
@@ -1714,7 +1717,7 @@ xqc_test_h3_ctrl_goaway_then_data(void)
 
     /* DATA must be rejected */
     CU_ASSERT(processed == -XQC_H3_CONTROL_FRAME_UNEXPECTED);
-    CU_ASSERT(conn->conn_err == H3_FRAME_UNEXPECTED);
+    CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err) == H3_FRAME_UNEXPECTED);
     CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
     CU_ASSERT(h3s->pctx.frame_pctx.state == XQC_H3_FRM_STATE_TYPE);
 
@@ -1752,7 +1755,7 @@ xqc_test_h3_ctrl_reject_partial_feed(void)
     processed = xqc_h3_stream_process_control(h3s, len_byte, sizeof(len_byte));
 
     CU_ASSERT(processed == -XQC_H3_CONTROL_FRAME_UNEXPECTED);
-    CU_ASSERT(conn->conn_err == H3_FRAME_UNEXPECTED);
+    CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err) == H3_FRAME_UNEXPECTED);
     CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
     CU_ASSERT(h3s->pctx.frame_pctx.state == XQC_H3_FRM_STATE_TYPE);
 
@@ -1854,7 +1857,7 @@ xqc_test_h3_missing_settings_one(uint64_t frame_type)
             sizeof(frame_buf));
 
     CU_ASSERT(processed == -XQC_H3_MISSING_SETTINGS);
-    CU_ASSERT(conn->conn_err == H3_MISSING_SETTINGS);
+    CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err) == H3_MISSING_SETTINGS);
     CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
 
     stream->stream_flag |= XQC_STREAM_FLAG_DISCARDED;
@@ -1930,15 +1933,16 @@ xqc_test_h3_request_frame_unexpected_one(uint64_t frame_type,
         /* must return the new internal error code */
         CU_ASSERT(processed == -XQC_H3_REQUEST_FRAME_UNEXPECTED);
         /* must set the wire-level H3_FRAME_UNEXPECTED (0x0105) */
-        CU_ASSERT(conn->conn_err == H3_FRAME_UNEXPECTED);
-        CU_ASSERT(conn->conn_err == 0x0105);
+        CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err) == H3_FRAME_UNEXPECTED);
+        CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err) == 0x0105);
         /* must set the error flag so CONNECTION_CLOSE is sent */
         CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
     } else {
         /* must NOT return the frame-unexpected error */
         CU_ASSERT(processed != -XQC_H3_REQUEST_FRAME_UNEXPECTED);
         /* must NOT set H3_FRAME_UNEXPECTED */
-        CU_ASSERT(conn->conn_err != H3_FRAME_UNEXPECTED);
+        CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err)
+                  != H3_FRAME_UNEXPECTED);
     }
 
     xqc_h3_msgerr_teardown(h3s, h3c, conn);
@@ -2063,8 +2067,8 @@ xqc_test_h3_server_push_promise_rejected()
             sizeof(push_promise), XQC_FALSE);
 
     CU_ASSERT(processed == -XQC_H3_REQUEST_FRAME_UNEXPECTED);
-    CU_ASSERT(conn->conn_err == H3_FRAME_UNEXPECTED);
-    CU_ASSERT(conn->conn_err == 0x0105);
+    CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err) == H3_FRAME_UNEXPECTED);
+    CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err) == 0x0105);
     CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
 
     xqc_h3_msgerr_teardown(h3s, h3c, conn);
@@ -2087,8 +2091,8 @@ xqc_test_h3_server_push_promise_rejected()
             sizeof(push_promise), XQC_FALSE);
 
     CU_ASSERT(processed == -XQC_H3_EPROC_REQUEST);
-    CU_ASSERT(conn->conn_err == H3_FRAME_UNEXPECTED);
-    CU_ASSERT(conn->conn_err == 0x0105);
+    CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err) == H3_FRAME_UNEXPECTED);
+    CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err) == 0x0105);
     CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
 
     xqc_h3_msgerr_teardown(h3s, h3c, conn);


### PR DESCRIPTION
### Mechanism

- RFC or draft: RFC 9000 Sections 10.2.3, 11.1, and 19.19
- Preserve the transport or application namespace inside `conn_err` instead
  of inferring it from the numeric error code. The private tag is removed at
  API, callback, stats, log, and wire boundaries. Transport CRYPTO_ERROR 0x178
  remains a type 0x1c close, while application errors in Initial or Handshake
  packets are replaced by transport APPLICATION_ERROR.

Fixes: #473

### Validation Cases

- 43 — ALPN negotiation failure reports transport error 0x178.
- 1003 — HTTP/3 frame rejection reports an application error after handshake.

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Complete
- CI: Pending — Build and CodeQL
