### PR TITLE
[~] Fix #505: Retry path DCID synchronization

### DIFF
--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -5712,8 +5712,12 @@ xqc_conn_on_recv_retry(xqc_connection_t *conn, xqc_cid_t *retry_scid)
     /* RFC 9000 §7.3: save Retry SCID for later retry_source_connection_id validation */
     xqc_cid_copy(&conn->retry_scid, retry_scid);
 
-    /* change the DCID it uses for sending packets in response to Retry packet. */
+    /*
+     * RFC 9000 Section 17.2.5.1: subsequent packets use the Retry SCID
+     * as their DCID. The final send path reads the per-path DCID.
+     */
     xqc_cid_copy(&conn->dcid_set.current_dcid, retry_scid);
+    xqc_cid_copy(&conn->conn_initial_path->path_dcid, retry_scid);
     xqc_datagram_record_mss(conn);
     /* reset initial keys */
     ret = xqc_tls_reset_initial(conn->tls, conn->version, retry_scid);

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -279,6 +279,8 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite, "xqc_test_prefixed_str", xqc_test_prefixed_str)
         || !CU_add_test(pSuite, "xqc_test_id_hash", xqc_test_id_hash)
         || !CU_add_test(pSuite, "xqc_test_retry", xqc_test_retry)
+        || !CU_add_test(pSuite, "xqc_test_retry_same_length_dcid",
+                        xqc_test_retry_same_length_dcid)
         || !CU_add_test(pSuite, "xqc_test_receive_invalid_dgram", xqc_test_receive_invalid_dgram)
         || !CU_add_test(pSuite, "xqc_test_h3_ext_frame", xqc_test_h3_ext_frame)
 #ifdef XQC_ENABLE_FEC

--- a/tests/unittest/xqc_retry_test.c
+++ b/tests/unittest/xqc_retry_test.c
@@ -30,6 +30,8 @@ xqc_test_retry()
     xqc_connection_t *conn = test_engine_connect();
     CU_ASSERT(conn != NULL);
 
+    uint8_t initial_dcid_len = conn->conn_initial_path->path_dcid.cid_len;
+
     xqc_packet_in_t packet;
     xqc_packet_in_t *packet_in = &packet;
     memset(packet_in, 0, sizeof(*packet_in));
@@ -45,6 +47,36 @@ xqc_test_retry()
     ret = xqc_packet_parse_long_header(conn, packet_in);
     CU_ASSERT(ret == XQC_OK);
     CU_ASSERT(conn->conn_flag & XQC_CONN_FLAG_RETRY_RECVD);
+    CU_ASSERT(initial_dcid_len != packet_in->pi_pkt.pkt_scid.cid_len);
+    CU_ASSERT(xqc_cid_is_equal(&conn->dcid_set.current_dcid,
+                               &packet_in->pi_pkt.pkt_scid) == XQC_OK);
+    CU_ASSERT(xqc_cid_is_equal(&conn->conn_initial_path->path_dcid,
+                               &packet_in->pi_pkt.pkt_scid) == XQC_OK);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
+void
+xqc_test_retry_same_length_dcid()
+{
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT(conn != NULL);
+
+    xqc_cid_t retry_scid;
+    xqc_cid_copy(&retry_scid, &conn->conn_initial_path->path_dcid);
+    retry_scid.cid_buf[0] ^= 0xff;
+    CU_ASSERT(conn->conn_initial_path->path_dcid.cid_len
+              == retry_scid.cid_len);
+    CU_ASSERT(xqc_cid_is_equal(&conn->conn_initial_path->path_dcid,
+                               &retry_scid) != XQC_OK);
+
+    xqc_int_t ret = xqc_conn_on_recv_retry(conn, &retry_scid);
+    CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(xqc_cid_is_equal(&conn->dcid_set.current_dcid,
+                               &retry_scid) == XQC_OK);
+    CU_ASSERT(xqc_cid_is_equal(&conn->conn_initial_path->path_dcid,
+                               &retry_scid) == XQC_OK);
 
     xqc_engine_destroy(conn->engine);
 }

--- a/tests/unittest/xqc_retry_test.h
+++ b/tests/unittest/xqc_retry_test.h
@@ -6,5 +6,6 @@
 #define XQC_RETRY_TEST_H
 
 void xqc_test_retry();
+void xqc_test_retry_same_length_dcid();
 
 #endif


### PR DESCRIPTION
### Mechanism

- RFC or draft: [RFC 9000 Section 17.2.5.1](https://www.rfc-editor.org/rfc/rfc9000.html#section-17.2.5.1)
- Synchronize the initial path destination connection ID when a client accepts
  a Retry packet. This prevents the final short-header send path from
  restoring the pre-Retry DCID and allows conforming servers to route the
  subsequent HTTP/3 request.

Fixes: #505

### Validation Cases

- External Netty HTTP/3 — a Retry handshake is followed by a successful
  request and response exchange with the official Netty example server.
- Repository case-test gap — no targeted selector currently covers an
  external Netty Retry peer.

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Incomplete — targeted Netty case-test selector is not
  available; the complete unit suite and external interoperability run pass.
- CI: Pending
