### PR TITLE
[~] Fix #579: Use 1 ms recovery timer granularity

### DIFF
--- a/src/transport/xqc_send_ctl.h
+++ b/src/transport/xqc_send_ctl.h
@@ -20,10 +20,9 @@
 
 #define XQC_CONSECUTIVE_PTO_THRESH          2
 /*
- * Timer granularity.  This is a system-dependent value.
- * However, implementations SHOULD use a value no smaller than 1ms.
+ * RFC 9002 Section 6.1.2 recommends a timer granularity of 1 ms.
  */
-#define XQC_kGranularity                    2
+#define XQC_kGranularity                    1
 
 #define XQC_kInitialRtt_us                  250000
 

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -313,6 +313,12 @@ main(int argc, char *argv[])
                         xqc_test_pto_remote_default_when_unset)
         || !CU_add_test(pSuite, "xqc_test_send_ctl_update_rtt_ack_delay_cap",
                         xqc_test_send_ctl_update_rtt_ack_delay_cap)
+        || !CU_add_test(pSuite,
+                        "xqc_test_send_ctl_granularity_marks_at_boundary",
+                        xqc_test_send_ctl_granularity_marks_at_boundary)
+        || !CU_add_test(pSuite,
+                        "xqc_test_send_ctl_granularity_defers_before_boundary",
+                        xqc_test_send_ctl_granularity_defers_before_boundary)
         /* issue #739: persistent-congestion RTT reset (RFC 9002 §5.2) */
         || !CU_add_test(pSuite, "xqc_test_send_ctl_persistent_congestion_resets_rtt",
                         xqc_test_send_ctl_persistent_congestion_resets_rtt)

--- a/tests/unittest/xqc_send_ctl_test.c
+++ b/tests/unittest/xqc_send_ctl_test.c
@@ -383,6 +383,63 @@ xqc_test_send_ctl_seed_lost_packet(xqc_connection_t *conn,
 }
 
 
+void
+xqc_test_send_ctl_granularity_marks_at_boundary(void)
+{
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_FATAL(conn != NULL);
+    CU_ASSERT_FATAL(conn->conn_initial_path != NULL);
+
+    xqc_send_ctl_t *send_ctl = conn->conn_initial_path->path_send_ctl;
+    CU_ASSERT_FATAL(send_ctl != NULL);
+
+    send_ctl->ctl_srtt = 0;
+    send_ctl->ctl_latest_rtt = 0;
+    send_ctl->ctl_largest_acked[XQC_PNS_APP_DATA] = 100;
+    send_ctl->ctl_reordering_packet_threshold = XQC_kPacketThreshold;
+
+    xqc_packet_out_t *po = xqc_test_send_ctl_seed_lost_packet(conn, 99, 1);
+    CU_ASSERT_FATAL(po != NULL);
+
+    xqc_send_ctl_detect_lost(send_ctl, conn->conn_send_queue,
+                             XQC_PNS_APP_DATA, 1001);
+
+    CU_ASSERT_EQUAL(conn->detected_loss_cnt, 1);
+    CU_ASSERT_EQUAL(send_ctl->sampler.loss, 1);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
+void
+xqc_test_send_ctl_granularity_defers_before_boundary(void)
+{
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_FATAL(conn != NULL);
+    CU_ASSERT_FATAL(conn->conn_initial_path != NULL);
+
+    xqc_send_ctl_t *send_ctl = conn->conn_initial_path->path_send_ctl;
+    CU_ASSERT_FATAL(send_ctl != NULL);
+
+    send_ctl->ctl_srtt = 0;
+    send_ctl->ctl_latest_rtt = 0;
+    send_ctl->ctl_largest_acked[XQC_PNS_APP_DATA] = 100;
+    send_ctl->ctl_reordering_packet_threshold = XQC_kPacketThreshold;
+
+    xqc_packet_out_t *po = xqc_test_send_ctl_seed_lost_packet(conn, 99, 1);
+    CU_ASSERT_FATAL(po != NULL);
+
+    xqc_send_ctl_detect_lost(send_ctl, conn->conn_send_queue,
+                             XQC_PNS_APP_DATA, 1000);
+
+    CU_ASSERT_EQUAL(conn->detected_loss_cnt, 0);
+    CU_ASSERT_EQUAL(send_ctl->sampler.loss, 0);
+    CU_ASSERT_EQUAL(send_ctl->ctl_loss_time[XQC_PNS_APP_DATA], 1001);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
 /*
  * Build a send_ctl state that satisfies xqc_send_ctl_in_persistent_congestion:
  *   - pto_count == XQC_CONSECUTIVE_PTO_THRESH

--- a/tests/unittest/xqc_send_ctl_test.h
+++ b/tests/unittest/xqc_send_ctl_test.h
@@ -22,6 +22,13 @@ void xqc_test_pto_remote_default_when_unset(void);
 void xqc_test_send_ctl_update_rtt_ack_delay_cap(void);
 
 /*
+ * RFC 9002 Section 6.1.2 recommends a 1 ms timer granularity. Verify that
+ * time-threshold loss detection fires at that boundary, but not before it.
+ */
+void xqc_test_send_ctl_granularity_marks_at_boundary(void);
+void xqc_test_send_ctl_granularity_defers_before_boundary(void);
+
+/*
  * Regression tests for issue #739 (RFC 9002 5.2):
  * After persistent congestion is detected the RTT estimator on the
  * affected path must be reset, and the next RTT sample must re-seed


### PR DESCRIPTION
### Mechanism

- Use the RFC 9002 Section 6.1.2 recommended 1 ms recovery timer granularity,
  reducing the minimum time-threshold loss detection and PTO floor from 2 ms
  to 1 ms.
- Add paired unit coverage for loss detection at the exact boundary and
  immediately before it.

- RFC or draft: RFC 9002 Section 6.1.2

Fixes: #579

### Validation Cases

- Not applicable — no deterministic client-to-server case can assert a local
  1 ms sender timer boundary.

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Incomplete — endpoint-specific timer-boundary case gap
- CI: Pending
