### PR TITLE
[~] Fix #452: Align CID string documentation with exported API signatures

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -620,13 +620,13 @@ If equal, XQC_OK will be returned.
 
 #### xqc_scid_str
 ```
-unsigned char *xqc_scid_str(const xqc_cid_t *scid);
+unsigned char *xqc_scid_str(xqc_engine_t *engine, const xqc_cid_t *scid);
 ```
 Transfer scid to human-readable string.
 
 #### xqc_dcid_str
 ```
-unsigned char *xqc_dcid_str(const xqc_cid_t *dcid);
+unsigned char *xqc_dcid_str(xqc_engine_t *engine, const xqc_cid_t *dcid);
 ```
 Transfer dcid to human-readable string.
 


### PR DESCRIPTION
### Mechanism

Update the documented `xqc_scid_str` and `xqc_dcid_str` signatures to match
the exported API, which has required the `xqc_engine_t *engine` argument since
xquic v1.8.0.

Tengine has already adapted its callers to this API in
[alibaba/tengine#2020](https://github.com/alibaba/tengine/pull/2020). This PR
fixes the remaining xquic documentation mismatch.

- RFC or draft: Not applicable

Fixes: #452

### Validation Cases

- Not applicable — documentation-only change with no runtime behavior change.

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Complete
- CI: Pending
