### PR TITLE
[~] Fix #611: Reject HTTP/2 reserved frames in HTTP/3

### DIFF
--- a/case_test/http3/core.sh
+++ b/case_test/http3/core.sh
@@ -750,6 +750,35 @@ fi
 
 }
 
+case_http3_core_h3_h2_reserved_request_frame_rejected()
+{
+case_test_stop_server
+clear_log
+rm -f test_session xqc_token tp_localhost h3_request_frame_server.log
+case_test_start_server ${SERVER_BIN} -l d -e -x 1015 > h3_request_frame_server.log
+sleep 1
+echo -e "HTTP/2 reserved frame on request stream gets H3_FRAME_UNEXPECTED ...\c"
+${CLIENT_BIN} -s 1024 -l d -t 1 -E -x 1015 > stdlog
+for wait_idx in 1 2 3 4 5 6 7 8 9 10; do
+    server_err=`grep "\\[h3-request-frame-test\\]|http2-reserved|conn_err:261|" \
+        h3_request_frame_server.log`
+    [ -n "$server_err" ] && break
+    sleep 0.2
+done
+sent=`grep "\\[h3-request-frame-test\\]|type:0x2|ret:0|" stdlog`
+wire_err=`grep "err:0x105" slog`
+client_err=`grep -E "(conn errno:261|conn_err:261)" stdlog`
+application_type=`grep "conn_err_type:2" stdlog`
+if [ -n "$sent" ] && [ -n "$server_err" ] && [ -n "$wire_err" ] \
+    && [ -n "$client_err" ] && [ -n "$application_type" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "h3_h2_reserved_request_frame_rejected" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "h3_h2_reserved_request_frame_rejected" "fail"
+fi
+}
+
 case_http3_core_h3_client_push_promise_rejected()
 {
 
@@ -1018,6 +1047,36 @@ fi
 
 }
 
+case_http3_core_h3_h2_reserved_control_frame_rejected()
+{
+case_test_stop_server
+clear_log
+rm -f test_session xqc_token tp_localhost h3_control_frame_server.log
+case_test_start_server stdbuf -oL ${SERVER_BIN} -l d -e -x 1016 > h3_control_frame_server.log
+sleep 1
+echo -e "HTTP/2 reserved frame on control stream gets H3_FRAME_UNEXPECTED ...\c"
+${CLIENT_BIN} -s 1024 -l d -t 1 -E -x 1016 > stdlog
+for wait_idx in 1 2 3 4 5 6 7 8 9 10; do
+    server_err=`grep "\\[h3-control-frame-test\\]|case:1016|conn_err:261|" \
+        h3_control_frame_server.log`
+    [ -n "$server_err" ] && break
+    sleep 0.2
+done
+sent=`grep "\\[h3-control-frame-test\\]|type:0x2|write:0|send:0|" \
+    h3_control_frame_server.log`
+wire_err=`grep "err:0x105" clog`
+client_err=`grep "\\[h3-control-frame-test\\]|case:1016|conn_err:261|" stdlog`
+application_type=`grep "conn_err_type:2" stdlog`
+if [ -n "$sent" ] && [ -n "$wire_err" ] && [ -n "$client_err" ] \
+    && [ -n "$server_err" ] && [ -n "$application_type" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "h3_h2_reserved_control_frame_rejected" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "h3_h2_reserved_control_frame_rejected" "fail"
+fi
+}
+
 case_http3_core_h3_cancel_push_unset_rejected()
 {
 
@@ -1201,6 +1260,7 @@ case_test_case "h3_engine_set_settings_api_h3_ext_more" --id native --mode self-
 case_test_case "h3_reserved_uni_stream_survives" --id native --mode self-reporting --run case_http3_core_h3_reserved_uni_stream_survives
 case_test_case "h3_client_push_stream_creation_error" --id native --mode self-reporting --run case_http3_core_h3_client_push_stream_creation_error
 case_test_case "h3_reserved_request_frame_accepted" --id native --mode self-reporting --run case_http3_core_h3_reserved_request_frame_accepted
+case_test_case "h3_h2_reserved_request_frame_rejected" --id 1015 --mode self-reporting --run case_http3_core_h3_h2_reserved_request_frame_rejected
 case_test_case "h3_client_push_promise_rejected" --id native --mode self-reporting --run case_http3_core_h3_client_push_promise_rejected
 case_test_case "h3_max_push_id_increase_accepted" --id native --mode self-reporting --run case_http3_core_h3_max_push_id_increase_accepted
 case_test_case "h3_max_push_id_decrease_rejected" --id native --mode self-reporting --run case_http3_core_h3_max_push_id_decrease_rejected
@@ -1210,6 +1270,7 @@ case_test_case "h3_max_push_id_wrong_role_rejected" --id native --mode self-repo
 case_test_case "h3_non_minimal_max_push_id_accepted" --id native --mode self-reporting --run case_http3_core_h3_non_minimal_max_push_id_accepted
 case_test_case "h3_overlong_max_push_id_rejected" --id native --mode self-reporting --run case_http3_core_h3_overlong_max_push_id_rejected
 case_test_case "h3_reserved_control_frame_accepted" --id native --mode self-reporting --run case_http3_core_h3_reserved_control_frame_accepted
+case_test_case "h3_h2_reserved_control_frame_rejected" --id 1016 --mode self-reporting --run case_http3_core_h3_h2_reserved_control_frame_rejected
 case_test_case "h3_cancel_push_unset_rejected" --id native --mode self-reporting --run case_http3_core_h3_cancel_push_unset_rejected
 case_test_case "h3_field_section_within_limit_succeeds" --id native --mode self-reporting --run case_http3_core_h3_field_section_within_limit_succeeds
 case_test_case "h3_field_section_over_limit_is_stream_error" --id native --mode self-reporting --run case_http3_core_h3_field_section_over_limit_is_stream_error

--- a/harness/spec/validation.md
+++ b/harness/spec/validation.md
@@ -102,7 +102,7 @@ its case is retired so later changes cannot reuse it.
 | `[705, 799]` | QUIC Transport core | `705-714`, `717-719` |
 | `[800, 899]` | Recovery and congestion control | `800` |
 | `[900, 999]` | QUIC-TLS | `902-903` |
-| `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1014`, `1017-1018` |
+| `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1018` |
 | `[1100, 1149]` | QPACK | None |
 | `[1150, 1199]` | HTTP priority | None |
 | `[1200, 1299]` | QUIC DATAGRAM | `1201-1202` |

--- a/include/xquic/xqc_errno.h
+++ b/include/xquic/xqc_errno.h
@@ -299,6 +299,7 @@ typedef enum {
     XQC_H3_INVALID_MAX_PUSH_ID          = 836,  /**< RFC 9114 §7.2.7 */
     XQC_H3_EMALFORMED_HEADER            = 837,  /**< malformed HTTP/3 header field (RFC 9114 4.1.2 / 4.2) */
     XQC_H3_INVALID_CANCEL_PUSH_ID       = 838,  /**< RFC 9114 §7.2.3 */
+    XQC_H3_RESERVED_FRAME_UNEXPECTED    = 839,  /**< HTTP/2 reserved frame received, RFC 9114 §7.2.8 */
     XQC_H3_INVALID_GOAWAY_ID            = 840,  /**< RFC 9114 §5.2 */
 
     XQC_H3_ERR_MAX,

--- a/src/http3/frame/xqc_h3_frame.c
+++ b/src/http3/frame/xqc_h3_frame.c
@@ -75,6 +75,11 @@ xqc_h3_frm_reset_pctx(xqc_h3_frame_pctx_t *pctx)
         break;
     case XQC_H3_FRM_MAX_PUSH_ID:
         break;
+    case XQC_H3_FRM_RESERVED_PRIORITY:
+    case XQC_H3_FRM_RESERVED_PING:
+    case XQC_H3_FRM_RESERVED_WINDOW_UPDATE:
+    case XQC_H3_FRM_RESERVED_CONTINUATION:
+        break;
     case XQC_H3_EXT_FRM_BIDI_STREAM_TYPE:
         break;
     case XQC_H3_FRM_UNKNOWN:
@@ -195,6 +200,21 @@ xqc_h3_ext_frm_parse_bidi_stream_type(const unsigned char *p, size_t sz, xqc_h3_
     return pos - p;
 }
 
+xqc_bool_t
+xqc_h3_frm_is_h2_reserved(uint64_t frame_type)
+{
+    switch (frame_type) {
+    case XQC_H3_FRM_RESERVED_PRIORITY:
+    case XQC_H3_FRM_RESERVED_PING:
+    case XQC_H3_FRM_RESERVED_WINDOW_UPDATE:
+    case XQC_H3_FRM_RESERVED_CONTINUATION:
+        return XQC_TRUE;
+    default:
+        return XQC_FALSE;
+    }
+}
+
+
 ssize_t
 xqc_h3_frm_parse_reserved(const unsigned char *p, size_t sz,
     xqc_h3_frame_t *frame, xqc_bool_t *fin)
@@ -233,6 +253,9 @@ xqc_h3_frm_parse(const unsigned char *p, size_t sz, xqc_h3_frame_pctx_t *pctx)
             pctx->frame.type = pctx->pctx.vi;
             xqc_discrete_int_pctx_clear(&pctx->pctx);
             pctx->state = XQC_H3_FRM_STATE_LEN;
+            if (xqc_h3_frm_is_h2_reserved(pctx->frame.type)) {
+                return -XQC_H3_RESERVED_FRAME_UNEXPECTED;
+            }
             fin = 0;
         }
     }

--- a/src/http3/frame/xqc_h3_frame.h
+++ b/src/http3/frame/xqc_h3_frame.h
@@ -56,6 +56,8 @@ typedef struct xqc_h3_frame_pctx_s {
  */
 ssize_t xqc_h3_frm_parse(const unsigned char *pos, size_t sz, xqc_h3_frame_pctx_t *pctx);
 
+xqc_bool_t xqc_h3_frm_is_h2_reserved(uint64_t frame_type);
+
 
 /**
  * @brief parse SETTINGS frame

--- a/src/http3/frame/xqc_h3_frame_defs.h
+++ b/src/http3/frame/xqc_h3_frame_defs.h
@@ -11,10 +11,14 @@
 typedef enum xqc_h3_frm_type_s {
     XQC_H3_FRM_DATA                 = 0x00,
     XQC_H3_FRM_HEADERS              = 0x01,
+    XQC_H3_FRM_RESERVED_PRIORITY    = 0x02,
     XQC_H3_FRM_CANCEL_PUSH          = 0x03,
     XQC_H3_FRM_SETTINGS             = 0x04,
     XQC_H3_FRM_PUSH_PROMISE         = 0x05,
+    XQC_H3_FRM_RESERVED_PING        = 0x06,
     XQC_H3_FRM_GOAWAY               = 0x07,
+    XQC_H3_FRM_RESERVED_WINDOW_UPDATE = 0x08,
+    XQC_H3_FRM_RESERVED_CONTINUATION  = 0x09,
     XQC_H3_FRM_MAX_PUSH_ID          = 0x0d,
 
     /* extension */

--- a/src/http3/xqc_h3_stream.c
+++ b/src/http3/xqc_h3_stream.c
@@ -712,6 +712,21 @@ xqc_h3_stream_write_notify(xqc_stream_t *stream, void *user_data)
 }
 
 
+static inline ssize_t
+xqc_h3_stream_process_frame_parse_error(xqc_h3_stream_t *h3s,
+    xqc_h3_frame_pctx_t *pctx, ssize_t err)
+{
+    if (err == -XQC_H3_RESERVED_FRAME_UNEXPECTED) {
+        xqc_log(h3s->log, XQC_LOG_ERROR,
+                "|HTTP/2 reserved frame received|type:%xL|", pctx->frame.type);
+        XQC_H3_CONN_ERR(h3s->h3c, H3_FRAME_UNEXPECTED, err);
+    }
+
+    xqc_h3_frm_reset_pctx(pctx);
+    return err;
+}
+
+
 ssize_t
 xqc_h3_stream_process_control(xqc_h3_stream_t *h3s, unsigned char *data, size_t data_len)
 {
@@ -723,8 +738,7 @@ xqc_h3_stream_process_control(xqc_h3_stream_t *h3s, unsigned char *data, size_t 
     while (processed < data_len) {
         ssize_t read = xqc_h3_frm_parse(data + processed, data_len - processed, pctx);
         if (read < 0) {
-            xqc_h3_frm_reset_pctx(pctx);
-            return read;
+            return xqc_h3_stream_process_frame_parse_error(h3s, pctx, read);
         }
 
         processed += read;
@@ -895,8 +909,7 @@ xqc_h3_stream_process_push(xqc_h3_stream_t *h3s, unsigned char *data, size_t dat
     while (processed < data_len) {
         ssize_t read = xqc_h3_frm_parse(data + processed, data_len - processed, pctx);
         if (read < 0) {
-            xqc_h3_frm_reset_pctx(pctx);
-            return read;
+            return xqc_h3_stream_process_frame_parse_error(h3s, pctx, read);
         }
 
         processed += read;
@@ -975,8 +988,7 @@ xqc_h3_stream_process_request(xqc_h3_stream_t *h3s, unsigned char *data, size_t 
         if (read < 0) {
             xqc_log(h3s->log, XQC_LOG_ERROR, "|parse frame error|ret:%z|state:%d|frame_type:%xL|",
                     read, pctx->state, pctx->frame.type);
-            xqc_h3_frm_reset_pctx(pctx);
-            return read;
+            return xqc_h3_stream_process_frame_parse_error(h3s, pctx, read);
         }
 
         xqc_log(h3s->log, XQC_LOG_DEBUG, "|parse frame success|frame_type:%xL|len:%ui|read:%z|",
@@ -1183,8 +1195,7 @@ xqc_h3_stream_process_bytestream(xqc_h3_stream_t *h3s,
         if (read < 0) {
             xqc_log(h3s->log, XQC_LOG_ERROR, "|parse frame error|ret:%z|state:%d|frame_type:%xL|",
                     read, pctx->state, pctx->frame.type);
-            xqc_h3_frm_reset_pctx(pctx);
-            return read;
+            return xqc_h3_stream_process_frame_parse_error(h3s, pctx, read);
         }
 
         xqc_log(h3s->log, XQC_LOG_DEBUG, "|parse frame success|frame_type:%xL|len:%ui|read:%z|",
@@ -1450,8 +1461,7 @@ xqc_h3_stream_process_bidi_type_unknown(xqc_h3_stream_t *h3s,
     if (read < 0) {
         xqc_log(h3s->log, XQC_LOG_ERROR, "|parse frame error|ret:%z|state:%d|frame_type:%xL|",
                 read, pctx->state, pctx->frame.type);
-        xqc_h3_frm_reset_pctx(pctx);
-        return read;
+        return xqc_h3_stream_process_frame_parse_error(h3s, pctx, read);
     }
 
     processed += read;

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -87,6 +87,8 @@ printf_null(const char *format, ...)
 #define XQC_TEST_CASE_H3_FIELD_SECTION_OVER_LIMIT 1012
 #define XQC_TEST_CASE_H3_LOWERCASE_RESPONSE 1013
 #define XQC_TEST_CASE_H3_UPPERCASE_RESPONSE 1014
+#define XQC_TEST_CASE_H3_H2_RESERVED_REQUEST_FRAME 1015
+#define XQC_TEST_CASE_H3_H2_RESERVED_CONTROL_FRAME 1016
 #define XQC_TEST_CASE_H3_GOAWAY_DECREASE 1017
 #define XQC_TEST_CASE_H3_GOAWAY_INCREASE 1018
 #define XQC_TEST_CASE_AEAD_CONFIDENTIALITY_BELOW_LIMIT 902
@@ -2016,7 +2018,8 @@ xqc_client_h3_conn_close_notify(xqc_h3_conn_t *conn, const xqc_cid_t *cid, void 
         fflush(stdout);
 
     } else if (g_test_case == XQC_TEST_CASE_H3_RESERVED_CONTROL_FRAME
-        || g_test_case == XQC_TEST_CASE_H3_CANCEL_PUSH_UNSET)
+        || g_test_case == XQC_TEST_CASE_H3_CANCEL_PUSH_UNSET
+        || g_test_case == XQC_TEST_CASE_H3_H2_RESERVED_CONTROL_FRAME)
     {
         printf("[h3-control-frame-test]|case:%d|conn_err:%d|\n",
                g_test_case, stats.conn_err);
@@ -2297,7 +2300,7 @@ xqc_client_send_test_request_frame(xqc_h3_request_t *h3_request,
                                             XQC_FALSE);
 
     } else {
-        unsigned char frame[] = { 0x21, 0x00 };
+        unsigned char frame[] = { (unsigned char)frame_type, 0x00 };
         ret = xqc_var_buf_save_data(buf, frame, sizeof(frame));
         if (ret == XQC_OK) {
             ret = xqc_list_buf_to_tail(&h3_stream->send_buf, buf);
@@ -2869,12 +2872,16 @@ xqc_client_request_send(xqc_h3_request_t *h3_request, user_stream_t *user_stream
 
     if (!user_stream->h3_test_frame_queued
         && (g_test_case == XQC_TEST_CASE_H3_RESERVED_REQUEST_FRAME
-            || g_test_case == XQC_TEST_CASE_H3_CLIENT_PUSH_PROMISE))
+            || g_test_case == XQC_TEST_CASE_H3_CLIENT_PUSH_PROMISE
+            || g_test_case == XQC_TEST_CASE_H3_H2_RESERVED_REQUEST_FRAME))
     {
-        uint64_t frame_type =
-            g_test_case == XQC_TEST_CASE_H3_CLIENT_PUSH_PROMISE
-            ? XQC_H3_FRM_PUSH_PROMISE
-            : 0x21;
+        uint64_t frame_type = XQC_H3_FRM_RESERVED_PRIORITY;
+        if (g_test_case == XQC_TEST_CASE_H3_CLIENT_PUSH_PROMISE) {
+            frame_type = XQC_H3_FRM_PUSH_PROMISE;
+
+        } else if (g_test_case == XQC_TEST_CASE_H3_RESERVED_REQUEST_FRAME) {
+            frame_type = 0x21;
+        }
         ret = xqc_client_send_test_request_frame(h3_request, frame_type);
         if (ret != XQC_OK) {
             return ret;
@@ -2883,7 +2890,8 @@ xqc_client_request_send(xqc_h3_request_t *h3_request, user_stream_t *user_stream
     }
 
     if (g_test_case == XQC_TEST_CASE_H3_RESERVED_REQUEST_FRAME
-        || g_test_case == XQC_TEST_CASE_H3_CLIENT_PUSH_PROMISE)
+        || g_test_case == XQC_TEST_CASE_H3_CLIENT_PUSH_PROMISE
+        || g_test_case == XQC_TEST_CASE_H3_H2_RESERVED_REQUEST_FRAME)
     {
         return XQC_OK;
     }

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -66,6 +66,8 @@ printf_null(const char *format, ...)
 #define XQC_TEST_CASE_H3_FIELD_SECTION_OVER_LIMIT 1012
 #define XQC_TEST_CASE_H3_LOWERCASE_RESPONSE 1013
 #define XQC_TEST_CASE_H3_UPPERCASE_RESPONSE 1014
+#define XQC_TEST_CASE_H3_H2_RESERVED_REQUEST_FRAME 1015
+#define XQC_TEST_CASE_H3_H2_RESERVED_CONTROL_FRAME 1016
 #define XQC_TEST_CASE_AEAD_CONFIDENTIALITY_BELOW_LIMIT 902
 #define XQC_TEST_CASE_AEAD_CONFIDENTIALITY_AT_LIMIT 903
 #define XQC_TEST_CASE_DATAGRAM_1RTT_ALLOWED 1201
@@ -1025,8 +1027,12 @@ xqc_server_h3_conn_close_notify(xqc_h3_conn_t *h3_conn, const xqc_cid_t *cid, vo
     printf("send_count:%u, lost_count:%u, tlp_count:%u, recv_count:%u, srtt:%"PRIu64" early_data_flag:%d, conn_err:%d, ack_info:%s, conn_info:%s, alpn:%s\n",
            stats.send_count, stats.lost_count, stats.tlp_count, stats.recv_count, stats.srtt, stats.early_data_flag, stats.conn_err, stats.ack_info, stats.conn_info, stats.alpn);
 
-    if (g_test_case == XQC_TEST_CASE_H3_RESERVED_REQUEST_FRAME) {
-        printf("[h3-request-frame-test]|reserved-frame|conn_err:%d|\n",
+    if (g_test_case == XQC_TEST_CASE_H3_RESERVED_REQUEST_FRAME
+        || g_test_case == XQC_TEST_CASE_H3_H2_RESERVED_REQUEST_FRAME)
+    {
+        const char *kind = g_test_case == XQC_TEST_CASE_H3_RESERVED_REQUEST_FRAME
+                           ? "reserved-frame" : "http2-reserved";
+        printf("[h3-request-frame-test]|%s|conn_err:%d|\n", kind,
                stats.conn_err);
         fflush(stdout);
 
@@ -1051,7 +1057,8 @@ xqc_server_h3_conn_close_notify(xqc_h3_conn_t *h3_conn, const xqc_cid_t *cid, vo
         fflush(stdout);
 
     } else if (g_test_case == XQC_TEST_CASE_H3_RESERVED_CONTROL_FRAME
-               || g_test_case == XQC_TEST_CASE_H3_CANCEL_PUSH_UNSET)
+               || g_test_case == XQC_TEST_CASE_H3_CANCEL_PUSH_UNSET
+               || g_test_case == XQC_TEST_CASE_H3_H2_RESERVED_CONTROL_FRAME)
     {
         printf("[h3-control-frame-test]|case:%d|conn_err:%d|\n",
                g_test_case, stats.conn_err);
@@ -1125,6 +1132,10 @@ xqc_server_h3_conn_handshake_finished(xqc_h3_conn_t *h3_conn, void *conn_user_da
 
     } else if (g_test_case == XQC_TEST_CASE_H3_RESERVED_CONTROL_FRAME) {
         xqc_server_send_test_control_frame(h3_conn, 0x21);
+
+    } else if (g_test_case == XQC_TEST_CASE_H3_H2_RESERVED_CONTROL_FRAME) {
+        xqc_server_send_test_control_frame(h3_conn,
+                                           XQC_H3_FRM_RESERVED_PRIORITY);
 
     } else if (g_test_case == XQC_TEST_CASE_H3_CANCEL_PUSH_UNSET) {
         xqc_server_send_test_control_frame(h3_conn,
@@ -1214,7 +1225,7 @@ xqc_server_send_test_control_frame(xqc_h3_conn_t *h3_conn,
                                                  XQC_FALSE);
 
     } else {
-        unsigned char frame[] = { 0x21, 0x01, 0x00 };
+        unsigned char frame[] = { (unsigned char)frame_type, 0x01, 0x00 };
         xqc_var_buf_t *buf = xqc_var_buf_create(sizeof(frame));
         write_ret = -XQC_EMALLOC;
         if (buf != NULL) {

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -306,6 +306,9 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite,
                         "xqc_test_h3_reserved_control_frame_accepted",
                         xqc_test_h3_reserved_control_frame_accepted)
+        || !CU_add_test(pSuite,
+                        "xqc_test_h3_h2_reserved_frames_rejected",
+                        xqc_test_h3_h2_reserved_frames_rejected)
         || !CU_add_test(pSuite, "xqc_test_h3_cancel_push_rejected",
                         xqc_test_h3_cancel_push_rejected)
         /* RFC 9114 §4.2.2 field-section-size 32B overhead (issue 751) */

--- a/tests/unittest/xqc_h3_test.c
+++ b/tests/unittest/xqc_h3_test.c
@@ -1590,6 +1590,56 @@ xqc_test_h3_reserved_control_frame_accepted()
 
 
 void
+xqc_test_h3_h2_reserved_frames_rejected()
+{
+    const unsigned char frame_types[] = {
+        XQC_H3_FRM_RESERVED_PRIORITY,
+        XQC_H3_FRM_RESERVED_PING,
+        XQC_H3_FRM_RESERVED_WINDOW_UPDATE,
+        XQC_H3_FRM_RESERVED_CONTINUATION,
+    };
+
+    for (size_t i = 0; i < sizeof(frame_types); ++i) {
+        unsigned char frame[] = { frame_types[i], 0x00 };
+        xqc_h3_frame_pctx_t pctx = {0};
+        xqc_h3_frm_reset_pctx(&pctx);
+        CU_ASSERT(xqc_h3_frm_parse(frame, sizeof(frame), &pctx)
+                  == -XQC_H3_RESERVED_FRAME_UNEXPECTED);
+        CU_ASSERT(pctx.frame.type == frame_types[i]);
+        CU_ASSERT(pctx.state == XQC_H3_FRM_STATE_LEN);
+
+        xqc_connection_t *conn = NULL;
+        xqc_h3_conn_t *h3c = NULL;
+        xqc_h3_stream_t *h3s = xqc_h3_ctrl_test_setup(&conn, &h3c);
+        CU_ASSERT_FATAL(h3s != NULL);
+        CU_ASSERT_FATAL(xqc_h3_ctrl_feed_settings(h3s) > 0);
+
+        CU_ASSERT(xqc_h3_stream_process_control(h3s, frame, sizeof(frame))
+                  == -XQC_H3_RESERVED_FRAME_UNEXPECTED);
+        CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err) == H3_FRAME_UNEXPECTED);
+        CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
+        CU_ASSERT(h3s->pctx.frame_pctx.state == XQC_H3_FRM_STATE_TYPE);
+        xqc_h3_ctrl_test_teardown(h3s, h3c, conn);
+
+        conn = NULL;
+        h3c = NULL;
+        h3s = xqc_h3_msgerr_setup(&conn, &h3c);
+        CU_ASSERT_FATAL(h3s != NULL);
+        conn->conn_type = XQC_CONN_TYPE_SERVER;
+
+        CU_ASSERT(xqc_h3_stream_process_in(h3s, frame, sizeof(frame),
+                  XQC_FALSE) == -XQC_H3_EPROC_REQUEST);
+        CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err) == H3_FRAME_UNEXPECTED);
+        CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
+        CU_ASSERT(h3s->pctx.frame_pctx.state == XQC_H3_FRM_STATE_TYPE);
+        xqc_h3_msgerr_teardown(h3s, h3c, conn);
+    }
+
+    CU_ASSERT(xqc_h3_frm_is_h2_reserved(0x21) == XQC_FALSE);
+}
+
+
+void
 xqc_test_h3_cancel_push_rejected()
 {
     xqc_connection_t *conn = NULL;

--- a/tests/unittest/xqc_h3_test.h
+++ b/tests/unittest/xqc_h3_test.h
@@ -22,6 +22,7 @@ void xqc_test_h3_goaway_id_increase_rejected();
 void xqc_test_h3_settings_accepted();
 void xqc_test_h3_reserved_h2_settings_rejected();
 void xqc_test_h3_reserved_control_frame_accepted();
+void xqc_test_h3_h2_reserved_frames_rejected();
 void xqc_test_h3_cancel_push_rejected();
 void xqc_test_h3_uncompressed_fields_size();
 void xqc_test_h3_recv_header_field_section_size();


### PR DESCRIPTION
### Mechanism

Reject HTTP/2 reserved frame types during HTTP/3 frame parsing and map the dedicated parser error to the `H3_FRAME_UNEXPECTED` connection error while preserving unknown extension-frame handling.

- RFC or draft: RFC 9114 Section 7.2.8

Fixes: #611

### Validation Cases

- 1015 — Reject an HTTP/2 reserved frame on a request stream
- 1016 — Reject an HTTP/2 reserved frame on a control stream

### CONTRIBUTING.md

- Overall: Passed
- Local regression: Complete
- CI: Complete
