### PR TITLE
[~] Fix #665: Close invalid Retry-token Initials

### DIFF
--- a/case_test/transport/core.sh
+++ b/case_test/transport/core.sh
@@ -1011,6 +1011,66 @@ rm -f test_session xqc_token tp_localhost
 
 }
 
+case_transport_core_retry_invalid_token_close()
+{
+
+clear_log
+rm -rf tp_localhost test_session xqc_token
+echo -e "retry invalid token closes connection ...\c"
+case_test_stop_server
+case_test_start_server ${SERVER_BIN} -l d -e -x 715 > svr_stdlog
+sleep 1
+${CLIENT_BIN} -s 1024 -l d -t 2 -E -x 715 > stdlog 2>&1
+corrupted=`grep "\[retry-token-test\]|corrupt_retry_token" stdlog`
+retry_enabled=`grep "\[retry-token-test\]|retry_enabled|case:715" svr_stdlog`
+invalid_token=`grep -E "(conn_err:11|err:0xb|TRA_INVALID_TOKEN)" stdlog slog svr_stdlog 2>/dev/null`
+if [ -n "$corrupted" ] && [ -n "$retry_enabled" ] && [ -n "$invalid_token" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "retry_invalid_token_close" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "retry_invalid_token_close" "fail"
+    echo "$corrupted"
+    echo "$retry_enabled"
+    echo "$invalid_token"
+fi
+rm -rf tp_localhost test_session xqc_token
+}
+
+case_transport_core_retry_ignore_old_initial_dcid()
+{
+
+clear_log
+rm -rf tp_localhost test_session xqc_token
+echo -e "retry ignores old Initial DCID after Retry ...\c"
+case_test_stop_server
+case_test_start_server ${SERVER_BIN} -l d -e -x 716 > svr_stdlog
+sleep 1
+${CLIENT_BIN} -s 1024 -l d -t 2 -E -x 716 > stdlog 2>&1
+large_sni=`grep "\[retry-token-test\]|large_sni_len" stdlog`
+saved=`grep "\[retry-token-test\]|save_original_initial" stdlog`
+replayed=`grep "\[retry-token-test\]|replay_original_initial" stdlog`
+retry_enabled=`grep "\[retry-token-test\]|retry_enabled|case:716" svr_stdlog`
+result=`grep ">>>>>>>> pass:1" stdlog`
+invalid_token=`grep -E "(conn_err:11|err:0xb|TRA_INVALID_TOKEN)" stdlog slog svr_stdlog 2>/dev/null`
+if [ -n "$large_sni" ] && [ -n "$saved" ] && [ -n "$replayed" ] \
+    && [ -n "$retry_enabled" ] && [ "$result" == ">>>>>>>> pass:1" ] \
+    && [ -z "$invalid_token" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "retry_ignore_old_initial_dcid" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "retry_ignore_old_initial_dcid" "fail"
+    echo "$large_sni"
+    echo "$saved"
+    echo "$replayed"
+    echo "$retry_enabled"
+    echo "$result"
+    echo "$invalid_token"
+fi
+rm -rf tp_localhost test_session xqc_token
+}
+
 case_test_case "log_switch_off" --id native --mode self-reporting --run case_transport_core_log_switch_off
 case_test_case "server_refuse" --id native --mode self-reporting --run case_transport_core_server_refuse
 case_test_case "create_connection_fail" --id native --mode self-reporting --run case_transport_core_create_connection_fail
@@ -1031,6 +1091,8 @@ case_test_case "active_cid_limit_minimum_accept" --id native --mode self-reporti
 case_test_case "active_cid_limit_below_minimum" --id native --mode self-reporting --run case_transport_core_active_cid_limit_below_minimum
 case_test_case "max_ack_delay_valid_boundary" --id native --mode self-reporting --run case_transport_core_max_ack_delay_valid_boundary
 case_test_case "max_ack_delay_invalid_boundary" --id native --mode self-reporting --run case_transport_core_max_ack_delay_invalid_boundary
+case_test_case "retry_invalid_token_close" --id 715 --mode self-reporting --run case_transport_core_retry_invalid_token_close
+case_test_case "retry_ignore_old_initial_dcid" --id 716 --mode self-reporting --run case_transport_core_retry_ignore_old_initial_dcid
 case_test_case "new_client_29_&_new_server" --id native --mode self-reporting --run case_transport_core_new_client_29_new_server
 case_test_case "load_balancer_cid_generate_with_encryption" --id native --mode self-reporting --run case_transport_core_load_balancer_cid_generate_with_encryption
 case_test_case "load_balancer_cid_generate" --id native --mode self-reporting --run case_transport_core_load_balancer_cid_generate

--- a/case_test/transport/core.sh
+++ b/case_test/transport/core.sh
@@ -1049,7 +1049,7 @@ sleep 1
 ${CLIENT_BIN} -s 1024 -l d -t 2 -E -x 716 > stdlog 2>&1
 large_sni=`grep "\[retry-token-test\]|large_sni_len" stdlog`
 saved=`grep "\[retry-token-test\]|save_original_initial" stdlog`
-replayed=`grep "\[retry-token-test\]|replay_original_initial" stdlog`
+replayed=`grep -F "[retry-token-test]|replay_original_initial|len:" stdlog`
 retry_enabled=`grep "\[retry-token-test\]|retry_enabled|case:716" svr_stdlog`
 result=`grep ">>>>>>>> pass:1" stdlog`
 invalid_token=`grep -E "(conn_err:11|err:0xb|TRA_INVALID_TOKEN)" stdlog slog svr_stdlog 2>/dev/null`

--- a/harness/spec/validation.md
+++ b/harness/spec/validation.md
@@ -99,7 +99,7 @@ its case is retired so later changes cannot reuse it.
 
 | Range | New-case namespace | Allocated IDs |
 |-------|--------------------|---------------|
-| `[705, 799]` | QUIC Transport core | `705-714`, `717-719` |
+| `[705, 799]` | QUIC Transport core | `705-719` |
 | `[800, 899]` | Recovery and congestion control | `800` |
 | `[900, 999]` | QUIC-TLS | `902-903` |
 | `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1014`, `1017-1018` |

--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -4233,7 +4233,7 @@ xqc_conn_early_data_reject(xqc_connection_t *conn)
  * check retry packet condition first and send retry packet if needed
  */
 xqc_int_t 
-xqc_conn_server_accept(xqc_connection_t *c)
+xqc_conn_server_accept(xqc_connection_t *c, xqc_packet_in_t *packet_in)
 {
     xqc_int_t ret = XQC_OK;
     /* check whether to send retry packet */
@@ -4245,7 +4245,13 @@ xqc_conn_server_accept(xqc_connection_t *c)
         } else if (c->version != XQC_IDRAFT_VER_29) { /* IDRAFT_VER_29 is too old to send retry packet */
             xqc_log(c->log, XQC_LOG_INFO, "|check_token fail|conn:%p|%s|", c, xqc_conn_addr_str(c)); 
             if (c->conn_flag & XQC_CONN_FLAG_RETRY_SENT) {
-                return -XQC_EIGNORE_PKT; /* retry packet already sent */
+                if (packet_in != NULL
+                    && xqc_cid_is_equal(&packet_in->pi_pkt.pkt_dcid, &c->retry_scid) == XQC_OK)
+                {
+                    XQC_CONN_ERR(c, TRA_INVALID_TOKEN);
+                    return -XQC_EPROTO;
+                }
+                return -XQC_EIGNORE_PKT;
             } else {
                 if (c->transport_cbs.conn_retry_packet_condition_check) {
                     if (c->transport_cbs.conn_retry_packet_condition_check(c->engine, 

--- a/src/transport/xqc_conn.h
+++ b/src/transport/xqc_conn.h
@@ -784,5 +784,5 @@ xqc_msec_t xqc_conn_get_queue_fin_timeout(xqc_connection_t *conn);
 void xqc_conn_set_init_idle_timeout(xqc_connection_t *conn, xqc_msec_t init_idle_time_out);
 void xqc_conn_try_to_enable_pmtud(xqc_connection_t *conn);
 
-xqc_int_t xqc_conn_server_accept(xqc_connection_t *c);
+xqc_int_t xqc_conn_server_accept(xqc_connection_t *c, xqc_packet_in_t *packet_in);
 #endif /* _XQC_CONN_H_INCLUDED_ */

--- a/src/transport/xqc_packet.c
+++ b/src/transport/xqc_packet.c
@@ -199,7 +199,7 @@ xqc_packet_parse_single(xqc_connection_t *c, xqc_packet_in_t *packet_in)
 
         if (XQC_PTYPE_INIT == XQC_PACKET_LONG_HEADER_GET_TYPE(pos)) {
             if (c->conn_type == XQC_CONN_TYPE_SERVER && !(c->conn_flag & XQC_CONN_FLAG_SERVER_ACCEPT)) {
-                return xqc_conn_server_accept(c); 
+                return xqc_conn_server_accept(c, packet_in);
             }
         }
 

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -93,6 +93,8 @@ printf_null(const char *format, ...)
 #define XQC_TEST_CASE_AEAD_CONFIDENTIALITY_AT_LIMIT 903
 #define XQC_TEST_CASE_DATAGRAM_1RTT_ALLOWED 1201
 #define XQC_TEST_CASE_DATAGRAM_INITIAL_REJECTED 1202
+#define XQC_TEST_CASE_RETRY_INVALID_TOKEN_CLOSE 715
+#define XQC_TEST_CASE_RETRY_IGNORE_OLD_INITIAL_DCID 716
 
 typedef struct user_conn_s user_conn_t;
 
@@ -254,6 +256,11 @@ size_t dgram2_size = 0;
 
 int dgram_drop_pkt1 = 0;
 int path_response_drop_pkt1 = 0;
+static unsigned char g_retry_original_initial[XQC_PACKET_TMP_BUF_LEN];
+static size_t g_retry_original_initial_len;
+static int g_retry_original_initial_saved;
+static int g_retry_original_initial_replayed;
+static int g_retry_token_corrupted;
 client_ctx_t ctx;
 struct event_base *eb;
 int g_send_dgram;
@@ -292,6 +299,7 @@ uint64_t g_last_sock_op_time;
  * 709/710 for active_connection_id_limit minimum validation
  * 711/712 for PMTUD peer-option omission validation
  * 713/714 for max_ack_delay boundary validation
+ * 715/716 for Retry invalid token and old Initial validation
  * 717 for RESET_STREAM on a peer-initiated unidirectional stream
  * 718/719 for MAX_STREAM_DATA stream direction validation
  * 902/903 for AEAD confidentiality-limit validation
@@ -307,7 +315,7 @@ int g_epoch_timeout = 1000000; /* us */
 char g_write_file[256];
 char g_read_file[256];
 char g_log_path[256];
-char g_host[64] = "test.xquic.com";
+char g_host[256] = "test.xquic.com";
 char g_url_path[256] = "/path/resource";
 char g_scheme[8] = "https";
 char g_url[2048];
@@ -917,6 +925,118 @@ xqc_client_read_token(unsigned char *token, unsigned token_len)
     return n;
 }
 
+static int
+xqc_test_read_vint_value(const unsigned char *buf, size_t size,
+    size_t *offset, uint64_t *value)
+{
+    if (*offset >= size) {
+        return 0;
+    }
+
+    size_t len = 1ULL << (buf[*offset] >> 6);
+    if (len > size - *offset) {
+        return 0;
+    }
+
+    uint64_t v = buf[*offset] & 0x3f;
+    for (size_t i = 1; i < len; i++) {
+        v = (v << 8) | buf[*offset + i];
+    }
+
+    *offset += len;
+    *value = v;
+    return 1;
+}
+
+
+static int
+xqc_test_parse_initial_token_range(const unsigned char *buf, size_t size,
+    size_t *token_offset, size_t *token_len)
+{
+    if (size < 7 || (buf[0] & 0x80) == 0 || ((buf[0] & 0x30) >> 4) != 0) {
+        return 0;
+    }
+
+    size_t offset = 5;
+    size_t dcid_len = buf[offset++];
+    if (dcid_len > size - offset) {
+        return 0;
+    }
+    offset += dcid_len;
+
+    if (offset >= size) {
+        return 0;
+    }
+
+    size_t scid_len = buf[offset++];
+    if (scid_len > size - offset) {
+        return 0;
+    }
+    offset += scid_len;
+
+    uint64_t len = 0;
+    if (!xqc_test_read_vint_value(buf, size, &offset, &len)
+        || len > size - offset)
+    {
+        return 0;
+    }
+
+    *token_offset = offset;
+    *token_len = (size_t)len;
+    return 1;
+}
+
+
+static void
+xqc_client_handle_retry_token_tests(unsigned char *send_buf, size_t send_buf_size,
+    int fd, const struct sockaddr *peer_addr, socklen_t peer_addrlen)
+{
+    size_t token_offset = 0;
+    size_t token_len = 0;
+
+    if (!xqc_test_parse_initial_token_range(send_buf, send_buf_size,
+                                            &token_offset, &token_len))
+    {
+        return;
+    }
+
+    if (g_test_case == XQC_TEST_CASE_RETRY_IGNORE_OLD_INITIAL_DCID
+        && token_len == 0 && !g_retry_original_initial_saved)
+    {
+        memcpy(g_retry_original_initial, send_buf, send_buf_size);
+        g_retry_original_initial_len = send_buf_size;
+        g_retry_original_initial_saved = 1;
+        printf("[retry-token-test]|save_original_initial|len:%zu|\n", send_buf_size);
+    }
+
+    if (g_test_case == XQC_TEST_CASE_RETRY_IGNORE_OLD_INITIAL_DCID
+        && token_len > 0 && g_retry_original_initial_saved
+        && !g_retry_original_initial_replayed)
+    {
+        ssize_t n = sendto(fd, g_retry_original_initial,
+                           g_retry_original_initial_len, 0,
+                           peer_addr, peer_addrlen);
+        if (n >= 0) {
+            g_retry_original_initial_replayed = 1;
+            printf("[retry-token-test]|replay_original_initial|len:%zu|\n",
+                   g_retry_original_initial_len);
+        } else {
+            printf("[retry-token-test]|replay_original_initial_failed|errno:%d|\n",
+                   get_sys_errno());
+        }
+    }
+
+    if (g_test_case == XQC_TEST_CASE_RETRY_INVALID_TOKEN_CLOSE
+        && token_len > 0 && !g_retry_token_corrupted)
+    {
+        send_buf[token_offset] ^= 0xff;
+        g_retry_token_corrupted = 1;
+        printf("[retry-token-test]|corrupt_retry_token|offset:%zu|len:%zu|\n",
+               token_offset, token_len);
+    }
+}
+
+
 int
 read_file_data(char *data, size_t data_len, char *filename)
 {
@@ -988,6 +1108,13 @@ xqc_client_write_socket(const unsigned char *buf, size_t size,
             g_test_case = -1;
             set_sys_errno(EAGAIN);
             return XQC_SOCKET_EAGAIN;
+        }
+
+        if (g_test_case == XQC_TEST_CASE_RETRY_INVALID_TOKEN_CLOSE
+            || g_test_case == XQC_TEST_CASE_RETRY_IGNORE_OLD_INITIAL_DCID)
+        {
+            xqc_client_handle_retry_token_tests(send_buf, send_buf_size, fd,
+                                                peer_addr, peer_addrlen);
         }
 
         /* client Initial dcid corruption */
@@ -1262,6 +1389,13 @@ xqc_client_write_socket_ex(uint64_t path_id,
             g_test_case = -1;
             errno = EAGAIN;
             return XQC_SOCKET_EAGAIN;
+        }
+
+        if (g_test_case == XQC_TEST_CASE_RETRY_INVALID_TOKEN_CLOSE
+            || g_test_case == XQC_TEST_CASE_RETRY_IGNORE_OLD_INITIAL_DCID)
+        {
+            xqc_client_handle_retry_token_tests(send_buf, send_buf_size, fd,
+                                                peer_addr, peer_addrlen);
         }
 
         /* client Initial dcid corruption */
@@ -5327,6 +5461,16 @@ int main(int argc, char *argv[]) {
     if (g_test_case == 703) {
         g_verify_cert = 1;
         g_verify_cert_allow_self_sign = 0;
+    }
+
+    if (g_test_case == XQC_TEST_CASE_RETRY_IGNORE_OLD_INITIAL_DCID) {
+        memset(g_host, 'a', 63);
+        g_host[63] = '.';
+        memset(g_host + 64, 'b', 63);
+        g_host[127] = '.';
+        memset(g_host + 128, 'c', 63);
+        snprintf(g_host + 191, sizeof(g_host) - 191, ".test.xquic.com");
+        printf("[retry-token-test]|large_sni_len:%zu|\n", strlen(g_host));
     }
 
     g_conn_settings = &conn_settings;

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -166,6 +166,9 @@ int g_send_body_size_defined;
 int g_save_body;
 int g_read_body;
 int g_spec_url;
+#define XQC_TEST_CASE_RETRY_INVALID_TOKEN_CLOSE 715
+#define XQC_TEST_CASE_RETRY_IGNORE_OLD_INITIAL_DCID 716
+
 /* 99 pure fin, 7XX for transport, 9XX for QUIC-TLS */
 int g_test_case;
 int g_server_conn_cnt;
@@ -2382,7 +2385,11 @@ xqc_retry_packet_check(xqc_engine_t *engine, xqc_connection_t *conn, const xqc_c
     (void *)conn;
     (void *)cid;
     (void *)user_data;
-    if (g_test_case == 601) { /* 601 for test retry packet */
+    if (g_test_case == 601
+        || g_test_case == XQC_TEST_CASE_RETRY_INVALID_TOKEN_CLOSE
+        || g_test_case == XQC_TEST_CASE_RETRY_IGNORE_OLD_INITIAL_DCID)
+    {
+        printf("[retry-token-test]|retry_enabled|case:%d|\n", g_test_case);
         return XQC_TRUE;
     }
     return XQC_FALSE; 

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -353,6 +353,10 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite, "xqc_test_retry", xqc_test_retry)
         || !CU_add_test(pSuite, "xqc_test_retry_same_length_dcid",
                         xqc_test_retry_same_length_dcid)
+        || !CU_add_test(pSuite, "xqc_test_retry_invalid_token_close",
+                        xqc_test_retry_invalid_token_close)
+        || !CU_add_test(pSuite, "xqc_test_retry_invalid_token_ignore_original_dcid",
+                        xqc_test_retry_invalid_token_ignore_original_dcid)
         || !CU_add_test(pSuite, "xqc_test_receive_invalid_dgram", xqc_test_receive_invalid_dgram)
         || !CU_add_test(pSuite,
                         "xqc_test_receive_dgram_at_valid_encryption_level",

--- a/tests/unittest/xqc_retry_test.c
+++ b/tests/unittest/xqc_retry_test.c
@@ -80,3 +80,62 @@ xqc_test_retry_same_length_dcid()
 
     xqc_engine_destroy(conn->engine);
 }
+
+
+void
+xqc_test_retry_invalid_token_close()
+{
+    static const unsigned char retry_scid_buf[] = "retrycid";
+
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_FATAL(conn != NULL);
+
+    xqc_packet_in_t packet_in;
+    memset(&packet_in, 0, sizeof(packet_in));
+
+    conn->conn_type = XQC_CONN_TYPE_SERVER;
+    conn->conn_flag |= XQC_CONN_FLAG_RETRY_SENT;
+    conn->conn_flag &= ~XQC_CONN_FLAG_TOKEN_OK;
+    conn->conn_token_len = 0;
+    conn->conn_err = 0;
+    conn->version = XQC_VERSION_V1;
+    xqc_cid_set(&conn->retry_scid, retry_scid_buf, sizeof(retry_scid_buf) - 1);
+    xqc_cid_copy(&packet_in.pi_pkt.pkt_dcid, &conn->retry_scid);
+
+    xqc_int_t ret = xqc_conn_server_accept(conn, &packet_in);
+    CU_ASSERT(ret == -XQC_EPROTO);
+    CU_ASSERT(conn->conn_err == TRA_INVALID_TOKEN);
+    CU_ASSERT(conn->conn_flag & XQC_CONN_FLAG_ERROR);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
+void
+xqc_test_retry_invalid_token_ignore_original_dcid()
+{
+    static const unsigned char retry_scid_buf[] = "retrycid";
+    static const unsigned char original_dcid_buf[] = "origdcid";
+
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_FATAL(conn != NULL);
+
+    xqc_packet_in_t packet_in;
+    memset(&packet_in, 0, sizeof(packet_in));
+
+    conn->conn_type = XQC_CONN_TYPE_SERVER;
+    conn->conn_flag |= XQC_CONN_FLAG_RETRY_SENT;
+    conn->conn_flag &= ~XQC_CONN_FLAG_TOKEN_OK;
+    conn->conn_token_len = 0;
+    conn->conn_err = 0;
+    conn->version = XQC_VERSION_V1;
+    xqc_cid_set(&conn->retry_scid, retry_scid_buf, sizeof(retry_scid_buf) - 1);
+    xqc_cid_set(&packet_in.pi_pkt.pkt_dcid, original_dcid_buf, sizeof(original_dcid_buf) - 1);
+
+    xqc_int_t ret = xqc_conn_server_accept(conn, &packet_in);
+    CU_ASSERT(ret == -XQC_EIGNORE_PKT);
+    CU_ASSERT(conn->conn_err == 0);
+    CU_ASSERT(!(conn->conn_flag & XQC_CONN_FLAG_ERROR));
+
+    xqc_engine_destroy(conn->engine);
+}

--- a/tests/unittest/xqc_retry_test.h
+++ b/tests/unittest/xqc_retry_test.h
@@ -7,5 +7,7 @@
 
 void xqc_test_retry();
 void xqc_test_retry_same_length_dcid();
+void xqc_test_retry_invalid_token_close();
+void xqc_test_retry_invalid_token_ignore_original_dcid();
 
 #endif


### PR DESCRIPTION
### Mechanism

- RFC or draft: RFC 9000 Section 8.1.2 and Section 20.1
- After Retry has been sent, the server now treats an invalid token as `INVALID_TOKEN` only when the Initial DCID matches the Retry SCID, while old Initial-flight packets with the original DCID remain ignored.

Fixes: #665

### Validation Cases

- 715 — invalid Retry-token Initial closes with `INVALID_TOKEN`.
- 716 — replayed old-DCID Initial after Retry is ignored without killing the connection.

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Complete
- CI: Pending
