### PR TITLE
[~] Fix #493: Evaluate the entire first Initial packet before rejecting PING

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,10 @@ endif()
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O2 -std=gnu11 -Wall ${CMAKE_C_FLAGS_OPTION} -DNDEBUG_PRINT -DNPRINT_MALLOC ")
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS} -g -O0 -std=gnu11 -Wall ${CMAKE_C_FLAGS_OPTION} -DNDEBUG_PRINT -DNPRINT_MALLOC -DXQC_DEBUG ")
 
+if(XQC_PING_ATTACK_PROTECT)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DXQC_PING_ATTACK_PROTECT")
+endif()
+
 if(ASAN)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w -fsanitize=address -fsanitize-address-use-after-scope -fno-omit-frame-pointer")
 endif()
@@ -430,4 +434,3 @@ if(CMAKE_BUILD_TYPE STREQUAL MinSizeRel)
     add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
             COMMAND ${CMAKE_STRIP} libxquic.so)
 endif()
-

--- a/harness/spec/harness-manifest.yml
+++ b/harness/spec/harness-manifest.yml
@@ -141,6 +141,20 @@ modules:
           level: targeted
           hints: [multipath, MP, MPNS]
     features:
+      ping_attack_protect:
+        paths:
+          - src/transport/xqc_frame*
+        feature_flags:
+          - XQC_PING_ATTACK_PROTECT=1
+        read:
+          - harness/spec/architecture.md
+          - tests/unittest/xqc_process_frame_test.c
+        validation:
+          level: targeted
+          unit:
+            - xqc_test_initial_ping_before_crypto_accepted
+            - xqc_test_initial_ping_without_crypto_rejected
+          hints: [frame, initial, ping]
       fec:
         paths:
           - src/transport/xqc_fec*

--- a/src/transport/xqc_frame.c
+++ b/src/transport/xqc_frame.c
@@ -206,6 +206,15 @@ xqc_process_frames(xqc_connection_t *conn, xqc_packet_in_t *packet_in)
 {
     xqc_int_t ret;
     unsigned char *last_pos = NULL;
+#ifdef XQC_PING_ATTACK_PROTECT
+    xqc_bool_t first_server_initial;
+
+    first_server_initial =
+        conn->conn_type == XQC_CONN_TYPE_SERVER
+        && conn->conn_state == XQC_CONN_STATE_SERVER_INIT
+        && packet_in->pi_pkt.pkt_type == XQC_PTYPE_INIT
+        && !(conn->conn_flag & XQC_CONN_FLAG_INIT_RECVD);
+#endif
 
     while (packet_in->pos < packet_in->last) {
         last_pos = packet_in->pos;
@@ -427,6 +436,22 @@ xqc_process_frames(xqc_connection_t *conn, xqc_packet_in_t *packet_in)
             return -XQC_ESYS;
         }
     }
+
+#ifdef XQC_PING_ATTACK_PROTECT
+    /*
+     * RFC 9000 Section 17.2.2 permits PING in Initial packets and requires
+     * the first client Initial to include CRYPTO.  Check the complete packet
+     * so acceptance does not depend on the relative order of those frames.
+     */
+    if (first_server_initial
+        && (packet_in->pi_frame_types & XQC_FRAME_BIT_PING)
+        && !(packet_in->pi_frame_types & XQC_FRAME_BIT_CRYPTO))
+    {
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|first client Initial contains PING without CRYPTO|");
+        return XQC_ERROR;
+    }
+#endif
 
     /*
      * An endpoint MUST treat receipt of a packet containing no frames as a
@@ -936,16 +961,6 @@ xqc_int_t
 xqc_process_ping_frame(xqc_connection_t *conn, xqc_packet_in_t *packet_in)
 {
     xqc_int_t ret;
-#ifdef XQC_PING_ATTACK_PROTECT
-    /* ping frame should not be the first frame in the first initial packet */
-    if (conn->conn_state == XQC_CONN_STATE_SERVER_INIT
-        && !(conn->conn_flag & XQC_CONN_FLAG_INIT_RECVD)) 
-    {
-        xqc_log(conn->log, XQC_LOG_ERROR,
-                "|xqc_process_ping_frame error: ping frame shoud not be the first frame|");
-        return XQC_ERROR; 
-    }
-#endif
 
     ret = xqc_parse_ping_frame(packet_in, conn);
     if (ret != XQC_OK) {

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -164,6 +164,14 @@ main(int argc, char *argv[])
                 || !CU_add_test(pSuite, "xqc_test_stream_frame_buffered_limit", xqc_test_stream_frame_buffered_limit)
         || !CU_add_test(pSuite, "xqc_test_process_frame", xqc_test_process_frame)
         || !CU_add_test(pSuite, "xqc_test_parse_padding_frame", xqc_test_parse_padding_frame)
+#ifdef XQC_PING_ATTACK_PROTECT
+        || !CU_add_test(pSuite,
+                        "xqc_test_initial_ping_before_crypto_accepted",
+                        xqc_test_initial_ping_before_crypto_accepted)
+        || !CU_add_test(pSuite,
+                        "xqc_test_initial_ping_without_crypto_rejected",
+                        xqc_test_initial_ping_without_crypto_rejected)
+#endif
         || !CU_add_test(pSuite, "xqc_test_large_ack_frame", xqc_test_large_ack_frame)
         /* RFC 9000 Section 19.3.1 ACK packet-number boundaries */
         || !CU_add_test(pSuite, "xqc_test_ack_range_zero_boundary",

--- a/tests/unittest/xqc_process_frame_test.c
+++ b/tests/unittest/xqc_process_frame_test.c
@@ -108,6 +108,98 @@ xqc_test_parse_padding_frame()
     xqc_engine_destroy(conn->engine);
 }
 
+
+#ifdef XQC_PING_ATTACK_PROTECT
+static xqc_connection_t *xqc_test_server_initial_connection(void);
+
+
+static xqc_connection_t *
+xqc_test_server_initial_connection(void)
+{
+    xqc_connection_t *conn = test_engine_connect();
+
+    CU_ASSERT(conn != NULL);
+    if (conn == NULL) {
+        return NULL;
+    }
+
+    conn->conn_type = XQC_CONN_TYPE_SERVER;
+    conn->conn_state = XQC_CONN_STATE_SERVER_INIT;
+    conn->conn_flag &= ~XQC_CONN_FLAG_INIT_RECVD;
+
+    return conn;
+}
+
+
+void
+xqc_test_initial_ping_before_crypto_accepted(void)
+{
+    unsigned char frames[] = {
+        0x00,                   /* PADDING */
+        0x01,                   /* PING */
+        0x00,                   /* PADDING */
+        0x06, 0x00, 0x00       /* CRYPTO, offset 0, length 0 */
+    };
+    xqc_connection_t *conn;
+    xqc_packet_in_t packet_in;
+    xqc_int_t ret;
+
+    conn = xqc_test_server_initial_connection();
+    if (conn == NULL) {
+        return;
+    }
+
+    memset(&packet_in, 0, sizeof(packet_in));
+    packet_in.pi_pkt.pkt_type = XQC_PTYPE_INIT;
+    packet_in.pos = frames;
+    packet_in.last = frames + sizeof(frames);
+
+    ret = xqc_process_frames(conn, &packet_in);
+
+    CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(packet_in.pos == packet_in.last);
+    CU_ASSERT((packet_in.pi_frame_types & XQC_FRAME_BIT_PING) != 0);
+    CU_ASSERT((packet_in.pi_frame_types & XQC_FRAME_BIT_CRYPTO) != 0);
+    CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_INIT_RECVD) != 0);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
+void
+xqc_test_initial_ping_without_crypto_rejected(void)
+{
+    unsigned char frames[] = {
+        0x00,                   /* PADDING */
+        0x01,                   /* PING */
+        0x00                    /* PADDING */
+    };
+    xqc_connection_t *conn;
+    xqc_packet_in_t packet_in;
+    xqc_int_t ret;
+
+    conn = xqc_test_server_initial_connection();
+    if (conn == NULL) {
+        return;
+    }
+
+    memset(&packet_in, 0, sizeof(packet_in));
+    packet_in.pi_pkt.pkt_type = XQC_PTYPE_INIT;
+    packet_in.pos = frames;
+    packet_in.last = frames + sizeof(frames);
+
+    ret = xqc_process_frames(conn, &packet_in);
+
+    CU_ASSERT(ret == XQC_ERROR);
+    CU_ASSERT(packet_in.pos == packet_in.last);
+    CU_ASSERT((packet_in.pi_frame_types & XQC_FRAME_BIT_PING) != 0);
+    CU_ASSERT((packet_in.pi_frame_types & XQC_FRAME_BIT_CRYPTO) == 0);
+    CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_INIT_RECVD) == 0);
+
+    xqc_engine_destroy(conn->engine);
+}
+#endif
+
 static void
 xqc_test_conn_close_error_type(unsigned char *frame, size_t frame_len,
     xqc_conn_err_type_t expected_type)

--- a/tests/unittest/xqc_process_frame_test.h
+++ b/tests/unittest/xqc_process_frame_test.h
@@ -9,6 +9,12 @@ void xqc_test_process_frame();
 
 void xqc_test_parse_padding_frame();
 
+#ifdef XQC_PING_ATTACK_PROTECT
+void xqc_test_initial_ping_before_crypto_accepted(void);
+
+void xqc_test_initial_ping_without_crypto_rejected(void);
+#endif
+
 void xqc_test_large_ack_frame();
 
 void xqc_test_ack_range_zero_boundary(void);


### PR DESCRIPTION
### Mechanism

The optional PING attack guard now evaluates the complete first client Initial
packet, accepting a permitted PING before CRYPTO while still rejecting a PING
packet that contains no CRYPTO frame. The CMake option and harness feature
profile now compile and validate the guarded path.

- RFC or draft: RFC 9000 Sections 12.4 and 17.2.2

Fixes: #493

### Validation Cases

- Not executed — the endpoint runner cannot inject raw first-Initial frame ordering.

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Incomplete — targeted raw Initial frame-order endpoint coverage is unavailable.
- CI: Pending
