### PR TITLE
[~] Fix #613: Reject increasing HTTP/3 GOAWAY IDs

### DIFF
--- a/case_test/http3/core.sh
+++ b/case_test/http3/core.sh
@@ -832,6 +832,54 @@ fi
 
 }
 
+case_http3_core_h3_goaway_decrease_accepted()
+{
+case_test_stop_server
+clear_log
+rm -f test_session xqc_token tp_localhost
+case_test_start_server ${SERVER_BIN} -l d -e -x 1017 > /dev/null
+sleep 1
+echo -e "HTTP/3 decreasing GOAWAY IDs are accepted ...\c"
+${CLIENT_BIN} -s 1024 -l d -t 1 -E -x 1017 > stdlog
+sent=`grep "\\[h3-goaway-test\\]|first:3|second:1|write:0,0|send:0|" \
+    stdlog`
+first_received=`grep "|H3_GOAWAY|stream_id:3|" slog`
+second_received=`grep "|H3_GOAWAY|stream_id:1|" slog`
+result=`grep ">>>>>>>> pass:1" stdlog`
+id_error=`grep "err:0x108" slog`
+if [ -n "$sent" ] && [ -n "$first_received" ] \
+    && [ -n "$second_received" ] && [ -n "$result" ] \
+    && [ -z "$id_error" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "h3_goaway_decrease_accepted" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "h3_goaway_decrease_accepted" "fail"
+fi
+}
+
+case_http3_core_h3_goaway_increase_rejected()
+{
+case_test_stop_server
+clear_log
+rm -f test_session xqc_token tp_localhost
+case_test_start_server ${SERVER_BIN} -l d -e -x 1018 > /dev/null
+sleep 1
+echo -e "HTTP/3 increasing GOAWAY ID gets H3_ID_ERROR ...\c"
+${CLIENT_BIN} -s 1024 -l d -t 1 -E -x 1018 > stdlog
+sent=`grep "\\[h3-goaway-test\\]|first:1|second:3|write:0,0|send:0|" \
+    stdlog`
+server_err=`grep "err:0x108" slog`
+client_err=`grep -E "(conn errno:264|conn_err:264)" stdlog`
+if [ -n "$sent" ] && [ -n "$server_err" ] && [ -n "$client_err" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "h3_goaway_increase_rejected" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "h3_goaway_increase_rejected" "fail"
+fi
+}
+
 case_http3_core_h3_max_push_id_wrong_role_rejected()
 {
 
@@ -1156,6 +1204,8 @@ case_test_case "h3_reserved_request_frame_accepted" --id native --mode self-repo
 case_test_case "h3_client_push_promise_rejected" --id native --mode self-reporting --run case_http3_core_h3_client_push_promise_rejected
 case_test_case "h3_max_push_id_increase_accepted" --id native --mode self-reporting --run case_http3_core_h3_max_push_id_increase_accepted
 case_test_case "h3_max_push_id_decrease_rejected" --id native --mode self-reporting --run case_http3_core_h3_max_push_id_decrease_rejected
+case_test_case "h3_goaway_decrease_accepted" --id 1017 --mode self-reporting --run case_http3_core_h3_goaway_decrease_accepted
+case_test_case "h3_goaway_increase_rejected" --id 1018 --mode self-reporting --run case_http3_core_h3_goaway_increase_rejected
 case_test_case "h3_max_push_id_wrong_role_rejected" --id native --mode self-reporting --run case_http3_core_h3_max_push_id_wrong_role_rejected
 case_test_case "h3_non_minimal_max_push_id_accepted" --id native --mode self-reporting --run case_http3_core_h3_non_minimal_max_push_id_accepted
 case_test_case "h3_overlong_max_push_id_rejected" --id native --mode self-reporting --run case_http3_core_h3_overlong_max_push_id_rejected

--- a/harness/spec/validation.md
+++ b/harness/spec/validation.md
@@ -102,7 +102,7 @@ its case is retired so later changes cannot reuse it.
 | `[705, 799]` | QUIC Transport core | `705-714` |
 | `[800, 899]` | Recovery and congestion control | `800` |
 | `[900, 999]` | QUIC-TLS | `902-903` |
-| `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1014` |
+| `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1014`, `1017-1018` |
 | `[1100, 1149]` | QPACK | None |
 | `[1150, 1199]` | HTTP priority | None |
 | `[1200, 1299]` | QUIC DATAGRAM | None |

--- a/include/xquic/xqc_errno.h
+++ b/include/xquic/xqc_errno.h
@@ -299,6 +299,7 @@ typedef enum {
     XQC_H3_INVALID_MAX_PUSH_ID          = 836,  /**< RFC 9114 §7.2.7 */
     XQC_H3_EMALFORMED_HEADER            = 837,  /**< malformed HTTP/3 header field (RFC 9114 4.1.2 / 4.2) */
     XQC_H3_INVALID_CANCEL_PUSH_ID       = 838,  /**< RFC 9114 §7.2.3 */
+    XQC_H3_INVALID_GOAWAY_ID            = 840,  /**< RFC 9114 §5.2 */
 
     XQC_H3_ERR_MAX,
 } xqc_h3_error_t;

--- a/src/http3/xqc_h3_stream.c
+++ b/src/http3/xqc_h3_stream.c
@@ -802,22 +802,31 @@ xqc_h3_stream_process_control(xqc_h3_stream_t *h3s, unsigned char *data, size_t 
                 break;
 
             case XQC_H3_FRM_GOAWAY:
-                
-                if (!(h3s->h3c->flags & XQC_H3_CONN_FLAG_GOAWAY_RECVD)) {
-                    h3c->goaway_stream_id = pl->goaway.stream_id.vi;
-                    h3s->h3c->flags |= XQC_H3_CONN_FLAG_GOAWAY_RECVD;
-                }
+                /*
+                 * RFC 9114 Section 5.2: a later GOAWAY identifier cannot
+                 * exceed any previously received identifier.
+                 */
+                if (h3c->flags & XQC_H3_CONN_FLAG_GOAWAY_RECVD) {
+                    if (pl->goaway.stream_id.vi > h3c->goaway_stream_id) {
+                        xqc_log(h3c->log, XQC_LOG_ERROR,
+                                "|GOAWAY ID increased|old:%ui|new:%ui|",
+                                h3c->goaway_stream_id,
+                                pl->goaway.stream_id.vi);
+                        xqc_h3_frm_reset_pctx(pctx);
+                        XQC_H3_CONN_ERR(h3c, H3_ID_ERROR,
+                                        -XQC_H3_INVALID_GOAWAY_ID);
+                        return -XQC_H3_INVALID_GOAWAY_ID;
+                    }
 
-                if (h3c->goaway_stream_id > pl->goaway.stream_id.vi) {
                     h3c->goaway_stream_id = pl->goaway.stream_id.vi;
 
                 } else {
-                    xqc_log(h3c->log, XQC_LOG_WARN, "|xqc_h3_stream_process_control goaway_frame"
-                            " receive bigger push id|push_id:%ui|",
-                            pl->goaway.stream_id.vi);
+                    h3c->goaway_stream_id = pl->goaway.stream_id.vi;
+                    h3c->flags |= XQC_H3_CONN_FLAG_GOAWAY_RECVD;
                 }
-                xqc_log(h3c->log, XQC_LOG_DEBUG, "|H3_GOAWAY|stream_id:%ui|", pl->goaway.stream_id.vi);
-                
+
+                xqc_log(h3c->log, XQC_LOG_DEBUG, "|H3_GOAWAY|stream_id:%ui|",
+                        pl->goaway.stream_id.vi);
                 break;
 
 

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -87,6 +87,8 @@ printf_null(const char *format, ...)
 #define XQC_TEST_CASE_H3_FIELD_SECTION_OVER_LIMIT 1012
 #define XQC_TEST_CASE_H3_LOWERCASE_RESPONSE 1013
 #define XQC_TEST_CASE_H3_UPPERCASE_RESPONSE 1014
+#define XQC_TEST_CASE_H3_GOAWAY_DECREASE 1017
+#define XQC_TEST_CASE_H3_GOAWAY_INCREASE 1018
 #define XQC_TEST_CASE_AEAD_CONFIDENTIALITY_BELOW_LIMIT 902
 #define XQC_TEST_CASE_AEAD_CONFIDENTIALITY_AT_LIMIT 903
 
@@ -97,6 +99,8 @@ static void xqc_client_send_test_uni_stream(xqc_h3_conn_t *h3_conn,
 static xqc_int_t xqc_client_send_test_request_frame(
     xqc_h3_request_t *h3_request, uint64_t frame_type);
 static void xqc_client_send_test_max_push_ids(xqc_h3_conn_t *h3_conn,
+    uint64_t first, uint64_t second);
+static void xqc_client_send_test_goaway_ids(xqc_h3_conn_t *h3_conn,
     uint64_t first, uint64_t second);
 static void xqc_client_send_test_single_vint_frame(
     xqc_h3_conn_t *h3_conn, xqc_bool_t overlong);
@@ -2175,6 +2179,12 @@ xqc_client_h3_conn_handshake_finished(xqc_h3_conn_t *h3_conn, void *user_data)
     } else if (g_test_case == XQC_TEST_CASE_H3_MAX_PUSH_ID_DECREASE) {
         xqc_client_send_test_max_push_ids(h3_conn, 3, 1);
 
+    } else if (g_test_case == XQC_TEST_CASE_H3_GOAWAY_DECREASE) {
+        xqc_client_send_test_goaway_ids(h3_conn, 3, 1);
+
+    } else if (g_test_case == XQC_TEST_CASE_H3_GOAWAY_INCREASE) {
+        xqc_client_send_test_goaway_ids(h3_conn, 1, 3);
+
     } else if (g_test_case == XQC_TEST_CASE_H3_SINGLE_VINT_VALID) {
         xqc_client_send_test_single_vint_frame(h3_conn, XQC_FALSE);
 
@@ -2261,6 +2271,23 @@ xqc_client_send_test_max_push_ids(xqc_h3_conn_t *h3_conn,
     xqc_int_t send_ret = xqc_h3_stream_send_buffer(control);
 
     printf("[h3-max-push-id-test]|first:%" PRIu64 "|second:%" PRIu64
+           "|write:%d,%d|send:%d|\n",
+           first, second, first_ret, second_ret, send_ret);
+}
+
+
+static void
+xqc_client_send_test_goaway_ids(xqc_h3_conn_t *h3_conn,
+    uint64_t first, uint64_t second)
+{
+    xqc_h3_stream_t *control = h3_conn->control_stream_out;
+    xqc_int_t first_ret = xqc_h3_frm_write_goaway(
+        &control->send_buf, first, XQC_FALSE);
+    xqc_int_t second_ret = xqc_h3_frm_write_goaway(
+        &control->send_buf, second, XQC_FALSE);
+    xqc_int_t send_ret = xqc_h3_stream_send_buffer(control);
+
+    printf("[h3-goaway-test]|first:%" PRIu64 "|second:%" PRIu64
            "|write:%d,%d|send:%d|\n",
            first, second, first_ret, second_ret, send_ret);
 }

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -255,6 +255,10 @@ main(int argc, char *argv[])
                         xqc_test_h3_max_push_id_valid)
         || !CU_add_test(pSuite, "xqc_test_h3_max_push_id_errors",
                         xqc_test_h3_max_push_id_errors)
+        || !CU_add_test(pSuite, "xqc_test_h3_goaway_id_valid",
+                        xqc_test_h3_goaway_id_valid)
+        || !CU_add_test(pSuite, "xqc_test_h3_goaway_id_increase_rejected",
+                        xqc_test_h3_goaway_id_increase_rejected)
         || !CU_add_test(pSuite,
                         "xqc_test_h3_reserved_control_frame_accepted",
                         xqc_test_h3_reserved_control_frame_accepted)

--- a/tests/unittest/xqc_h3_test.c
+++ b/tests/unittest/xqc_h3_test.c
@@ -1409,6 +1409,73 @@ xqc_h3_ctrl_feed_cancel_push(xqc_h3_stream_t *h3s, unsigned char push_id)
 }
 
 
+static ssize_t
+xqc_h3_ctrl_feed_goaway(xqc_h3_stream_t *h3s, unsigned char identifier)
+{
+    unsigned char frame[] = { XQC_H3_FRM_GOAWAY, 0x01, identifier };
+    return xqc_h3_stream_process_control(h3s, frame, sizeof(frame));
+}
+
+
+void
+xqc_test_h3_goaway_id_valid()
+{
+    const xqc_conn_type_t roles[] = {
+        XQC_CONN_TYPE_CLIENT, XQC_CONN_TYPE_SERVER
+    };
+
+    for (size_t i = 0; i < sizeof(roles) / sizeof(roles[0]); i++) {
+        xqc_connection_t *conn = NULL;
+        xqc_h3_conn_t *h3c = NULL;
+        xqc_h3_stream_t *h3s = xqc_h3_ctrl_test_setup(&conn, &h3c);
+        CU_ASSERT_FATAL(h3s != NULL);
+
+        conn->conn_type = roles[i];
+        CU_ASSERT_FATAL(xqc_h3_ctrl_feed_settings(h3s) > 0);
+
+        /* RFC 9114 Section 5.2 permits equal and decreasing IDs. */
+        CU_ASSERT(xqc_h3_ctrl_feed_goaway(h3s, 8) == 3);
+        CU_ASSERT(xqc_h3_ctrl_feed_goaway(h3s, 4) == 3);
+        CU_ASSERT(xqc_h3_ctrl_feed_goaway(h3s, 4) == 3);
+        CU_ASSERT(h3c->goaway_stream_id == 4);
+        CU_ASSERT(conn->conn_err == 0);
+        CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) == 0);
+
+        xqc_h3_ctrl_test_teardown(h3s, h3c, conn);
+    }
+}
+
+
+void
+xqc_test_h3_goaway_id_increase_rejected()
+{
+    const xqc_conn_type_t roles[] = {
+        XQC_CONN_TYPE_CLIENT, XQC_CONN_TYPE_SERVER
+    };
+
+    for (size_t i = 0; i < sizeof(roles) / sizeof(roles[0]); i++) {
+        xqc_connection_t *conn = NULL;
+        xqc_h3_conn_t *h3c = NULL;
+        xqc_h3_stream_t *h3s = xqc_h3_ctrl_test_setup(&conn, &h3c);
+        CU_ASSERT_FATAL(h3s != NULL);
+
+        conn->conn_type = roles[i];
+        CU_ASSERT_FATAL(xqc_h3_ctrl_feed_settings(h3s) > 0);
+        CU_ASSERT_FATAL(xqc_h3_ctrl_feed_goaway(h3s, 4) == 3);
+
+        /* A later larger ID is an H3_ID_ERROR and cannot replace the cutoff. */
+        CU_ASSERT(xqc_h3_ctrl_feed_goaway(h3s, 8)
+                  == -XQC_H3_INVALID_GOAWAY_ID);
+        CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err) == H3_ID_ERROR);
+        CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
+        CU_ASSERT(h3c->goaway_stream_id == 4);
+        CU_ASSERT(h3s->pctx.frame_pctx.state == XQC_H3_FRM_STATE_TYPE);
+
+        xqc_h3_ctrl_test_teardown(h3s, h3c, conn);
+    }
+}
+
+
 void
 xqc_test_h3_reserved_control_frame_accepted()
 {

--- a/tests/unittest/xqc_h3_test.h
+++ b/tests/unittest/xqc_h3_test.h
@@ -17,6 +17,8 @@ void xqc_test_h3_reserved_uni_stream_accepted();
 void xqc_test_h3_push_stream_error_codes();
 void xqc_test_h3_max_push_id_valid();
 void xqc_test_h3_max_push_id_errors();
+void xqc_test_h3_goaway_id_valid();
+void xqc_test_h3_goaway_id_increase_rejected();
 void xqc_test_h3_reserved_control_frame_accepted();
 void xqc_test_h3_cancel_push_rejected();
 void xqc_test_h3_uncompressed_fields_size();


### PR DESCRIPTION
### Mechanism

Reject a later HTTP/3 GOAWAY identifier when it exceeds the previously received identifier, preserving the existing cutoff and closing the connection with `H3_ID_ERROR`.

- RFC or draft: RFC 9114 Section 5.2

Fixes: #613

### Validation Cases

- 1017 — Accept decreasing GOAWAY identifiers.
- 1018 — Reject an increasing GOAWAY identifier with `H3_ID_ERROR`.

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Complete
- CI: Pending
