### PR TITLE
[~] Fix #536: Validate coalesced Initial packets by datagram size

### DIFF
--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -5107,6 +5107,7 @@ xqc_conn_process_packet(xqc_connection_t *c,
         xqc_packet_in_t *packet_in = &packet;
         memset(packet_in, 0, sizeof(*packet_in));
         xqc_packet_in_init(packet_in, pos, end - pos, decrypt_payload, XQC_MAX_PACKET_IN_LEN, recv_time);
+        packet_in->datagram_size = packet_in_size;
 
         packet_in->pi_path_id = XQC_UNKNOWN_PATH_ID;
 

--- a/src/transport/xqc_packet_in.c
+++ b/src/transport/xqc_packet_in.c
@@ -17,6 +17,7 @@ xqc_packet_in_init(xqc_packet_in_t *packet_in,
 {
     packet_in->buf = packet_in_buf;
     packet_in->buf_size = packet_in_size;
+    packet_in->datagram_size = packet_in_size;
     packet_in->decode_payload = decode_payload;
     packet_in->decode_payload_size = decode_payload_size;
     packet_in->pos = (unsigned char *)packet_in_buf;
@@ -31,4 +32,3 @@ xqc_packet_in_destroy(xqc_packet_in_t *packet_in, xqc_connection_t *conn)
     xqc_free((void *)packet_in->decode_payload);
     xqc_free(packet_in);
 }
-

--- a/src/transport/xqc_packet_in.h
+++ b/src/transport/xqc_packet_in.h
@@ -22,6 +22,7 @@ struct xqc_packet_in_s {
     xqc_list_head_t         pi_list;
     const unsigned char    *buf;
     size_t                  buf_size;
+    size_t                  datagram_size;
     unsigned char          *decode_payload;
     size_t                  decode_payload_size;
     size_t                  decode_payload_len;

--- a/src/transport/xqc_packet_parser.c
+++ b/src/transport/xqc_packet_parser.c
@@ -461,11 +461,11 @@ xqc_packet_parse_initial(xqc_connection_t *c, xqc_packet_in_t *packet_in)
     packet_in->pi_pkt.pkt_type = XQC_PTYPE_INIT;
     packet_in->pi_pkt.pkt_pns = XQC_PNS_INIT;
 
-    /* The smallest length of udp datagrams carrying initial packet frome client is 1200  */
+    /* RFC 9000 Section 14.1 applies the minimum to the UDP datagram. */
     if (c->conn_type == XQC_CONN_TYPE_SERVER) {
-        if (XQC_BUFF_LEFT_SIZE(packet_in->buf, end) < XQC_PACKET_INITIAL_MIN_LENGTH) {
+        if (packet_in->datagram_size < XQC_PACKET_INITIAL_MIN_LENGTH) {
             xqc_log(c->log, XQC_LOG_ERROR, "|initial size too small|%z|",
-                    (size_t)XQC_BUFF_LEFT_SIZE(packet_in->buf, end));
+                    packet_in->datagram_size);
             XQC_CONN_ERR(c, TRA_PROTOCOL_VIOLATION);
             return -XQC_EILLPKT;
         }

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -151,6 +151,11 @@ main(int argc, char *argv[])
                         xqc_test_coalesced_matching_dcid_processed)
         || !CU_add_test(pSuite, "xqc_test_coalesced_mismatching_dcid_ignored",
                         xqc_test_coalesced_mismatching_dcid_ignored)
+        || !CU_add_test(pSuite, "xqc_test_coalesced_initial_datagram_minimum",
+                        xqc_test_coalesced_initial_datagram_minimum)
+        || !CU_add_test(pSuite,
+                        "xqc_test_coalesced_initial_datagram_too_small",
+                        xqc_test_coalesced_initial_datagram_too_small)
         || !CU_add_test(pSuite, "xqc_test_transport_params", xqc_test_transport_params)
         || !CU_add_test(pSuite, "xqc_test_max_ack_delay_default_when_absent",
                         xqc_test_max_ack_delay_default_when_absent)

--- a/tests/unittest/xqc_packet_test.c
+++ b/tests/unittest/xqc_packet_test.c
@@ -529,7 +529,7 @@ xqc_test_coalesced_teardown(test_ctx *cli, test_ctx *svr)
 static size_t
 xqc_test_build_initial(test_ctx *cli, const xqc_cid_t *dcid,
     xqc_packet_number_t packet_number, xqc_bool_t connection_close,
-    unsigned char *buf, size_t buf_cap)
+    size_t packet_size, unsigned char *buf, size_t buf_cap)
 {
     xqc_packet_out_t *packet_out;
     size_t encrypted_size = 0;
@@ -571,12 +571,12 @@ xqc_test_build_initial(test_ctx *cli, const xqc_cid_t *dcid,
     }
 
     if (packet_out->po_used_size + XQC_TLS_AEAD_OVERHEAD_MAX_LEN
-        >= XQC_TEST_COALESCED_PACKET_SIZE)
+        >= packet_size)
     {
         goto end;
     }
 
-    padding_size = XQC_TEST_COALESCED_PACKET_SIZE
+    padding_size = packet_size
                    - packet_out->po_used_size
                    - XQC_TLS_AEAD_OVERHEAD_MAX_LEN;
     memset(packet_out->po_buf + packet_out->po_used_size, 0, padding_size);
@@ -615,10 +615,10 @@ xqc_test_coalesced_matching_dcid_processed(void)
 
     first_size = xqc_test_build_initial(
         &cli, &cli.c->dcid_set.current_dcid, 1, XQC_FALSE,
-        first, sizeof(first));
+        XQC_TEST_COALESCED_PACKET_SIZE, first, sizeof(first));
     second_size = xqc_test_build_initial(
         &cli, &cli.c->dcid_set.current_dcid, 2, XQC_TRUE,
-        second, sizeof(second));
+        XQC_TEST_COALESCED_PACKET_SIZE, second, sizeof(second));
     CU_ASSERT_NOT_EQUAL(first_size, 0);
     CU_ASSERT_NOT_EQUAL(second_size, 0);
     if (first_size == 0 || second_size == 0) {
@@ -674,9 +674,13 @@ xqc_test_coalesced_mismatching_dcid_ignored(void)
     dropped_count = svr.c->packet_dropped_count;
 
     first_size = xqc_test_build_initial(&cli, &matching_dcid, 1,
-                                        XQC_FALSE, first, sizeof(first));
+                                        XQC_FALSE,
+                                        XQC_TEST_COALESCED_PACKET_SIZE,
+                                        first, sizeof(first));
     second_size = xqc_test_build_initial(&cli, &mismatching_dcid, 2,
-                                         XQC_TRUE, second, sizeof(second));
+                                         XQC_TRUE,
+                                         XQC_TEST_COALESCED_PACKET_SIZE,
+                                         second, sizeof(second));
     CU_ASSERT_NOT_EQUAL(first_size, 0);
     CU_ASSERT_NOT_EQUAL(second_size, 0);
     if (first_size == 0 || second_size == 0) {
@@ -695,11 +699,17 @@ xqc_test_coalesced_mismatching_dcid_ignored(void)
     CU_ASSERT_EQUAL(svr.c->packet_dropped_count, dropped_count);
 
     first_size = xqc_test_build_initial(&cli, &matching_dcid, 3,
-                                        XQC_FALSE, first, sizeof(first));
+                                        XQC_FALSE,
+                                        XQC_TEST_COALESCED_PACKET_SIZE,
+                                        first, sizeof(first));
     second_size = xqc_test_build_initial(&cli, &mismatching_dcid, 4,
-                                         XQC_FALSE, second, sizeof(second));
+                                         XQC_FALSE,
+                                         XQC_TEST_COALESCED_PACKET_SIZE,
+                                         second, sizeof(second));
     third_size = xqc_test_build_initial(&cli, &matching_dcid, 5,
-                                        XQC_TRUE, third, sizeof(third));
+                                        XQC_TRUE,
+                                        XQC_TEST_COALESCED_PACKET_SIZE,
+                                        third, sizeof(third));
     CU_ASSERT_NOT_EQUAL(first_size, 0);
     CU_ASSERT_NOT_EQUAL(second_size, 0);
     CU_ASSERT_NOT_EQUAL(third_size, 0);
@@ -721,6 +731,103 @@ xqc_test_coalesced_mismatching_dcid_ignored(void)
     CU_ASSERT_NOT_EQUAL(svr.c->conn_close_recv_time, 0);
     CU_ASSERT(svr.c->conn_state >= XQC_CONN_STATE_DRAINING);
     CU_ASSERT_EQUAL(svr.c->packet_dropped_count, dropped_count);
+
+    xqc_test_coalesced_teardown(&cli, &svr);
+}
+
+
+void
+xqc_test_coalesced_initial_datagram_minimum(void)
+{
+    test_ctx cli = {0};
+    test_ctx svr = {0};
+    unsigned char first[XQC_PACKET_INITIAL_MIN_LENGTH];
+    unsigned char second[XQC_PACKET_INITIAL_MIN_LENGTH];
+    unsigned char datagram[XQC_PACKET_INITIAL_MIN_LENGTH];
+    size_t packet_size = XQC_PACKET_INITIAL_MIN_LENGTH / 2;
+    size_t first_size;
+    size_t second_size;
+    xqc_int_t ret;
+
+    ret = xqc_test_coalesced_setup(&cli, &svr);
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    if (ret != XQC_OK) {
+        xqc_test_coalesced_teardown(&cli, &svr);
+        return;
+    }
+
+    first_size = xqc_test_build_initial(
+        &cli, &cli.c->dcid_set.current_dcid, 1, XQC_FALSE, packet_size,
+        first, sizeof(first));
+    second_size = xqc_test_build_initial(
+        &cli, &cli.c->dcid_set.current_dcid, 2, XQC_TRUE, packet_size,
+        second, sizeof(second));
+    CU_ASSERT_EQUAL(first_size, packet_size);
+    CU_ASSERT_EQUAL(second_size, packet_size);
+    if (first_size != packet_size || second_size != packet_size) {
+        xqc_test_coalesced_teardown(&cli, &svr);
+        return;
+    }
+
+    memcpy(datagram, first, first_size);
+    memcpy(datagram + first_size, second, second_size);
+
+    /* RFC 9000 Sections 12.2 and 14.1 allow expansion by coalescing. */
+    ret = xqc_conn_process_packet(svr.c, datagram, sizeof(datagram),
+                                  xqc_now());
+
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    CU_ASSERT_NOT_EQUAL(svr.c->conn_close_recv_time, 0);
+    CU_ASSERT(svr.c->conn_state >= XQC_CONN_STATE_DRAINING);
+
+    xqc_test_coalesced_teardown(&cli, &svr);
+}
+
+
+void
+xqc_test_coalesced_initial_datagram_too_small(void)
+{
+    test_ctx cli = {0};
+    test_ctx svr = {0};
+    unsigned char first[XQC_PACKET_INITIAL_MIN_LENGTH];
+    unsigned char second[XQC_PACKET_INITIAL_MIN_LENGTH];
+    unsigned char datagram[XQC_PACKET_INITIAL_MIN_LENGTH - 1];
+    size_t first_packet_size = XQC_PACKET_INITIAL_MIN_LENGTH / 2;
+    size_t second_packet_size = sizeof(datagram) - first_packet_size;
+    size_t first_size;
+    size_t second_size;
+    xqc_int_t ret;
+
+    ret = xqc_test_coalesced_setup(&cli, &svr);
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    if (ret != XQC_OK) {
+        xqc_test_coalesced_teardown(&cli, &svr);
+        return;
+    }
+
+    first_size = xqc_test_build_initial(
+        &cli, &cli.c->dcid_set.current_dcid, 1, XQC_FALSE,
+        first_packet_size, first, sizeof(first));
+    second_size = xqc_test_build_initial(
+        &cli, &cli.c->dcid_set.current_dcid, 2, XQC_TRUE,
+        second_packet_size, second, sizeof(second));
+    CU_ASSERT_EQUAL(first_size, first_packet_size);
+    CU_ASSERT_EQUAL(second_size, second_packet_size);
+    if (first_size != first_packet_size || second_size != second_packet_size) {
+        xqc_test_coalesced_teardown(&cli, &svr);
+        return;
+    }
+
+    memcpy(datagram, first, first_size);
+    memcpy(datagram + first_size, second, second_size);
+
+    /* RFC 9000 Section 14.1 rejects an undersized Initial datagram. */
+    ret = xqc_conn_process_packet(svr.c, datagram, sizeof(datagram),
+                                  xqc_now());
+
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    CU_ASSERT_EQUAL(svr.c->conn_err, TRA_PROTOCOL_VIOLATION);
+    CU_ASSERT_EQUAL(svr.c->conn_close_recv_time, 0);
 
     xqc_test_coalesced_teardown(&cli, &svr);
 }

--- a/tests/unittest/xqc_packet_test.h
+++ b/tests/unittest/xqc_packet_test.h
@@ -14,6 +14,8 @@ void xqc_test_empty_pkt();
 void xqc_test_stateless_reset_parse_boundary(void);
 void xqc_test_coalesced_matching_dcid_processed(void);
 void xqc_test_coalesced_mismatching_dcid_ignored(void);
+void xqc_test_coalesced_initial_datagram_minimum(void);
+void xqc_test_coalesced_initial_datagram_too_small(void);
 
 
 #endif


### PR DESCRIPTION
### Mechanism

Retain the enclosing UDP payload size on each packet input so every
coalesced Initial packet is validated against its datagram, rather than the
bytes remaining after earlier packets. This follows the receiver coalescing
requirement and Initial datagram minimum in RFC 9000 Sections 12.2 and 14.1.

Fixes: #536

- RFC or draft: RFC 9000 Sections 12.2 and 14.1

### Validation Cases

- Not executed — `scripts/case_test.sh` has no targeted coalesced-Initial
  datagram case.

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Incomplete — targeted client-to-server case coverage is
  unavailable; the complete unit suite passes.
- CI: Pending
