### PR TITLE
Fix CID handling for single-path H3 clients

### DIFF
--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -5287,6 +5287,9 @@ xqc_conn_try_add_new_conn_id(xqc_connection_t *conn, uint64_t retire_prior_to)
     xqc_cid_set_inner_t *inner_set;
 
     if (xqc_conn_is_handshake_confirmed(conn)) {
+        if (!conn->enable_multipath && conn->local_settings.disable_active_migration) {
+            return XQC_OK;
+        }
         if (conn->enable_multipath && conn->conn_settings.multipath_version >= XQC_MULTIPATH_10) 
         {
             /* principle #1 there are two CIDs for the next path ID */

--- a/src/transport/xqc_defs.h
+++ b/src/transport/xqc_defs.h
@@ -24,8 +24,8 @@
 /* connection max UDP payload size */
 #define XQC_CONN_MAX_UDP_PAYLOAD_SIZE   1500
 
-/* connection active cid limit */
-#define XQC_CONN_ACTIVE_CID_LIMIT       8
+/* connection active cid limit. Some public H3 endpoints provide more spare CIDs than 8. */
+#define XQC_CONN_ACTIVE_CID_LIMIT       16
 
 /* version definitions */
 #define XQC_VERSION_V1_VALUE            0x00000001

--- a/tests/unittest/xqc_cid_test.c
+++ b/tests/unittest/xqc_cid_test.c
@@ -415,12 +415,9 @@ xqc_test_cid_active_limit()
  * Issue #776 — RFC 9000 §5.1.1: handshake CIDs MUST NOT count toward
  * active_connection_id_limit.
  *
- * Reproduces the nginx interop failure: server sends 7 NEW_CONNECTION_ID
- * frames (seq 1..7) with active_connection_id_limit = 8. The initial
- * handshake produced 2 USED CIDs in the dcid_set. Pre-fix, the 7th
- * NEW_CONNECTION_ID was rejected because (6 unused + 2 used) >= 8.
- * Post-fix, handshake CIDs are excluded: (7 unused + 2 used - 2 original)
- * = 7 < 8, so all 7 are accepted.
+ * Reproduces interop failures where the server sends many NEW_CONNECTION_ID
+ * frames. The initial handshake produced 2 USED CIDs in the dcid_set.
+ * Handshake CIDs are excluded from active_connection_id_limit accounting.
  */
 void
 xqc_test_cid_handshake_exclusion()
@@ -466,23 +463,23 @@ xqc_test_cid_handshake_exclusion()
      * the 2 handshake CIDs are excluded from the count.
      * (Pre-fix, the 7th would fail: (6+2) >= 8.)
      */
-    uint64_t limit = conn->local_settings.active_connection_id_limit;  /* 8 */
-    CU_ASSERT(limit == 8);
+    uint64_t limit = conn->local_settings.active_connection_id_limit;
+    CU_ASSERT(limit == XQC_CONN_ACTIVE_CID_LIMIT);
 
-    for (i = 1; i <= 7; i++) {
+    for (i = 1; i < limit; i++) {
         ret = xqc_test_cid_insert_one(conn, &conn->dcid_set,
                                       XQC_CID_UNUSED, limit, 100 + i);
         CU_ASSERT(ret == XQC_OK);
     }
 
-    /* 8th also succeeds: countable = 7 < 8 (max active NCID CIDs = limit = 8) */
+    /* The limit-th non-handshake CID also succeeds because countable was limit - 1. */
     ret = xqc_test_cid_insert_one(conn, &conn->dcid_set,
-                                  XQC_CID_UNUSED, limit, 108);
+                                  XQC_CID_UNUSED, limit, 100 + limit);
     CU_ASSERT(ret == XQC_OK);
 
-    /* 9th is rejected: countable = 8 >= 8 */
+    /* The next CID is rejected: countable == limit. */
     ret = xqc_test_cid_insert_one(conn, &conn->dcid_set,
-                                  XQC_CID_UNUSED, limit, 109);
+                                  XQC_CID_UNUSED, limit, 101 + limit);
     CU_ASSERT(ret == -XQC_EACTIVE_CID_LIMIT);
 
     /*
@@ -496,11 +493,9 @@ xqc_test_cid_handshake_exclusion()
                                        XQC_CID_RETIRED, XQC_INITIAL_PATH_ID);
     CU_ASSERT(ret == XQC_OK);
 
-    /* now countable = (8 unused + 1 used - 1 original) = 8 >= 8, still at limit */
-    /* But wait: used_cnt decreased (orig retired), so: unused=8, used=1, original=1 */
-    /* countable = 8+1-1 = 8 >= 8, still denied */
+    /* Retiring one original CID still leaves countable == limit, so it remains denied. */
     ret = xqc_test_cid_insert_one(conn, &conn->dcid_set,
-                                  XQC_CID_UNUSED, limit, 110);
+                                  XQC_CID_UNUSED, limit, 102 + limit);
     CU_ASSERT(ret == -XQC_EACTIVE_CID_LIMIT);
 
     /* retire one of the NCID CIDs to free a slot */
@@ -511,9 +506,9 @@ xqc_test_cid_handshake_exclusion()
                                        XQC_CID_RETIRED, XQC_INITIAL_PATH_ID);
     CU_ASSERT(ret == XQC_OK);
 
-    /* now countable = (7 unused + 1 used - 1 original) = 7 < 8, insert succeeds */
+    /* Retiring one non-handshake CID frees a slot, so inserting a fresh CID succeeds. */
     ret = xqc_test_cid_insert_one(conn, &conn->dcid_set,
-                                  XQC_CID_UNUSED, limit, 111);
+                                  XQC_CID_UNUSED, limit, 103 + limit);
     CU_ASSERT(ret == XQC_OK);
 
     xqc_engine_destroy(conn->engine);
@@ -605,4 +600,3 @@ xqc_test_cid_delete_original()
 
     xqc_engine_destroy(conn->engine);
 }
-


### PR DESCRIPTION
### Mechanism

<!-- Explain the changed mechanism concisely. For protocol behavior, cite the
exact RFC or draft section. Otherwise write `Not applicable`. When the change
closes an issue, add the exact standalone line `Fixes: #123`. -->

- RFC or draft: `<RFC/draft section, or Not applicable>`

### Validation Cases

<!-- List only each case ID and its concise behavior. Do not repeat commands,
test function names, logs, namespace ranges, or reservation snapshots. For a
documentation/tooling-only change, write `Not applicable` with a reason. -->

- `<case ID>` — `<concise happy-path or abnormal-path behavior>`

### CONTRIBUTING.md

<!-- Check every CONTRIBUTING.md requirement internally, but publish only the
aggregate result. If local or CI validation is incomplete, name only the
failing case ID and meaning or the incomplete CI check. -->

- Overall: `<Passed / Pending / Not passed>`
- Local regression: `<Complete / Incomplete — concise failed cases>`
- CI: `<Complete / Pending / Failed — concise incomplete checks>`
