### PR TITLE
[~]: Cap anti-amplification setting

### DIFF
--- a/include/xquic/xquic.h
+++ b/include/xquic/xquic.h
@@ -1352,7 +1352,11 @@ typedef struct xqc_conn_settings_s {
     xqc_msec_t                  idle_time_out;
     xqc_usec_t                  fec_conn_queue_rpr_timeout;
     int32_t                     spurious_loss_detect_on;
-    /** limit of anti-amplification, default 5 */
+    /**
+     * Anti-amplification factor before client address validation.
+     * Zero uses the default of 3; explicit values are limited to 1 through 3
+     * per RFC 9000 Section 8.1.
+     */
     uint32_t                    anti_amplification_limit;
     /**
      * Optional early key-update threshold for one 1-RTT key phase. Zero

--- a/mini/mini_server.c
+++ b/mini/mini_server.c
@@ -206,7 +206,6 @@ xqc_mini_svr_init_conn_settings(xqc_engine_t *engine, xqc_mini_svr_args_t *args)
         .scheduler_callback = sched,
         .standby_path_probe_timeout = 1000,
         .adaptive_ack_frequency = 1,
-        .anti_amplification_limit = 4,
     };
 
     /* set customized connection settings to engine ctx */

--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -236,7 +236,9 @@ xqc_server_set_conn_settings(xqc_engine_t *engine, const xqc_conn_settings_t *se
     }
 
     if (settings->anti_amplification_limit > 0) {
-        engine->default_conn_settings.anti_amplification_limit = settings->anti_amplification_limit;
+        engine->default_conn_settings.anti_amplification_limit =
+            xqc_min(settings->anti_amplification_limit,
+                    XQC_MAX_ANTI_AMPLIFICATION_LIMIT);
     }
 
     if (xqc_check_proto_version_valid(settings->proto_version)) {

--- a/src/transport/xqc_defs.h
+++ b/src/transport/xqc_defs.h
@@ -85,7 +85,9 @@ extern const unsigned char  xqc_proto_version_field[][XQC_PROTO_VERSION_LEN];
 #define XQC_MAX_ALPN_LEN                        255
 
 /* limit of anti-amplification (RFC 9000 Section 8.1) */
-#define XQC_DEFAULT_ANTI_AMPLIFICATION_LIMIT    3
+#define XQC_MAX_ANTI_AMPLIFICATION_LIMIT        3
+#define XQC_DEFAULT_ANTI_AMPLIFICATION_LIMIT    \
+    XQC_MAX_ANTI_AMPLIFICATION_LIMIT
 
 #define XQC_MAX_MT_ROW                          256
 

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -82,6 +82,12 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite, "xqc_test_get_random", xqc_test_get_random)
         || !CU_add_test(pSuite, "xqc_test_engine_create", xqc_test_engine_create)
         || !CU_add_test(pSuite, "xqc_test_conn_create", xqc_test_conn_create)
+        || !CU_add_test(pSuite,
+                        "xqc_test_conn_anti_amplification_limit_valid",
+                        xqc_test_conn_anti_amplification_limit_valid)
+        || !CU_add_test(pSuite,
+                        "xqc_test_conn_anti_amplification_limit_excess",
+                        xqc_test_conn_anti_amplification_limit_excess)
         || !CU_add_test(pSuite, "xqc_test_conn_idle_timeout", xqc_test_conn_idle_timeout)
         || !CU_add_test(pSuite, "xqc_test_conn_pmtud_force_enable",
                         xqc_test_conn_pmtud_force_enable)

--- a/tests/unittest/xqc_conn_test.c
+++ b/tests/unittest/xqc_conn_test.c
@@ -91,6 +91,54 @@ xqc_test_conn_create()
     xqc_engine_destroy(engine);
 }
 
+void
+xqc_test_conn_anti_amplification_limit_valid(void)
+{
+    xqc_engine_t *engine = test_create_engine();
+    xqc_conn_settings_t settings = {0};
+
+    CU_ASSERT_PTR_NOT_NULL_FATAL(engine);
+    CU_ASSERT_EQUAL(engine->default_conn_settings.anti_amplification_limit,
+                    XQC_DEFAULT_ANTI_AMPLIFICATION_LIMIT);
+
+    xqc_server_set_conn_settings(engine, &settings);
+    CU_ASSERT_EQUAL(engine->default_conn_settings.anti_amplification_limit,
+                    XQC_DEFAULT_ANTI_AMPLIFICATION_LIMIT);
+
+    settings.anti_amplification_limit = 2;
+    xqc_server_set_conn_settings(engine, &settings);
+    CU_ASSERT_EQUAL(engine->default_conn_settings.anti_amplification_limit, 2);
+
+    settings.anti_amplification_limit = XQC_MAX_ANTI_AMPLIFICATION_LIMIT;
+    xqc_server_set_conn_settings(engine, &settings);
+    CU_ASSERT_EQUAL(engine->default_conn_settings.anti_amplification_limit,
+                    XQC_MAX_ANTI_AMPLIFICATION_LIMIT);
+
+    xqc_engine_destroy(engine);
+}
+
+void
+xqc_test_conn_anti_amplification_limit_excess(void)
+{
+    xqc_engine_t *engine = test_create_engine();
+    xqc_conn_settings_t settings = {0};
+
+    CU_ASSERT_PTR_NOT_NULL_FATAL(engine);
+
+    settings.anti_amplification_limit =
+        XQC_MAX_ANTI_AMPLIFICATION_LIMIT + 1;
+    xqc_server_set_conn_settings(engine, &settings);
+    CU_ASSERT_EQUAL(engine->default_conn_settings.anti_amplification_limit,
+                    XQC_MAX_ANTI_AMPLIFICATION_LIMIT);
+
+    settings.anti_amplification_limit = UINT32_MAX;
+    xqc_server_set_conn_settings(engine, &settings);
+    CU_ASSERT_EQUAL(engine->default_conn_settings.anti_amplification_limit,
+                    XQC_MAX_ANTI_AMPLIFICATION_LIMIT);
+
+    xqc_engine_destroy(engine);
+}
+
 /* -------------------------------------------------------------------------
  * Idle-timeout negotiation tests for issue #559.
  *

--- a/tests/unittest/xqc_conn_test.h
+++ b/tests/unittest/xqc_conn_test.h
@@ -6,6 +6,8 @@
 #define XQC_CONN_TEST_H
 
 void xqc_test_conn_create();
+void xqc_test_conn_anti_amplification_limit_valid(void);
+void xqc_test_conn_anti_amplification_limit_excess(void);
 void xqc_test_conn_idle_timeout();
 void xqc_test_conn_pmtud_force_enable();
 void xqc_test_conn_pmtud_legacy_compatibility();


### PR DESCRIPTION
### Mechanism

Cap server anti-amplification configuration at the RFC 9000 Section 8.1
maximum of three times received bytes before client address validation. Values
1 through 3 remain available for stricter policy, and zero keeps the default
of 3.

- RFC or draft: RFC 9000 Section 8.1

Fixes: #913

### Validation Cases

- Not executed — targeted client-to-server coverage for compliant and excessive
  configured factors is unavailable.

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Incomplete — targeted client-to-server anti-amplification
  cases unavailable
- CI: Pending
