### PR TITLE
[~] Fix #402: Use the default TLS certificate when SNI is absent

### DIFF
--- a/src/tls/xqc_tls.c
+++ b/src/tls/xqc_tls.c
@@ -1112,9 +1112,11 @@ xqc_ssl_cert_cb(SSL *ssl, void *arg)
     }
 
     hostname = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
+    /* RFC 8446 Section 9.2 permits a missing server_name extension. */
     if (NULL == hostname) {
-        xqc_log(tls->log, XQC_LOG_ERROR, "|hostname is NULL");
-        return XQC_SSL_FAIL;
+        xqc_log(tls->log, XQC_LOG_INFO,
+                "|hostname is NULL|use default certificate");
+        goto end;
     }
 
     /* callback to upper layer to get SSL_CTX */

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -248,6 +248,10 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite,
                         "xqc_test_h3_single_vint_frame_length_error",
                         xqc_test_h3_single_vint_frame_length_error)
+        || !CU_add_test(pSuite, "xqc_test_tls_default_cert_with_sni",
+                        xqc_test_tls_default_cert_with_sni)
+        || !CU_add_test(pSuite, "xqc_test_tls_default_cert_without_sni",
+                        xqc_test_tls_default_cert_without_sni)
         || !CU_add_test(pSuite, "xqc_test_tls", xqc_test_tls)
         || !CU_add_test(pSuite, "xqc_test_h3_stream", xqc_test_stream)
         || !CU_add_test(pSuite, "xqc_test_h3_critical_stream_close", xqc_test_h3_critical_stream_close)

--- a/tests/unittest/xqc_tls_test.c
+++ b/tests/unittest/xqc_tls_test.c
@@ -35,6 +35,7 @@ typedef struct xqc_tls_test_buff_s {
         };
         xqc_connection_t conn;
     };
+    int                  cert_cb_called;
 } xqc_tls_test_buff_t;
 
 static inline xqc_tls_test_buff_t*
@@ -54,6 +55,7 @@ xqc_create_tls_test_buffer()
     ttbuf->crypto_data_total_len = 0;
 
     ttbuf->error_code = 0;
+    ttbuf->cert_cb_called = 0;
 
     return ttbuf;
 }
@@ -177,6 +179,20 @@ xqc_tt_cert_verify_cb(const unsigned char *certs[], const size_t cert_len[],
     return XQC_OK;
 }
 
+xqc_int_t
+xqc_tt_cert_cb(const char *sni, void **chain, void **crt, void **key,
+               void *user_data)
+{
+    xqc_tls_test_buff_t *ttbuf = (xqc_tls_test_buff_t *)user_data;
+
+    if (sni == NULL) {
+        return -XQC_TLS_INVALID_ARGUMENT;
+    }
+
+    ttbuf->cert_cb_called++;
+    return XQC_OK;
+}
+
 void
 xqc_tt_session_cb(const char *data, size_t data_len, void *user_data)
 {
@@ -235,6 +251,164 @@ xqc_tls_callbacks_t tls_test_cbs = {
     
 static xqc_log_t *test_log;
 static xqc_tls_ctx_t *ctx_cli, *ctx_svr;
+
+#define TEST_ALPN_1 "transport"
+#define TEST_ALPN_2 "h3"
+
+static xqc_int_t
+xqc_test_tls_default_cert_handshake(xqc_bool_t with_sni,
+                                    int *cert_cb_called)
+{
+    xqc_int_t              ret = -XQC_EFATAL;
+    size_t                 data_len;
+    uint8_t               *data_buf = NULL;
+    xqc_log_t             *log = NULL;
+    xqc_tls_ctx_t         *local_ctx_cli = NULL;
+    xqc_tls_ctx_t         *local_ctx_svr = NULL;
+    xqc_tls_t             *tls_cli = NULL;
+    xqc_tls_t             *tls_svr = NULL;
+    xqc_tls_test_buff_t   *ttbuf_cli = NULL;
+    xqc_tls_test_buff_t   *ttbuf_svr = NULL;
+    xqc_log_callbacks_t    log_cb = xqc_null_log_cb;
+    xqc_tls_callbacks_t    cert_test_cbs = tls_test_cbs;
+    xqc_tls_config_t       tls_config = {0};
+    xqc_cid_t              odcid = {1};
+    def_engine_ssl_config_cli;
+    def_engine_ssl_config_svr;
+
+    *cert_cb_called = 0;
+    cert_test_cbs.cert_cb = xqc_tt_cert_cb;
+
+    log = xqc_log_init(0, 0, 0, 0, 0, NULL, &log_cb, NULL);
+    if (log == NULL) {
+        goto end;
+    }
+
+    local_ctx_cli = xqc_tls_ctx_create(XQC_TLS_TYPE_CLIENT,
+        &engine_ssl_config_cli, &cert_test_cbs, log);
+    local_ctx_svr = xqc_tls_ctx_create(XQC_TLS_TYPE_SERVER,
+        &engine_ssl_config_svr, &cert_test_cbs, log);
+    if (local_ctx_cli == NULL || local_ctx_svr == NULL) {
+        goto end;
+    }
+
+    ret = xqc_tls_ctx_register_alpn(local_ctx_svr, TEST_ALPN_1,
+                                    sizeof(TEST_ALPN_1) - 1);
+    if (ret != XQC_OK) {
+        goto end;
+    }
+
+    tls_config.hostname = "test.xquic.com";
+    tls_config.alpn = TEST_ALPN_1;
+    tls_config.trans_params = "10086";
+    tls_config.trans_params_len = 5;
+
+    ttbuf_cli = xqc_create_tls_test_buffer();
+    ttbuf_svr = xqc_create_tls_test_buffer();
+    if (ttbuf_cli == NULL || ttbuf_svr == NULL) {
+        ret = -XQC_EMALLOC;
+        goto end;
+    }
+
+    tls_cli = xqc_tls_create(local_ctx_cli, &tls_config, log, ttbuf_cli);
+    tls_svr = xqc_tls_create(local_ctx_svr, &tls_config, log, ttbuf_svr);
+    if (tls_cli == NULL || tls_svr == NULL) {
+        ret = -XQC_TLS_INTERNAL;
+        goto end;
+    }
+
+    if (!with_sni
+        && SSL_set_tlsext_host_name(xqc_tls_get_ssl(tls_cli), NULL)
+           != XQC_SSL_SUCCESS)
+    {
+        ret = -XQC_TLS_INTERNAL;
+        goto end;
+    }
+
+    ret = xqc_tls_init(tls_cli, XQC_VERSION_V1, &odcid);
+    if (ret != XQC_OK
+        || xqc_list_empty(&ttbuf_cli->initial_crypto_data_list))
+    {
+        ret = -XQC_TLS_INTERNAL;
+        goto end;
+    }
+
+    ret = xqc_tls_init(tls_svr, XQC_VERSION_V1, &odcid);
+    if (ret != XQC_OK) {
+        goto end;
+    }
+
+    data_buf = xqc_malloc(XQC_TEST_MAX_CRYPTO_DATA_BUF);
+    if (data_buf == NULL) {
+        ret = -XQC_EMALLOC;
+        goto end;
+    }
+
+    data_len = xqc_crypto_data_list_get_buf(
+        &ttbuf_cli->initial_crypto_data_list, data_buf);
+    if (data_len == 0 || data_len > XQC_TEST_MAX_CRYPTO_DATA_BUF) {
+        ret = -XQC_TLS_INTERNAL;
+        goto end;
+    }
+
+    ret = xqc_tls_process_crypto_data(tls_svr, XQC_ENC_LEV_INIT,
+                                      data_buf, data_len);
+    *cert_cb_called = ttbuf_svr->cert_cb_called;
+    if (ret == XQC_OK
+        && (xqc_list_empty(&ttbuf_svr->initial_crypto_data_list)
+            || xqc_list_empty(&ttbuf_svr->hsk_crypto_data_list)))
+    {
+        ret = -XQC_TLS_INTERNAL;
+    }
+
+end:
+    if (data_buf != NULL) {
+        xqc_free(data_buf);
+    }
+    if (tls_cli != NULL) {
+        xqc_tls_destroy(tls_cli);
+    }
+    if (tls_svr != NULL) {
+        xqc_tls_destroy(tls_svr);
+    }
+    if (ttbuf_cli != NULL) {
+        xqc_destroy_tls_test_buffer(ttbuf_cli);
+    }
+    if (ttbuf_svr != NULL) {
+        xqc_destroy_tls_test_buffer(ttbuf_svr);
+    }
+    if (local_ctx_cli != NULL) {
+        xqc_tls_ctx_destroy(local_ctx_cli);
+    }
+    if (local_ctx_svr != NULL) {
+        xqc_tls_ctx_destroy(local_ctx_svr);
+    }
+    if (log != NULL) {
+        xqc_free(log);
+    }
+
+    return ret;
+}
+
+void
+xqc_test_tls_default_cert_with_sni(void)
+{
+    int cert_cb_called;
+
+    CU_ASSERT_EQUAL(xqc_test_tls_default_cert_handshake(
+        XQC_TRUE, &cert_cb_called), XQC_OK);
+    CU_ASSERT_EQUAL(cert_cb_called, 1);
+}
+
+void
+xqc_test_tls_default_cert_without_sni(void)
+{
+    int cert_cb_called;
+
+    CU_ASSERT_EQUAL(xqc_test_tls_default_cert_handshake(
+        XQC_FALSE, &cert_cb_called), XQC_OK);
+    CU_ASSERT_EQUAL(cert_cb_called, 0);
+}
 
 void
 xqc_test_create_client_tls_ctx()
@@ -348,9 +522,6 @@ xqc_test_create_server_tls_ctx()
     
     ctx_svr = ctx;
 }
-
-#define TEST_ALPN_1 "transport"
-#define TEST_ALPN_2 "h3"
 
 void
 xqc_test_tls_ctx_register_alpn()
@@ -882,7 +1053,7 @@ void xqc_test_destroy_tls_ctx()
 }
 
 void
-xqc_test_tls()
+xqc_test_tls(void)
 {
     xqc_log_callbacks_t log_cb =  xqc_null_log_cb;
     test_log =  xqc_log_init(0, 0, 0, 0, 0, NULL, &log_cb, NULL);

--- a/tests/unittest/xqc_tls_test.h
+++ b/tests/unittest/xqc_tls_test.h
@@ -5,6 +5,8 @@
 #ifndef _XQC_TLS_TEST_INCLUDE_
 #define _XQC_TLS_TEST_INCLUDE_
 
-void xqc_test_tls();
+void xqc_test_tls(void);
+void xqc_test_tls_default_cert_with_sni(void);
+void xqc_test_tls_default_cert_without_sni(void);
 
 #endif


### PR DESCRIPTION
### Mechanism

When a ClientHello omits `server_name`, keep the certificate and key already
configured on the server's default `SSL_CTX` instead of failing before
certificate selection. Named-SNI handshakes continue through the existing
dynamic certificate callback. RFC 8446 Section 9.2 permits a server to accept
a missing `server_name` unless the deployment explicitly requires it.

Fixes: #402

- RFC or draft: RFC 8446 Section 9.2

### Validation Cases

- Targeted no-SNI endpoint case unavailable — the repository client replaces
  an empty hostname with `localhost`; paired full-ClientHello unit coverage
  verifies the default-certificate and named-SNI paths.

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Incomplete — targeted no-SNI client-to-server case unavailable
- CI: Pending
