### PR TITLE
[~] Fix #512: Prevent RESET_STREAM on receive-only streams

### DIFF
--- a/case_test/transport/stream.sh
+++ b/case_test/transport/stream.sh
@@ -554,6 +554,32 @@ fi
 
 }
 
+case_transport_stream_reset_stream_on_recv_only_stream()
+{
+
+case_test_stop_server
+clear_log
+rm -f test_session xqc_token tp_localhost
+case_test_start_server ${SERVER_BIN} -l d -e -x 717 > svr_stdlog
+sleep 1
+echo -e "reset_stream_on_recv_only_stream ...\c"
+${CLIENT_BIN} -s 1024 -l d -t 1 -E -x 717 > stdlog
+sleep 1
+result=`grep ">>>>>>>> pass:1" stdlog`
+server_reset=`grep "\[recv-only-reset-test\]|stream_id:.*|ret:0|" svr_stdlog`
+server_rejected=`grep "RESET_STREAM on send-only stream" slog`
+client_close_code=`grep "xqc_parse_conn_close_frame|type:18|err_code:5|" clog`
+if [ -n "$result" ] && [ -n "$server_reset" ] \
+    && [ -z "$server_rejected" ] && [ -z "$client_close_code" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "reset_stream_on_recv_only_stream" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "reset_stream_on_recv_only_stream" "fail"
+fi
+
+}
+
 case_transport_stream_stop_sending_on_recv_only_stream()
 {
 
@@ -648,6 +674,7 @@ case_test_case "send_queue_full_batch" --id native --mode self-reporting --run c
 case_test_case "conn_rate_throttling" --id native --mode self-reporting --run case_transport_stream_conn_rate_throttling
 case_test_case "stream_rate_throttling" --id native --mode self-reporting --run case_transport_stream_stream_rate_throttling
 case_test_case "reset_stream_on_send_only_stream" --id native --mode self-reporting --run case_transport_stream_reset_stream_on_send_only_stream
+case_test_case "reset_stream_on_recv_only_stream" --id native --mode self-reporting --run case_transport_stream_reset_stream_on_recv_only_stream
 case_test_case "stop_sending_on_recv_only_stream" --id native --mode self-reporting --run case_transport_stream_stop_sending_on_recv_only_stream
 case_test_case "stream_frame_on_send_only_stream" --id native --mode self-reporting --run case_transport_stream_stream_frame_on_send_only_stream
 case_test_case "stream_frame_on_local_uncreated_stream" --id native --mode self-reporting --run case_transport_stream_stream_frame_on_local_uncreated_stream

--- a/harness/spec/validation.md
+++ b/harness/spec/validation.md
@@ -99,7 +99,7 @@ its case is retired so later changes cannot reuse it.
 
 | Range | New-case namespace | Allocated IDs |
 |-------|--------------------|---------------|
-| `[705, 799]` | QUIC Transport core | `705-714` |
+| `[705, 799]` | QUIC Transport core | `705-714`, `717` |
 | `[800, 899]` | Recovery and congestion control | `800` |
 | `[900, 999]` | QUIC-TLS | `902-903` |
 | `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1014` |

--- a/src/transport/xqc_frame.c
+++ b/src/transport/xqc_frame.c
@@ -1297,7 +1297,10 @@ xqc_process_reset_stream_frame(xqc_connection_t *conn, xqc_packet_in_t *packet_i
 
     xqc_stream_closing(stream, err_code);
 
-    if (stream->stream_state_send < XQC_SEND_STREAM_ST_RESET_SENT) {
+    /* RFC 9000 Section 3.3: only the sender sends RESET_STREAM. */
+    if (!xqc_stream_is_recv_only(conn->conn_type, stream_id)
+        && stream->stream_state_send < XQC_SEND_STREAM_ST_RESET_SENT)
+    {
         xqc_send_queue_drop_stream_frame_packets(conn, stream_id);
         xqc_write_reset_stream_to_packet(conn, stream, err_code, stream->stream_send_offset);
     }

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -284,6 +284,7 @@ uint64_t g_last_sock_op_time;
  * 709/710 for active_connection_id_limit minimum validation
  * 711/712 for PMTUD peer-option omission validation
  * 713/714 for max_ack_delay boundary validation
+ * 717 for RESET_STREAM on a peer-initiated unidirectional stream
  * 902/903 for AEAD confidentiality-limit validation
  * 1000-1014 for HTTP/3 protocol validation
  */

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -1164,6 +1164,24 @@ xqc_server_h3_conn_handshake_finished(xqc_h3_conn_t *h3_conn, void *conn_user_da
                ", sent_countable:%"PRIu64"\n", peer_limit, countable);
     }
 
+    if (g_test_case == 717) {
+        xqc_connection_t *conn = xqc_h3_conn_get_xqc_conn(h3_conn);
+        xqc_stream_t *stream;
+        xqc_int_t ret;
+
+        stream = xqc_stream_create_with_direction(conn, XQC_STREAM_UNI, NULL);
+        if (stream == NULL) {
+            printf("[recv-only-reset-test]|stream unavailable|\n");
+
+        } else {
+            ret = xqc_write_reset_stream_to_packet(conn, stream, 0,
+                                                    stream->stream_send_offset);
+            printf("[recv-only-reset-test]|stream_id:%"PRIu64"|ret:%d|\n",
+                   xqc_stream_id(stream), ret);
+        }
+        fflush(stdout);
+    }
+
     /* pretend to create a server-inited http3 stream */
     if (g_test_case == 17) {
         xqc_stream_t * stream = xqc_stream_create_with_direction(

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -226,6 +226,12 @@ main(int argc, char *argv[])
                         xqc_test_reset_stream_on_send_only_stream_server)
         || !CU_add_test(pSuite, "xqc_test_reset_stream_on_recv_only_stream_accepted",
                         xqc_test_reset_stream_on_recv_only_stream_accepted)
+        || !CU_add_test(pSuite,
+                        "xqc_test_process_reset_stream_on_bidirectional_stream",
+                        xqc_test_process_reset_stream_on_bidirectional_stream)
+        || !CU_add_test(pSuite,
+                        "xqc_test_process_reset_stream_on_recv_only_stream",
+                        xqc_test_process_reset_stream_on_recv_only_stream)
         || !CU_add_test(pSuite, "xqc_test_stop_sending_on_recv_only_stream",
                         xqc_test_stop_sending_on_recv_only_stream)
         || !CU_add_test(pSuite, "xqc_test_stop_sending_on_recv_only_stream_server",

--- a/tests/unittest/xqc_process_frame_test.c
+++ b/tests/unittest/xqc_process_frame_test.c
@@ -10,6 +10,8 @@
 #include "src/transport/xqc_packet.h"
 #include "src/transport/xqc_packet_in.h"
 #include "src/transport/xqc_packet_out.h"
+#include "src/transport/xqc_send_queue.h"
+#include "src/transport/xqc_stream.h"
 #include "src/common/utils/vint/xqc_variable_len_int.h"
 #include "src/transport/xqc_conn.h"
 #include "xquic/xqc_errno.h"
@@ -1403,6 +1405,58 @@ xqc_test_reset_stream_on_recv_only_stream_accepted(void)
     CU_ASSERT(pi.pos == frame_buf + sizeof(frame_buf));
 
     xqc_engine_destroy(conn->engine);
+}
+
+
+static void
+xqc_test_process_reset_stream_direction(xqc_stream_id_t stream_id,
+    xqc_bool_t expect_local_reset)
+{
+    unsigned char frame_buf[] = {0x04, (unsigned char)stream_id, 0x00, 0x00};
+    xqc_packet_in_t pi;
+    xqc_connection_t *conn;
+    xqc_stream_t *stream;
+    uint64_t packets_used;
+    xqc_int_t ret;
+
+    conn = xqc_test_dir_make_conn(XQC_CONN_TYPE_CLIENT);
+    CU_ASSERT_FATAL(conn != NULL);
+
+    packets_used = conn->conn_send_queue->sndq_packets_used;
+    xqc_test_dir_init_pi(&pi, frame_buf, sizeof(frame_buf));
+
+    ret = xqc_process_reset_stream_frame(conn, &pi);
+    CU_ASSERT(ret == XQC_OK);
+
+    stream = xqc_find_stream_by_id(stream_id, conn->streams_hash);
+    CU_ASSERT_FATAL(stream != NULL);
+    CU_ASSERT(stream->stream_state_recv == XQC_RECV_STREAM_ST_RESET_RECVD);
+
+    if (expect_local_reset) {
+        CU_ASSERT(conn->conn_send_queue->sndq_packets_used
+                  == packets_used + 1);
+        CU_ASSERT(stream->stream_state_send == XQC_SEND_STREAM_ST_RESET_SENT);
+
+    } else {
+        CU_ASSERT(conn->conn_send_queue->sndq_packets_used == packets_used);
+        CU_ASSERT(stream->stream_state_send == XQC_SEND_STREAM_ST_READY);
+    }
+
+    xqc_engine_destroy(conn->engine);
+}
+
+void
+xqc_test_process_reset_stream_on_bidirectional_stream(void)
+{
+    /* Server-initiated bidirectional stream: the client has a sending part. */
+    xqc_test_process_reset_stream_direction(1, XQC_TRUE);
+}
+
+void
+xqc_test_process_reset_stream_on_recv_only_stream(void)
+{
+    /* RFC 9000 Section 3.3: the receiver cannot send RESET_STREAM. */
+    xqc_test_process_reset_stream_direction(3, XQC_FALSE);
 }
 
 

--- a/tests/unittest/xqc_process_frame_test.h
+++ b/tests/unittest/xqc_process_frame_test.h
@@ -70,6 +70,10 @@ void xqc_test_reset_stream_on_send_only_stream_server(void);
 
 void xqc_test_reset_stream_on_recv_only_stream_accepted(void);
 
+void xqc_test_process_reset_stream_on_bidirectional_stream(void);
+
+void xqc_test_process_reset_stream_on_recv_only_stream(void);
+
 void xqc_test_stop_sending_on_recv_only_stream(void);
 
 void xqc_test_stop_sending_on_recv_only_stream_server(void);


### PR DESCRIPTION
### Mechanism

Skip the automatic local RESET_STREAM response when a peer reset belongs to a
receive-only stream, while preserving the existing bidirectional-stream
behavior.

- RFC or draft: RFC 9000 Sections 3.3 and 19.4

Fixes: #512

### Validation Cases

- 717 — a server-initiated unidirectional reset leaves the connection usable
- 705 — an illegal reset on a send-only stream is rejected with STREAM_STATE_ERROR

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Complete
- CI: Pending
