### PR TITLE
[~]: Standardize harness PR publication workflow

### DIFF
--- a/harness/pipelines/dev-pipeline.md
+++ b/harness/pipelines/dev-pipeline.md
@@ -80,17 +80,23 @@ allocation snapshot.
 2. Treat the `${...}` values as descriptive placeholders. The contribution
    guide does not require underscores or define a stricter character set for
    the expanded suffix.
-3. Create the working branch from its intended base, normally `main`, before
+3. Resolve the configured remote for the intended base, normally `main`, and
+   fetch that base before creating a branch. Do not describe a stale local ref
+   as the latest base. Record the refreshed remote-tracking SHA in the task
+   evidence.
+4. Create the working branch from the refreshed remote-tracking ref before
    editing implementation files:
 
    ```bash
-   git checkout -b <branch-name> main
+   git fetch <remote> <base-branch>
+   git checkout -b <branch-name> <remote>/<base-branch>
    ```
 
-4. Verify the result with `git branch --show-current`. The prefix must match
+5. Verify the result with `git branch --show-current`. The prefix must match
    the accepted task type; the four prefixes are not interchangeable, and an
    unlisted prefix such as `feat/` does not satisfy the contribution guide.
-5. If the current branch contains unrelated local changes, preserve them and
+   Confirm that the new branch started at the refreshed remote-tracking SHA.
+6. If the current branch contains unrelated local changes, preserve them and
    isolate the task in a separate worktree or clean checkout instead of
    moving or mixing them into the new branch.
 
@@ -148,9 +154,15 @@ conflict-free.
 2. Confirm generated headers, validation artifacts, and task-scoped
    `build/harness/` issue-check reports are absent from the commit.
 3. Check that documentation links and referenced commands still resolve.
-4. Assemble the evidence required by the
+4. Unless the requester explicitly asks to stop before publication, do not end
+   the task after local validation. Use
+   [`xquic-safe-push`](../skills/xquic-safe-push/SKILL.md) for the active Git
+   task: stage only the scoped files, create a conforming commit, resolve the
+   intended push remote, and push the working branch.
+5. Assemble the evidence required by the
    [pull-request specification](../spec/pull-requests.md).
-5. Complete the repository
+6. Use [`xquic-pr-formatting`](../skills/xquic-pr-formatting/SKILL.md) to build
+   the canonical English title and complete the repository
    [pull-request template](../../.github/pull_request_template.md) as a concise
    review summary:
    - explain the changed mechanism and cite the exact RFC or draft section
@@ -162,14 +174,14 @@ conflict-free.
      and concise failing cases.
    Do not copy commands, test function names, logs, namespace ranges, tested
    SHA, or successful reservation snapshots into the PR body.
-6. After Stage 5 passes, a new code pull request may be submitted as draft, or
-   an existing pull request may be updated after a follow-up revision and kept
-   in draft. Whenever the published PR head changes because code was pushed,
-   rerun PR formatting against the current base-to-head diff and update the PR
-   summary before moving on. Use
-   [`xquic-pr-formatting`](../skills/xquic-pr-formatting/SKILL.md) when PR
-   body or state handling is the active task.
-7. Before moving a code pull request from draft to review, fetch the published
+7. After Stage 5 passes and the branch is pushed, actively create every new
+   pull request as draft, or update the existing pull request after a follow-up
+   revision and keep it in draft. Fetch the published result and verify its
+   number, URL, base, head, canonical title, body, real line breaks, and draft
+   state. Whenever a push changes the published head, rerun PR formatting
+   against the current base-to-head diff and update the summary before moving
+   on.
+8. Before moving a code pull request from draft to review, fetch the published
    pull request and verify its number, URL, base commit, head commit, title,
    body, and draft state. Run the
    [`xquic-pr-pre-review` skill](../skills/xquic-pr-pre-review/SKILL.md)
@@ -178,17 +190,17 @@ conflict-free.
    `~/build/harness/pr-review-<number>/pr-review-<number>.md`. Keep all
    reviewer-created abnormal-case code and supporting artifacts in the same
    local review directory so they can be reused in the next iteration.
-8. Continue only when the report reviews the published current head and says
+9. Continue only when the report reviews the published current head and says
    `pre_review_result: true`. Keep the complete local review directory
    unstaged and uncommitted. A changed published head invalidates the report,
    returns the pull request to this step, and may reuse retained abnormal-case
    artifacts only after rerunning them against the new head.
-9. Immediately scan open pull requests again with the published current PR
+10. Immediately scan open pull requests again with the published current PR
    included. If two PRs contain the same case ID, the lower-numbered PR keeps
    it. Keep or return every later PR to draft, then go back to Stage 2,
    reallocate the colliding ID, update the selectors and registry, and rerun
    Stage 5 before publishing another head.
-10. Reflect a post-publication collision as an incomplete local-regression
+11. Reflect a post-publication collision as an incomplete local-regression
    blocker; keep successful scan details in local evidence. Fetch the published
    pull request and verify its title, concise body, real line breaks, issue and
    RFC linkage, aggregate gates, base, head, draft or review state, and URL.
@@ -224,9 +236,10 @@ published pull request are consistent.
 10. An issue fix must not enter implementation with a false or inconclusive
     issue-check gate, and its task-scoped issue-check report must never be
     committed.
-11. A new pull request is submitted only after the Stage 5 validation gate
-    passes, and every submission or follow-up update verifies the published
-    result.
+11. Unless the requester explicitly stops publication, every scoped change
+    continues from the refreshed-base working branch through push and draft
+    pull request creation after the Stage 5 validation gate passes. Every
+    submission or follow-up update verifies the published result.
 12. Case-ID allocation fails closed unless the base, repository history, and
     all open PR heads were checked. A post-publication collision is resolved in
     favor of the lowest PR number; a later PR must reallocate and revalidate.

--- a/harness/pipelines/dev-pipeline.md
+++ b/harness/pipelines/dev-pipeline.md
@@ -162,7 +162,8 @@ conflict-free.
 5. Assemble the evidence required by the
    [pull-request specification](../spec/pull-requests.md).
 6. Use [`xquic-pr-formatting`](../skills/xquic-pr-formatting/SKILL.md) to build
-   the canonical English title and complete the repository
+   the canonical title with a concise English summary and complete the
+   repository
    [pull-request template](../../.github/pull_request_template.md) as a concise
    review summary:
    - explain the changed mechanism and cite the exact RFC or draft section

--- a/harness/scripts/xqc_harness_check.sh
+++ b/harness/scripts/xqc_harness_check.sh
@@ -368,9 +368,6 @@ require_grep \
 require_grep "\\[<change-id>\\]: <English title>" \
     "harness/spec/pull-requests.md" \
     "pull request specification defines the no-issue title shape"
-require_grep "write the complete description in English" \
-    "harness/skills/xquic-pr-formatting/SKILL.md" \
-    "PR formatting skill requires English title descriptions"
 require_manifest_schema
 require_harness_script_set
 require_grep "harness/scripts/xqc_harness_check.sh" \

--- a/harness/scripts/xqc_harness_check.sh
+++ b/harness/scripts/xqc_harness_check.sh
@@ -358,14 +358,14 @@ require_grep "development pipeline reaches its default publication stage" \
     "harness/skills/xquic-safe-push/SKILL.md" \
     "safe push permits the default publication stage"
 require_grep \
-    "\\[<change-id>\\] Fix #<issue-number>: <English title>" \
+    "\\[<change-id>\\] Fix #<issue-number>: <concise English summary>" \
     "harness/spec/pull-requests.md" \
     "pull request specification defines the issue-closing title shape"
 require_grep \
-    "\\[<change-id>\\] Fix #<issue-number>: <English title>" \
+    "\\[<change-id>\\] Fix #<issue-number>: <concise English summary>" \
     "harness/skills/xquic-pr-formatting/SKILL.md" \
     "PR formatting skill enforces the issue-closing title shape"
-require_grep "\\[<change-id>\\]: <English title>" \
+require_grep "\\[<change-id>\\]: <concise English summary>" \
     "harness/spec/pull-requests.md" \
     "pull request specification defines the no-issue title shape"
 require_manifest_schema

--- a/harness/scripts/xqc_harness_check.sh
+++ b/harness/scripts/xqc_harness_check.sh
@@ -348,6 +348,29 @@ require_grep "--feature" \
 require_grep "build/harness/runs/<task-id>" \
     "harness/spec/run-artifacts.md" \
     "run artifact contract defines canonical task evidence directory"
+require_grep "fetch that base before creating a branch" \
+    "harness/pipelines/dev-pipeline.md" \
+    "development pipeline refreshes the base before branch creation"
+require_grep "explicitly asks to stop before publication" \
+    "harness/pipelines/dev-pipeline.md" \
+    "development pipeline continues through draft PR publication by default"
+require_grep "development pipeline reaches its default publication stage" \
+    "harness/skills/xquic-safe-push/SKILL.md" \
+    "safe push permits the default publication stage"
+require_grep \
+    "\\[<change-id>\\] Fix #<issue-number>: <English title>" \
+    "harness/spec/pull-requests.md" \
+    "pull request specification defines the issue-closing title shape"
+require_grep \
+    "\\[<change-id>\\] Fix #<issue-number>: <English title>" \
+    "harness/skills/xquic-pr-formatting/SKILL.md" \
+    "PR formatting skill enforces the issue-closing title shape"
+require_grep "\\[<change-id>\\]: <English title>" \
+    "harness/spec/pull-requests.md" \
+    "pull request specification defines the no-issue title shape"
+require_grep "write the complete description in English" \
+    "harness/skills/xquic-pr-formatting/SKILL.md" \
+    "PR formatting skill requires English title descriptions"
 require_manifest_schema
 require_harness_script_set
 require_grep "harness/scripts/xqc_harness_check.sh" \

--- a/harness/skills/xquic-pr-formatting/SKILL.md
+++ b/harness/skills/xquic-pr-formatting/SKILL.md
@@ -17,9 +17,10 @@ diagnosis, review-comment fixes, or code review.
    [pull-request template](../../../.github/pull_request_template.md).
 3. Build and validate the title with the exact shape from
    [Pull Request Title](../../spec/pull-requests.md#pull-request-title): use
-   `[<change-id>] Fix #<issue-number>: <English title>` when closing an issue,
-   or `[<change-id>]: <English title>` otherwise. Allow only `+`, `-`, `=`, or
-   `~` as the change identifier, and write the complete description in English.
+   `[<change-id>] Fix #<issue-number>: <concise English summary>` when closing
+   an issue, or `[<change-id>]: <concise English summary>` otherwise. Allow only
+   `+`, `-`, `=`, or `~` as the change identifier. Use one concise English
+   sentence that describes the core change.
 4. Treat the template's three concise sections as the canonical PR body
    structure:
    mechanism, validation cases, and aggregate `CONTRIBUTING.md` status.
@@ -85,10 +86,11 @@ List cases only as:
 
 ## Pull Request Title
 
-Use `[<change-id>] Fix #<issue-number>: <English title>` for an issue-closing
-pull request and `[<change-id>]: <English title>` otherwise. The marker is one
-of `+`, `-`, `=`, or `~`. Keep the description English-only and use GitHub's
-draft state instead of adding status prefixes to the title.
+Use `[<change-id>] Fix #<issue-number>: <concise English summary>` for an
+issue-closing pull request and `[<change-id>]: <concise English summary>`
+otherwise. The marker is one of `+`, `-`, `=`, or `~`. Summarize the core change
+in one concise English sentence and use GitHub's draft state instead of adding
+status prefixes to the title.
 
 ## Guardrails
 

--- a/harness/skills/xquic-pr-formatting/SKILL.md
+++ b/harness/skills/xquic-pr-formatting/SKILL.md
@@ -15,51 +15,57 @@ diagnosis, review-comment fixes, or code review.
    [pull-request specification](../../spec/pull-requests.md).
 2. Start from the repository
    [pull-request template](../../../.github/pull_request_template.md).
-3. Treat its three concise sections as the canonical PR body structure:
+3. Build and validate the title with the exact shape from
+   [Pull Request Title](../../spec/pull-requests.md#pull-request-title): use
+   `[<change-id>] Fix #<issue-number>: <English title>` when closing an issue,
+   or `[<change-id>]: <English title>` otherwise. Allow only `+`, `-`, `=`, or
+   `~` as the change identifier, and write the complete description in English.
+4. Treat the template's three concise sections as the canonical PR body
+   structure:
    mechanism, validation cases, and aggregate `CONTRIBUTING.md` status.
-4. Check the branch name against the task-to-prefix mapping in
+5. Check the branch name against the task-to-prefix mapping in
    `CONTRIBUTING.md`, then check commit format, CLA state, rebase and squash
    state, code style, complete-unit-suite result, relevant tests, CI state, and
    issue-closing syntax.
-5. Explain the changed mechanism and cite the exact RFC or draft section for
+6. Explain the changed mechanism and cite the exact RFC or draft section for
    protocol behavior. Include the exact `Fixes: #<issue-number>` line for an
    issue fix.
-6. Verify internally that the complete local unit suite passed; a focused unit
+7. Verify internally that the complete local unit suite passed; a focused unit
    test is insufficient. In the PR, list only executed client-to-server case
    IDs and concise behavior, or concise missing case evidence.
-7. For new case IDs, require a fresh, conflict-free reservation scan across
+8. For new case IDs, require a fresh, conflict-free reservation scan across
    every other open PR's published head. Keep successful scan details in local
    evidence; expose only a concise blocker when a conflict exists.
-8. Check every `CONTRIBUTING.md` item internally. Publish one overall result,
+9. Check every `CONTRIBUTING.md` item internally. Publish one overall result,
    `Local regression: Complete` or concise failed cases, and `CI: Complete` or
    only incomplete check names.
-9. Write multiline descriptions or comments to a Markdown file first.
-10. After the development pipeline's validation gate passes and the branch is
+10. Write multiline descriptions or comments to a Markdown file first.
+11. After the development pipeline's validation gate passes and the branch is
     already pushed, create every new code pull request as draft through the
     available GitHub client using that file. Keep follow-up updates in draft
     unless the active task is to move the current published head toward review.
-11. After any code push changes the published PR head, rerun this skill against
+12. After any code push changes the published PR head, rerun this skill against
     the current base-to-head diff before the PR is updated or moved forward.
     Update the mechanism, validation cases, and aggregate gate summary so they
     describe the current code and validation evidence, not a prior head.
-12. Fetch the published pull request and confirm its number, URL, base, head,
-    title, body, real line breaks, and draft state.
-13. Verify the published PR summary matches the current base-to-head diff:
+13. Fetch the published pull request and confirm its number, URL, base, head,
+    canonical title, body, real line breaks, and draft state.
+14. Verify the published PR summary matches the current base-to-head diff:
     changed mechanism, protocol citations, issue linkage, case IDs, local gate,
     and CI status must all be current and source-backed.
-14. When the active task is to move a code PR out of draft, run
+15. When the active task is to move a code PR out of draft, run
     [`xquic-pr-pre-review`](../xquic-pr-pre-review/SKILL.md) against the
     published pull request. Read
     `~/build/harness/pr-review-<number>/pr-review-<number>.md` and require
     `pre_review_result: true` for its exact published head. Keep the report out
     of the commit and concise PR body. Preserve its sibling abnormal-case
     artifacts as local inputs to the next PR iteration.
-15. When moving a PR toward review, immediately repeat the reservation scan with
+16. When moving a PR toward review, immediately repeat the reservation scan with
     the published current PR included. If duplicate case IDs exist, the lowest
     PR number keeps them.
     Keep or return every later PR to draft and send it back through allocation
     and validation before another update.
-16. Reflect a collision as an incomplete local gate; keep successful details
+17. Reflect a collision as an incomplete local gate; keep successful details
     out of the body. Fetch the published pull request and verify its title,
     concise body, real line breaks, RFC and issue links, aggregate statuses,
     base, head, draft or review state, and URL. Update the concise body and
@@ -77,11 +83,20 @@ List cases only as:
 <case ID> — <concise behavior>
 ```
 
+## Pull Request Title
+
+Use `[<change-id>] Fix #<issue-number>: <English title>` for an issue-closing
+pull request and `[<change-id>]: <English title>` otherwise. The marker is one
+of `+`, `-`, `=`, or `~`. Keep the description English-only and use GitHub's
+draft state instead of adding status prefixes to the title.
+
 ## Guardrails
 
 - Keep claims factual and source-backed.
 - Keep the PR body concise; detailed evidence belongs in code, CI, or ignored
   local validation artifacts.
+- Do not publish a title that omits the canonical change marker, uses another
+  issue syntax, or contains a non-English description.
 - Do not use escaped newline strings for multiline GitHub content.
 - Do not claim the complete local unit suite passed when only a focused test
   ran.

--- a/harness/skills/xquic-safe-push/SKILL.md
+++ b/harness/skills/xquic-safe-push/SKILL.md
@@ -49,7 +49,10 @@ Before pushing, show:
 - commits that will be pushed
 - local uncommitted files that will remain local
 
-Push only after the user confirms, unless the same message already explicitly requested the push target and branch.
+Push when the requester explicitly asks to push or create a pull request. Also
+push when the development pipeline reaches its default publication stage and
+the requester has not asked to stop before publication. A missing, ambiguous,
+or apparently unwritable target still requires confirmation.
 
 Push to the resolved target without embedding repository ownership in the
 skill:

--- a/harness/spec/PROJECT_INSTRUCTIONS.md
+++ b/harness/spec/PROJECT_INSTRUCTIONS.md
@@ -151,8 +151,8 @@ A change is complete when:
 - the complete local unit suite passes and accepted targeted case checks pass;
 - generated and temporary artifacts are absent from the diff;
 - durable documentation and relative links remain accurate;
-- the published pull request uses the canonical English title and current
-  base-to-head evidence;
+- the published pull request uses the canonical title with a concise English
+  summary of the core change and current base-to-head evidence;
 - the PR-scoped five-part pre-review report passes, and its local review
   workspace remains uncommitted and reusable for the next iteration; and
 - the pull request contains the evidence required by

--- a/harness/spec/PROJECT_INSTRUCTIONS.md
+++ b/harness/spec/PROJECT_INSTRUCTIONS.md
@@ -82,7 +82,11 @@ tests, build scripts, validation tooling, or repository automation.
   [working-branch stage](../pipelines/dev-pipeline.md#stage-3-working-branch).
 - Match the accepted task to its exact `CONTRIBUTING.md` branch pattern;
   `dev/`, `fix/`, `perf/`, and `doc/` are not interchangeable.
-- Use a scoped working branch and submit changes through a pull request.
+- Refresh the intended remote base and create a scoped working branch from that
+  latest base before implementation.
+- Unless the requester explicitly asks to stop before publication, continue
+  after local validation through scoped commit, push, and draft pull request
+  creation.
 - Preserve unrelated user changes, staged state, and untracked files.
 - Do not edit vendored content under `third_party/`.
 - Keep generated headers, validation logs, and temporary evidence out of
@@ -147,6 +151,8 @@ A change is complete when:
 - the complete local unit suite passes and accepted targeted case checks pass;
 - generated and temporary artifacts are absent from the diff;
 - durable documentation and relative links remain accurate;
+- the published pull request uses the canonical English title and current
+  base-to-head evidence;
 - the PR-scoped five-part pre-review report passes, and its local review
   workspace remains uncommitted and reusable for the next iteration; and
 - the pull request contains the evidence required by

--- a/harness/spec/pull-requests.md
+++ b/harness/spec/pull-requests.md
@@ -23,16 +23,16 @@ evidence.
 Use exactly one title shape:
 
 ```text
-[<change-id>] Fix #<issue-number>: <English title>
-[<change-id>]: <English title>
+[<change-id>] Fix #<issue-number>: <concise English summary>
+[<change-id>]: <concise English summary>
 ```
 
 Use the first shape when the pull request closes an issue and the second when
 no issue is being closed. `<change-id>` is one `CONTRIBUTING.md` change marker:
-`+`, `-`, `=`, or `~`. Write the complete title description in English. Do not
-add alternative prefixes such as `WIP`, `Feat`, or `fix`; draft state belongs
-in GitHub metadata. An issue-closing title does not replace the exact
-standalone `Fixes: #<number>` line in the body.
+`+`, `-`, `=`, or `~`. Write one concise English sentence that describes the
+core change. Do not add alternative prefixes such as `WIP`, `Feat`, or `fix`;
+draft state belongs in GitHub metadata. An issue-closing title does not replace
+the exact standalone `Fixes: #<number>` line in the body.
 
 ## CONTRIBUTING.md Compliance
 

--- a/harness/spec/pull-requests.md
+++ b/harness/spec/pull-requests.md
@@ -18,6 +18,22 @@ before review-state movement. The mechanism, validation cases, and aggregate
 gate must describe the current base-to-head diff and current validation
 evidence.
 
+## Pull Request Title
+
+Use exactly one title shape:
+
+```text
+[<change-id>] Fix #<issue-number>: <English title>
+[<change-id>]: <English title>
+```
+
+Use the first shape when the pull request closes an issue and the second when
+no issue is being closed. `<change-id>` is one `CONTRIBUTING.md` change marker:
+`+`, `-`, `=`, or `~`. Write the complete title description in English. Do not
+add alternative prefixes such as `WIP`, `Feat`, or `fix`; draft state belongs
+in GitHub metadata. An issue-closing title does not replace the exact
+standalone `Fixes: #<number>` line in the body.
+
 ## CONTRIBUTING.md Compliance
 
 The repository [contribution guide](../../CONTRIBUTING.md) remains the
@@ -28,6 +44,8 @@ authoritative contribution contract. Check every requirement before review:
   other enhancement, or `doc/` for documentation;
 - every commit header follows `[<type>]: <subject>` with an allowed `+`, `-`,
   `=`, or `~` type;
+- the pull request title uses the canonical change marker, issue linkage when
+  applicable, and an English description;
 - the contributor has signed or will complete the CLA before merge;
 - the change follows the Nginx-derived XQUIC code style;
 - the complete local unit suite and accepted relevant tests pass;


### PR DESCRIPTION
### Mechanism

The development pipeline now refreshes the configured remote base and creates
a scoped branch before implementation. After local validation, it continues
through scoped commit, push, and draft pull request creation unless the
requester explicitly stops publication. The safe-push workflow recognizes
that default publication stage while retaining ambiguous-remote safeguards.

The pull request specification and formatting skill now require a canonical
change marker, issue linkage when applicable, and one concise English summary
of the core change. Harness self-checks prevent the branch, publication, and
title-shape contracts from drifting.

- RFC or draft: `Not applicable`

### Validation Cases

- `Not applicable` — harness documentation and deterministic self-check changes
  do not affect runtime client-to-server behavior.

### CONTRIBUTING.md

- Overall: `Pending`
- Local regression: `Complete`
- CI: `Pending — current-head checks`
