### PR TITLE
[~]: Stabilize H3 field section case close wait

### DIFF
--- a/case_test/README.md
+++ b/case_test/README.md
@@ -264,6 +264,11 @@ case_test_case "negotiate_encoder_fec_scheme" \
     --run fec_negotiate_encoder_fec_scheme
 ```
 
+When a server callback can run after the client process exits, use
+`case_test_wait_for_log <file> <pattern> [attempts] [interval]` for a bounded
+wait instead of a fixed sleep. Redirect server stdout to `svr_stdlog` when the
+case needs that output so the per-case snapshot preserves the asserted log.
+
 The runner injects group-shared environment before executing the script:
 
 - `CASE_TEST_GROUP`

--- a/case_test/http3/core.sh
+++ b/case_test/http3/core.sh
@@ -1027,23 +1027,27 @@ fi
 case_http3_core_h3_field_section_over_limit_is_stream_error()
 {
 
+local server_close_pattern
+
 case_test_stop_server
 clear_log
 rm -f test_session xqc_token tp_localhost h3_field_section_server.log
-case_test_start_server ${SERVER_BIN} -l d -e -x 1012 > h3_field_section_server.log
+case_test_start_server ${SERVER_BIN} -l d -e -x 1012 > svr_stdlog
 sleep 1
 echo -e "HTTP/3 oversized fields reset one stream only ...\c"
 ${CLIENT_BIN} -s 1024 -l d -t 1 -E -P 2 -n 2 -x 1012 > stdlog
+server_close_pattern="\\[h3-field-section-test\\]|server_conn_close|"\
+"case:1012|conn_err:0|"
+case_test_wait_for_log svr_stdlog "${server_close_pattern}" 30 0.1
 oversized=`grep "\\[h3-field-section-test\\]|oversized_request_sent|" stdlog`
 stream_reset=`grep "\\[h3-field-section-test\\]|server_stream_close|"\
-".*|stream_err:270|" h3_field_section_server.log`
+".*|stream_err:270|" svr_stdlog`
 peer_error=`grep "\\[h3-field-section-test\\]|client_stream_closing|"\
 ".*|err:270|" stdlog`
 received_count=`grep -c "\\[h3-field-section-test\\]|request_received|" \
-    h3_field_section_server.log`
+    svr_stdlog`
 success_count=`grep -c ">>>>>>>> pass:1" stdlog`
-server_ok=`grep "\\[h3-field-section-test\\]|server_conn_close|case:1012|"\
-"conn_err:0|" h3_field_section_server.log`
+server_ok=`grep "${server_close_pattern}" svr_stdlog`
 client_ok=`grep "\\[h3-field-section-test\\]|client_conn_close|case:1012|"\
 "conn_err:0|" stdlog`
 if [ -n "$oversized" ] && [ -n "$stream_reset" ] \

--- a/case_test/lib/architecture_check.rb
+++ b/case_test/lib/architecture_check.rb
@@ -5,7 +5,7 @@ require "fileutils"
 require "open3"
 require "yaml"
 
-root = ARGV.shift || abort("usage: architecture_check.rb <repo-root> [--ownership|--runner-syntax|--parallel-selftest|--run-dir-selftest|--case-filter-run-dir-selftest|--case-filter-missing-selftest|--event-dedupe-selftest|--coverage-mismatch-selftest|--build-gate-selftest|--parallel-budget-selftest|--parallel-failure-selftest|--case-timeout-selftest|--background-fd-selftest|--all]")
+root = ARGV.shift || abort("usage: architecture_check.rb <repo-root> [--ownership|--runner-syntax|--parallel-selftest|--run-dir-selftest|--case-filter-run-dir-selftest|--case-filter-missing-selftest|--event-dedupe-selftest|--coverage-mismatch-selftest|--build-gate-selftest|--parallel-budget-selftest|--parallel-failure-selftest|--case-timeout-selftest|--background-fd-selftest|--wait-for-log-selftest|--all]")
 modes = ARGV.empty? ? ["--all"] : ARGV
 
 def run!(env, *cmd)
@@ -831,6 +831,32 @@ def background_fd_selftest(root)
   puts "elapsed_seconds=#{format("%.3f", elapsed)}"
 end
 
+def wait_for_log_selftest(root)
+  work_dir = File.join(root, "build/case_test_arch_check_wait_for_log")
+  FileUtils.rm_rf(work_dir)
+  FileUtils.mkdir_p(work_dir)
+
+  log_path = File.join(work_dir, "marker.log")
+  script_path = File.join(work_dir, "selftest_wait_for_log.sh")
+  File.write(script_path, <<~SH)
+    #!/bin/bash
+    set -u
+    source #{File.join(root, "case_test/lib/common.sh").inspect}
+    : > #{log_path.inspect}
+    (sleep 0.2; echo "delayed-marker" >> #{log_path.inspect}) &
+    writer_pid="$!"
+    case_test_wait_for_log #{log_path.inspect} "delayed-marker" 20 0.05
+    wait "${writer_pid}"
+    if case_test_wait_for_log #{log_path.inspect} "missing-marker" 2 0.05; then
+        exit 1
+    fi
+  SH
+  FileUtils.chmod("+x", script_path)
+
+  run!({}, "bash", script_path)
+  puts "wait_for_log_selftest=pass"
+end
+
 def parallel_budget_selftest(root)
   work_dir = File.join(root, "build/case_test_arch_check_budget")
   FileUtils.rm_rf(work_dir)
@@ -949,4 +975,8 @@ end
 
 if modes.include?("--all") || modes.include?("--background-fd-selftest")
   background_fd_selftest(root)
+end
+
+if modes.include?("--all") || modes.include?("--wait-for-log-selftest")
+  wait_for_log_selftest(root)
 end

--- a/case_test/lib/common.sh
+++ b/case_test/lib/common.sh
@@ -391,6 +391,26 @@ case_test_start_server()
     sleep "${CASE_TEST_SERVER_WAIT:-1}"
 }
 
+case_test_wait_for_log()
+{
+    local log_file="$1"
+    local pattern="$2"
+    local attempts="${3:-20}"
+    local interval="${4:-0.1}"
+    local attempt=0
+
+    while [[ "${attempt}" -lt "${attempts}" ]]; do
+        if grep -q -- "${pattern}" "${log_file}" 2> /dev/null; then
+            return 0
+        fi
+
+        sleep "${interval}"
+        attempt=$((attempt + 1))
+    done
+
+    return 1
+}
+
 case_test_require_sudo()
 {
     if ! sudo -n true 2> /dev/null; then


### PR DESCRIPTION
### Mechanism

- RFC or draft: `Not applicable`
- Wait a bounded time for the asynchronous server connection-close marker,
  and capture the asserted server stdout in the canonical case artifact.

### Validation Cases

- `1012` — an oversized field section resets only the affected stream while a
  second request succeeds and the connection closes without error

### CONTRIBUTING.md

- Overall: `Pending`
- Local regression: `Complete`
- CI: `Pending`
