### PR TITLE
[+]: Add issue complexity classification skill

### DIFF
--- a/harness/README.md
+++ b/harness/README.md
@@ -31,6 +31,7 @@ harness/
 - [XQUIC build skill](skills/xquic-build/SKILL.md)
 - [Validation skill](skills/validate/SKILL.md)
 - [Issue verification skill](skills/issue-check/SKILL.md)
+- [Issue complexity classification skill](skills/classify-issue-complexity/SKILL.md)
 - [Issue submission skill](skills/issue-submit/SKILL.md)
 - [Pull request pre-review skill](skills/xquic-pr-pre-review/SKILL.md)
 - [Pull request formatting skill](skills/xquic-pr-formatting/SKILL.md)

--- a/harness/docs/change-guide.md
+++ b/harness/docs/change-guide.md
@@ -9,6 +9,7 @@ Use this informative guide after locating the affected area in
 Examples:
 
 - Add a reusable skill.
+- Add or change issue classification and labeling guidance.
 - Change harness check routing.
 - Change generic schema checks.
 - Change task-local evidence layout.

--- a/harness/skills/classify-issue-complexity/SKILL.md
+++ b/harness/skills/classify-issue-complexity/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: classify-issue-complexity
+description: Classify XQUIC GitHub issues with an evidence-backed L1-L4 resolution-complexity label while keeping validity, priority, severity, and disposition separate and skipping uniquely labeled issues unless the user explicitly forces a recheck. Use when triaging one issue or a batch of issues, creating an issue-complexity backlog, or applying or correcting L1-L4 GitHub labels.
+---
+
+# Classify XQUIC Issue Complexity
+
+Estimate the work needed to resolve an issue. Do not use complexity as proof
+that a report is valid or as a proxy for priority or severity.
+
+## Select the operation
+
+- Use **preliminary triage** for backlog scans. Produce a
+  provisional level and confidence. Do not mutate issue labels unless the user
+  explicitly authorizes a batch classification and the complexity boundary is
+  high confidence for every issue being changed.
+- Use **verified classification** before applying a label. Satisfy every
+  evidence gate and resolve material uncertainty first.
+- Use **label mutation** only when the user authorizes GitHub changes. Preserve
+  unrelated labels and make no other issue mutation.
+- Use **forced recheck** only when the user explicitly asks to recheck or
+  reclassify already-labeled issues. This bypasses only the existing-label
+  skip gate; it does not authorize a GitHub mutation.
+
+## Gate repeated classification
+
+1. Read `harness/spec/issue-complexity/spec.md` in full.
+2. Resolve the repository and issue, then fetch its current labels before
+   refreshing `main`, reading source, or investigating protocol behavior.
+3. Select the labels whose names are exactly `L1`, `L2`, `L3`, or `L4`.
+4. Continue normally when no complexity label exists.
+5. When exactly one complexity label exists and no explicit forced recheck
+   applies, stop work on that issue. Report `skipped-existing-label` and the
+   existing level without rerunning classification or calling a label API. In
+   a batch, continue with the remaining issues and count the skipped row.
+6. When exactly one complexity label exists and the user explicitly forces a
+   recheck for that issue or batch scope, record the existing level and
+   continue. A general request to rerun triage is not a forced recheck.
+7. When multiple complexity labels exist, report
+   `inconsistent-existing-label` and stop without mutation.
+
+## Load evidence for issues that proceed
+
+1. Resolve the current issue state, body, comments, assignees, and milestone.
+2. Refresh the intended base and record the full `origin/main` commit SHA.
+   Classify current behavior, not a stale release or issue-provided line number.
+3. Use `harness/spec/architecture.md` and
+   `harness/spec/harness-manifest.yml` to identify affected modules, public
+   APIs, feature gates, tests, and validation boundaries.
+4. Read current source, callers, tests, and the closest module documentation.
+5. For protocol claims, read the exact RFC Editor section or exact active
+   Internet-Draft revision and section. Treat issue text and comparisons with
+   another implementation as leads, not authority.
+
+For batch triage, use issue text and focused current-source inspection for the
+first pass. Record missing evidence rather than expanding every issue into a
+full investigation.
+
+## Separate truth from complexity
+
+Route a claimed QUIC, HTTP/3, QPACK, TLS, recovery, DATAGRAM, multipath, or MoQT
+defect through `issue-check` before calling it a verified defect, closing it as
+not-a-problem, implementing a fix, or applying a high-confidence label based on
+that claim.
+
+Use these disposition values independently from the L1-L4 level:
+
+- `verified-defect`
+- `not-a-problem`
+- `duplicate-or-obsolete`
+- `feature-request`
+- `question-or-support`
+- `inconclusive`
+
+A not-a-problem closure can be L1 work. A localized interoperability defect
+can be L2 despite high severity. An unsupported major feature can be L4 even
+when no defect exists.
+
+## Choose the level
+
+Apply every scenario in `harness/spec/issue-complexity/spec.md`. Evaluate:
+
+- resolution type and whether production behavior changes;
+- affected modules, layers, public APIs, and TLS backends;
+- state-machine and lifetime complexity;
+- protocol negotiation and backward-compatibility risk;
+- paired unit-test, endpoint, and interoperability obligations; and
+- migration or ecosystem impact.
+
+Choose the highest level required by any dimension. Do not average dimensions
+or lower the level because the apparent code diff is short. If one issue mixes
+independent requests, recommend splitting it; until split, use the highest
+level and explain which sub-request controls it.
+
+Set confidence to:
+
+- `high`: current source, intended behavior, affected boundaries, and required
+  validation are established;
+- `medium`: the likely boundary is established but one non-decisive observation
+  or test obligation remains;
+- `low`: source applicability, intended behavior, protocol version, or blast
+  radius is unresolved.
+
+Only `high` confidence is eligible for label mutation. Confidence applies to
+the resolution-complexity boundary, not to whether the issue claim is true. A
+preliminary batch may contain medium or low confidence rows when their gaps
+are explicit, but those rows remain unlabelled.
+
+## Report the result
+
+For one issue, return:
+
+```yaml
+issue: <URL>
+status: classified
+existing_level: L1 | L2 | L3 | L4 | none
+forced_recheck: true | false
+inspected_main: <full SHA>
+level: L1 | L2 | L3 | L4
+confidence: high | medium | low
+disposition: <independent disposition value>
+rationale: <concise controlling complexity reason>
+affected_boundaries:
+  - <module, API, or state boundary>
+protocol:
+  source: <exact RFC/draft section or not-applicable>
+  compatibility_risk: low | medium | high
+validation:
+  unit: <paired coverage or gap>
+  endpoint: <paired coverage or gap>
+  interoperability: <evidence or gap>
+blocking_evidence:
+  - <missing evidence; empty when high confidence>
+next_action: <verification, closure explanation, design, or implementation gate>
+```
+
+For a skipped issue, return only its URL, `status: skipped-existing-label`,
+existing level, and skip reason. Do not claim current-`main` revalidation.
+
+For a batch, add one row per issue. Classified rows include issue, level,
+confidence, disposition, reason, and next action; skipped rows include issue,
+status, and existing level. Include level totals, confidence gaps, skipped
+count, and the inspected `main` SHA for classified issues. Keep full evidence
+available outside any compact summary.
+
+## Apply GitHub labels
+
+Use these repository labels exactly:
+
+| Label | Color | Description |
+|-------|-------|-------------|
+| `L1` | `5CC665` | L1 - Local change with simple logic and no peer-visible interoperability impact. |
+| `L2` | `F1F665` | L2 - Bounded feature with moderate state reasoning and verified backward-compatible peer behavior. |
+| `L3` | `EC5C03` | L3 - Complex state interactions with interoperability or potential legacy-version risk. |
+| `L4` | `481BCB` | L4 - Protocol-wide change with extreme reasoning complexity or known incompatibility. |
+
+Before mutation, restate the repository, issue, old complexity label, new
+label, inspected SHA, and confidence. Stop if multiple L1-L4 labels already
+exist or if the target label definition differs from this table.
+
+When authorized and high confidence:
+
+1. If the recommended label is already the issue's only L1-L4 label, do not
+   remove or re-add it.
+2. Otherwise, remove the prior L1-L4 label, if any, and add exactly one
+   recommended L1-L4 label.
+3. Preserve every unrelated label.
+4. Re-fetch the issue and verify the final single-label state.
+5. Report the mutation or verified no-op; do not close, edit, assign,
+   milestone, or comment on the issue unless separately requested.
+
+## Guardrails
+
+- Do not classify pull requests as issues in an age-based issue scan.
+- Do not treat a repeated batch-triage request as permission to recheck
+  uniquely labeled issues.
+- Do not expose private logs or security-sensitive reproduction details.
+- Restart active or forced classification after relevant input changes; an
+  input change alone does not permit rechecking a labeled issue.

--- a/harness/spec/PROJECT_INSTRUCTIONS.md
+++ b/harness/spec/PROJECT_INSTRUCTIONS.md
@@ -55,6 +55,7 @@ remain in the root [`README.md`](../../README.md).
 | Documentation or comment change | [Documentation style](doc-style.md) plus the closest owning spec |
 | Task evidence, command logs, failure trace | [Run artifact contract](run-artifacts.md) |
 | Verify an issue or protocol-defect claim | [`issue-check` skill](../skills/issue-check/SKILL.md) |
+| Classify issue resolution complexity or apply L1-L4 labels | [Issue-complexity specification](issue-complexity/spec.md) and [`classify-issue-complexity` skill](../skills/classify-issue-complexity/SKILL.md) |
 | Prepare or submit a GitHub issue | [`issue-submit` skill](../skills/issue-submit/SKILL.md), gated by [`issue-check`](../skills/issue-check/SKILL.md) |
 | Pre-review a code pull request | [`xquic-pr-pre-review` skill](../skills/xquic-pr-pre-review/SKILL.md), after draft PR publication and before ready-for-review state |
 | Pull request preparation or update | [Pull-request specification](pull-requests.md) and the relevant PR skill for formatting, review, comments, or CI |

--- a/harness/spec/harness-manifest.yml
+++ b/harness/spec/harness-manifest.yml
@@ -15,6 +15,7 @@ entrypoints:
   validation: scripts/validate.sh
   harness_check: harness/scripts/xqc_harness_check.sh
   openspec_long_tasks: harness/spec/openspec.md
+  issue_complexity: harness/skills/classify-issue-complexity/SKILL.md
 
 document_roles:
   specification:
@@ -54,6 +55,10 @@ global_docs:
   pull_requests:
     - harness/spec/pull-requests.md
     - harness/skills/xquic-pr-formatting/SKILL.md
+  issue_triage:
+    - harness/spec/issue-complexity/spec.md
+    - harness/skills/classify-issue-complexity/SKILL.md
+    - harness/skills/issue-check/SKILL.md
 
 test_routing:
   case_manifest: case_test/manifest.yml

--- a/harness/spec/issue-complexity/spec.md
+++ b/harness/spec/issue-complexity/spec.md
@@ -1,0 +1,165 @@
+# Issue Complexity Classification Specification
+
+## Purpose
+
+Define a repeatable, evidence-backed L1-L4 scale for XQUIC issue resolution
+complexity while preserving separate decisions about validity, priority,
+severity, and whether an issue should be closed without a code change.
+
+## Requirements
+
+### Requirement: Existing labels gate repeated classification
+
+The classifier SHALL inspect the current issue labels before starting source
+or protocol evidence collection. Exactly one existing `L1`, `L2`, `L3`, or
+`L4` label SHALL make classification idempotent by default. Only an explicit
+user instruction to force a recheck or reclassify already-labeled issues
+SHALL bypass this gate. A general request to rerun backlog triage SHALL NOT
+count as an override. The override SHALL NOT by itself authorize label or
+other issue mutations.
+
+#### Scenario: Existing unique label without an override
+
+- **WHEN** an issue has exactly one L1-L4 label and the user did not explicitly
+  force a recheck of labeled issues
+- **THEN** the classifier reports `skipped-existing-label` with the existing
+  level, preserves all labels, and does not rerun classification or call a
+  label mutation
+
+#### Scenario: User explicitly forces a recheck
+
+- **WHEN** an issue has exactly one L1-L4 label and the user explicitly asks to
+  recheck or reclassify that labeled issue
+- **THEN** the classifier records the existing level and runs the complete
+  evidence and classification workflow, while retaining the separate
+  high-confidence and mutation-authorization gates
+
+#### Scenario: Forced recheck confirms the existing level
+
+- **WHEN** a forced recheck recommends the same L1-L4 level already present
+- **THEN** the classifier preserves the existing label without removing or
+  re-adding it and reports that no mutation was required
+
+#### Scenario: Batch contains labeled and unlabeled issues
+
+- **WHEN** a batch triage contains both uniquely labeled and unlabeled issues
+  without an explicit forced-recheck scope
+- **THEN** the classifier skips the labeled issues, classifies the unlabeled
+  issues, and reports the skipped count separately
+
+### Requirement: Classification uses current evidence
+
+For every issue that proceeds to classification, the classifier SHALL record
+the issue URL and state, the inspected `main` commit SHA, relevant issue
+comments, affected source and test boundaries, and the governing RFC or
+Internet-Draft section when protocol behavior is claimed.
+
+#### Scenario: Protocol issue has sufficient evidence
+
+- **WHEN** an open issue claims a QUIC, HTTP/3, QPACK, TLS, recovery, or MoQT
+  protocol violation
+- **THEN** the classification names the exact specification section and current
+  source boundary used to estimate the resolution complexity
+
+#### Scenario: Evidence is incomplete
+
+- **WHEN** the current source boundary, protocol source, or intended behavior
+  cannot be established
+- **THEN** the classifier marks the result provisional, lowers confidence, and
+  does not mutate the GitHub complexity label
+
+### Requirement: Complexity is independent of disposition
+
+The classifier SHALL report complexity separately from issue validity,
+priority, severity, and disposition. A preliminary complexity classification
+SHALL NOT claim that a reported bug is real or authorize implementation.
+
+#### Scenario: Report is probably not a problem
+
+- **WHEN** current evidence suggests the issue can be closed as a question,
+  duplicate, obsolete report, or specification misunderstanding
+- **THEN** the classifier may assign L1 to the closure work while separately
+  requiring issue verification before posting the closing explanation
+
+#### Scenario: Small but severe protocol defect
+
+- **WHEN** a severe interoperability or security consequence has a localized
+  implementation and test boundary
+- **THEN** the classifier may assign L2 while preserving the independent high
+  severity and compatibility-risk assessment
+
+### Requirement: L1-L4 boundaries are stable
+
+The classifier SHALL assign the lowest level whose complete definition covers
+the expected resolution and SHALL use the highest affected complexity
+dimension when several dimensions differ.
+
+#### Scenario: L1 resolution
+
+- **WHEN** resolution is evidence-backed closure without production behavior,
+  documentation-only clarification, or a mechanical single-site maintenance
+  change with an established validation path
+- **THEN** the result is L1
+
+#### Scenario: L2 resolution
+
+- **WHEN** resolution is a localized single-module behavior change with a clear
+  invariant, bounded state impact, and existing unit-test surface
+- **THEN** the result is L2
+
+#### Scenario: L3 resolution
+
+- **WHEN** resolution crosses layers or modules, changes a public API or
+  compatibility boundary, modifies a non-trivial state machine, or requires
+  complex protocol/recovery reasoning and interoperability evidence
+- **THEN** the result is L3
+
+#### Scenario: L4 resolution
+
+- **WHEN** resolution adds a major feature or protocol extension, changes broad
+  negotiated wire behavior, or requires a substantial architecture or public
+  API migration
+- **THEN** the result is L4
+
+### Requirement: Label mutation is fail closed
+
+The classifier SHALL recommend exactly one of `L1`, `L2`, `L3`, or `L4` only
+after meeting the evidence gate. It SHALL preserve unrelated labels and SHALL
+not close, edit, or assign an issue unless the user separately requests that
+action.
+
+#### Scenario: Reclassifying an issue
+
+- **WHEN** high-confidence evidence changes an issue from one complexity level
+  to another and label mutation is authorized
+- **THEN** the classifier removes the prior L1-L4 label, adds exactly one new
+  level label, preserves all unrelated labels, and reports the mutation
+
+#### Scenario: Multiple complexity labels already exist
+
+- **WHEN** an issue has more than one L1-L4 label
+- **THEN** the classifier reports the inconsistent state and does not mutate it
+  until the correct single label is supported by evidence
+
+#### Scenario: Explicit batch classification
+
+- **WHEN** the user explicitly authorizes applying a batch classification and
+  the resolution-complexity boundary is high confidence for each selected issue
+- **THEN** the classifier may apply exactly one complexity label per issue even
+  when the independent defect-validity disposition remains inconclusive
+
+### Requirement: Classification output is auditable
+
+For every issue that proceeds to classification, the classifier SHALL output
+the recommended level, confidence, concise rationale, affected boundaries,
+protocol and compatibility risk, test and interop obligations, disposition
+candidate, and next verification action. For every skipped issue, it SHALL
+output the issue, `skipped-existing-label` status, existing level, and skip
+reason without claiming current-source revalidation.
+
+#### Scenario: Batch triage
+
+- **WHEN** multiple issues are classified in one triage operation
+- **THEN** the output includes one auditable row per issue plus level totals,
+  separately counted skipped rows, confidence gaps, and the inspected `main`
+  SHA for issues that proceeded to classification


### PR DESCRIPTION
### Mechanism

Add an evidence-backed L1-L4 issue-resolution complexity contract and a
repository skill that keeps complexity separate from validity, severity,
priority, and disposition. A unique existing L1-L4 label skips repeated work
unless the user explicitly forces a recheck; that override does not imply
mutation authorization. Protocol claims route through `issue-check`, while
authorized label changes remain fail closed, preserve unrelated labels, avoid
same-label churn, and require a final single-label check.

- RFC or draft: `Not applicable — no protocol or runtime behavior changes.`

### Validation Cases

- `Not applicable` — generic harness skill, specification, and routing only.

### CONTRIBUTING.md

- Overall: `Pending`
- Local regression: `Complete`
- CI: `Pending`
