### PR TITLE
[~] Fix #605: Enforce ACK delay RTT lower bound

### DIFF
--- a/src/transport/xqc_send_ctl.c
+++ b/src/transport/xqc_send_ctl.c
@@ -1171,11 +1171,12 @@ xqc_send_ctl_update_rtt(xqc_send_ctl_t *send_ctl, xqc_usec_t *latest_rtt, xqc_us
             ack_delay = xqc_min(ack_delay, XQC_DEFAULT_MAX_ACK_DELAY * 1000);
         }
 
-        /* Adjust for ack delay if it's plausible. */
+        /*
+         * RFC 9002 Section 5.3: do not subtract ack_delay if the result
+         * would be less than min_rtt.
+         */
         xqc_usec_t adjusted_rtt = *latest_rtt;
-        if (adjusted_rtt > ack_delay
-            && (adjusted_rtt + 1000) >= (send_ctl->ctl_minrtt + ack_delay)) 
-        {
+        if (ack_delay <= adjusted_rtt - send_ctl->ctl_minrtt) {
             adjusted_rtt -= ack_delay;
         }
 

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -339,6 +339,12 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite, "xqc_test_send_ctl_update_rtt_ack_delay_cap",
                         xqc_test_send_ctl_update_rtt_ack_delay_cap)
         || !CU_add_test(pSuite,
+                        "xqc_test_send_ctl_update_rtt_subtracts_at_min_rtt",
+                        xqc_test_send_ctl_update_rtt_subtracts_at_min_rtt)
+        || !CU_add_test(pSuite,
+                        "xqc_test_send_ctl_update_rtt_rejects_below_min_rtt",
+                        xqc_test_send_ctl_update_rtt_rejects_below_min_rtt)
+        || !CU_add_test(pSuite,
                         "xqc_test_send_ctl_granularity_marks_at_boundary",
                         xqc_test_send_ctl_granularity_marks_at_boundary)
         || !CU_add_test(pSuite,

--- a/tests/unittest/xqc_send_ctl_test.c
+++ b/tests/unittest/xqc_send_ctl_test.c
@@ -169,6 +169,60 @@ xqc_test_send_ctl_run_rtt_case(xqc_connection_t *conn, xqc_path_ctx_t *path,
 
 
 void
+xqc_test_send_ctl_update_rtt_subtracts_at_min_rtt(void)
+{
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_FATAL(conn != NULL);
+    CU_ASSERT_FATAL(conn->conn_initial_path != NULL);
+
+    xqc_rtt_case_t tc = {
+        .name = "subtracts_at_min_rtt",
+        .hsk_confirmed = XQC_FALSE,
+        .first_sample  = XQC_FALSE,
+        .remote_max_ack_delay_ms = 100,
+        .input_ack_delay = 10000,
+        .latest_rtt      = 20000,
+        .pre_minrtt      = 10000,
+        .pre_srtt        = 20000,
+        .pre_rttvar      = 1000,
+        .expected_srtt   = 18750,
+        .expected_rttvar = 3250,
+        .expected_minrtt = 10000,
+    };
+
+    xqc_test_send_ctl_run_rtt_case(conn, conn->conn_initial_path, &tc);
+    xqc_engine_destroy(conn->engine);
+}
+
+
+void
+xqc_test_send_ctl_update_rtt_rejects_below_min_rtt(void)
+{
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_FATAL(conn != NULL);
+    CU_ASSERT_FATAL(conn->conn_initial_path != NULL);
+
+    xqc_rtt_case_t tc = {
+        .name = "rejects_below_min_rtt",
+        .hsk_confirmed = XQC_FALSE,
+        .first_sample  = XQC_FALSE,
+        .remote_max_ack_delay_ms = 100,
+        .input_ack_delay = 10000,
+        .latest_rtt      = 19999,
+        .pre_minrtt      = 10000,
+        .pre_srtt        = 20000,
+        .pre_rttvar      = 1000,
+        .expected_srtt   = 19999,
+        .expected_rttvar = 750,
+        .expected_minrtt = 10000,
+    };
+
+    xqc_test_send_ctl_run_rtt_case(conn, conn->conn_initial_path, &tc);
+    xqc_engine_destroy(conn->engine);
+}
+
+
+void
 xqc_test_send_ctl_update_rtt_ack_delay_cap(void)
 {
     xqc_connection_t *conn = test_engine_connect();
@@ -289,8 +343,8 @@ xqc_test_send_ctl_update_rtt_ack_delay_cap(void)
             .pre_srtt        = 12000,
             .pre_rttvar      = 1000,
             /*
-             * adjusted_rtt + 1000us = 13000us, minrtt + ack_delay = 21000us;
-             * plausibility check fails, ack_delay not subtracted.
+             * latest_rtt = 12000us is below minrtt + ack_delay = 21000us,
+             * so ack_delay is not subtracted.
              */
             .expected_srtt   = 12000,
             .expected_rttvar = 750,

--- a/tests/unittest/xqc_send_ctl_test.h
+++ b/tests/unittest/xqc_send_ctl_test.h
@@ -22,6 +22,13 @@ void xqc_test_pto_remote_default_when_unset(void);
 void xqc_test_send_ctl_update_rtt_ack_delay_cap(void);
 
 /*
+ * RFC 9002 Section 5.3 permits subtracting ack_delay when the result is
+ * exactly min_rtt, but forbids subtraction when the result is smaller.
+ */
+void xqc_test_send_ctl_update_rtt_subtracts_at_min_rtt(void);
+void xqc_test_send_ctl_update_rtt_rejects_below_min_rtt(void);
+
+/*
  * RFC 9002 Section 6.1.2 recommends a 1 ms timer granularity. Verify that
  * time-threshold loss detection fires at that boundary, but not before it.
  */


### PR DESCRIPTION
### Mechanism

Reject ACK-delay subtraction whenever the adjusted RTT would fall below
`min_rtt`, using an overflow-safe form of the lower-bound check required by
RFC 9002 Section 5.3.

Fixes: #605

- RFC or draft: RFC 9002 Section 5.3

### Validation Cases

- Not applicable — existing client-to-server cases cannot deterministically control the sender RTT sample and peer ACK delay at a microsecond boundary.

### CONTRIBUTING.md

- Overall: Passed
- Local regression: Complete
- CI: Complete
