### PR TITLE
[~]: Fix connection closed log format widths

### DIFF
--- a/src/common/xqc_log_event_callback.c
+++ b/src/common/xqc_log_event_callback.c
@@ -72,17 +72,19 @@ xqc_log_CON_CONNECTION_CLOSED_callback(xqc_log_t *log, const char *func, xqc_con
             }
         }
         xqc_qlog_implement(log, CON_CONNECTION_CLOSED, func,
-                            "|err_code:%d|mtu_updatad_count:%d|pkt_dropped:%d|recent_congestion:%s|", 
-                            XQC_CONN_ERR_CODE(conn->conn_err),
-                            conn->MTU_updated_count,
-                            conn->packet_dropped_count, log_buf);
+                           "|err_code:%uL|mtu_updatad_count:%uD|"
+                           "pkt_dropped:%uL|recent_congestion:%s|",
+                           XQC_CONN_ERR_CODE(conn->conn_err),
+                           conn->MTU_updated_count,
+                           conn->packet_dropped_count, log_buf);
     }
     else{
         xqc_qlog_implement(log, CON_CONNECTION_CLOSED, func,
-                            "|err_code:%d|mtu_updatad_count:%d|pkt_dropped:%d|", 
-                            XQC_CONN_ERR_CODE(conn->conn_err),
-                            conn->MTU_updated_count,
-                            conn->packet_dropped_count);
+                           "|err_code:%uL|mtu_updatad_count:%uD|"
+                           "pkt_dropped:%uL|",
+                           XQC_CONN_ERR_CODE(conn->conn_err),
+                           conn->MTU_updated_count,
+                           conn->packet_dropped_count);
     }
 }
 

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -106,6 +106,10 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite, "xqc_test_conn_tls_error_cb_alert_zero", xqc_test_conn_tls_error_cb_alert_zero)
         || !CU_add_test(pSuite, "xqc_test_conn_tls_error_cb_max_alert", xqc_test_conn_tls_error_cb_max_alert)
         || !CU_add_test(pSuite, "xqc_test_pq", xqc_test_pq)
+        || !CU_add_test(pSuite, "xqc_test_connection_closed_log_no_error",
+                        xqc_test_connection_closed_log_no_error)
+        || !CU_add_test(pSuite, "xqc_test_connection_closed_log_with_error",
+                        xqc_test_connection_closed_log_with_error)
         || !CU_add_test(pSuite, "xqc_test_common", xqc_test_common)
         || !CU_add_test(pSuite, "xqc_test_vint", xqc_test_vint)
         || !CU_add_test(pSuite, "xqc_test_flow_ctl_clamp_boundary", xqc_test_flow_ctl_clamp_boundary)

--- a/tests/unittest/xqc_common_test.c
+++ b/tests/unittest/xqc_common_test.c
@@ -10,6 +10,10 @@
 #include "src/common/xqc_object_manager.h"
 #include "src/common/xqc_rbtree.h"
 #include "src/common/xqc_fifo.h"
+#include "src/common/xqc_log_event_callback.h"
+#include "src/transport/xqc_conn.h"
+#include "src/transport/xqc_multipath.h"
+#include "src/transport/xqc_send_ctl.h"
 
 
 typedef struct person_s {
@@ -23,6 +27,80 @@ typedef struct xqc_item_s {
     xqc_list_head_t list;
     int data;
 } xqc_item_t;
+
+typedef struct xqc_test_log_capture_s {
+    unsigned char   buf[XQC_MAX_LOG_LEN];
+    size_t          size;
+} xqc_test_log_capture_t;
+
+static void
+xqc_test_qlog_write(qlog_event_importance_t imp, const void *buf, size_t size,
+    void *user_data)
+{
+    xqc_test_log_capture_t  *capture = user_data;
+    size_t                   copy_size;
+
+    (void) imp;
+    copy_size = xqc_min(size, sizeof(capture->buf) - 1);
+    memcpy(capture->buf, buf, copy_size);
+    capture->buf[copy_size] = '\0';
+    capture->size = copy_size;
+}
+
+static void
+xqc_test_connection_closed_log(xqc_connection_t *conn, const char *expected)
+{
+    xqc_test_log_capture_t  capture = {0};
+    xqc_log_callbacks_t     callbacks = {0};
+    xqc_log_t               log = {0};
+
+    callbacks.xqc_qlog_event_write = xqc_test_qlog_write;
+    log.log_event = 1;
+    log.qlog_importance = EVENT_IMPORTANCE_BASE;
+    log.log_callbacks = &callbacks;
+    log.user_data = &capture;
+
+    xqc_log_CON_CONNECTION_CLOSED_callback(&log, "xqc_test", conn);
+
+    CU_ASSERT(capture.size > 0);
+    CU_ASSERT_STRING_EQUAL(capture.buf, expected);
+}
+
+void
+xqc_test_connection_closed_log_no_error(void)
+{
+    xqc_connection_t  conn = {0};
+
+    conn.MTU_updated_count = 0xffffffffu;
+    conn.packet_dropped_count = 0xffffffffffffffffULL;
+
+    xqc_test_connection_closed_log(
+        &conn,
+        "|xqc_test|err_code:0|mtu_updatad_count:4294967295|"
+        "pkt_dropped:18446744073709551615|");
+}
+
+void
+xqc_test_connection_closed_log_with_error(void)
+{
+    xqc_connection_t  conn = {0};
+    xqc_path_ctx_t     path = {0};
+    xqc_send_ctl_t     send_ctl = {0};
+
+    xqc_init_list_head(&conn.conn_paths_list);
+    path.path_id = 7;
+    path.path_send_ctl = &send_ctl;
+    xqc_list_add_tail(&path.path_list, &conn.conn_paths_list);
+
+    conn.conn_err = 0x100000002ULL;
+    conn.MTU_updated_count = 0xffffffffu;
+    conn.packet_dropped_count = 0x100000004ULL;
+
+    xqc_test_connection_closed_log(
+        &conn,
+        "|xqc_test|err_code:4294967298|mtu_updatad_count:4294967295|"
+        "pkt_dropped:4294967300|recent_congestion:<path:7, (0,0,0)>|");
+}
 
 static inline void
 test_object_manager_cb(xqc_object_t *o)
@@ -352,4 +430,3 @@ test_engine_connect()
     xqc_connection_t *conn = test_connect(engine);
     return conn;
 }
-

--- a/tests/unittest/xqc_common_test.h
+++ b/tests/unittest/xqc_common_test.h
@@ -12,6 +12,8 @@
 #include "src/transport/xqc_engine.h"
 
 void xqc_test_common();
+void xqc_test_connection_closed_log_no_error(void);
+void xqc_test_connection_closed_log_with_error(void);
 const xqc_cid_t *test_cid_connect(xqc_engine_t *engine);
 xqc_connection_t *test_engine_connect();
 xqc_engine_t *test_create_engine();


### PR DESCRIPTION
### Mechanism

Correct the connection-close event formatter to consume the connection error
and packet-drop counters with the logger's 64-bit unsigned conversion, and the
MTU update counter with its 32-bit unsigned conversion. This preserves the
full values and avoids incompatible variadic reads.

- RFC or draft: `Not applicable — this changes local event-log rendering only`

Fixes: #500

### Validation Cases

- Not applicable — local event-log rendering has no client-to-server case

### CONTRIBUTING.md

- Overall: `Pending`
- Local regression: `Complete`
- CI: `Pending`
