### PR TITLE
[~] Fix #617: Reject DATAGRAM frames at invalid encryption levels

### DIFF
--- a/case_test/transport/datagram.sh
+++ b/case_test/transport/datagram.sh
@@ -331,6 +331,50 @@ fi
 
 }
 
+case_transport_datagram_1rtt_frame_allowed()
+{
+case_test_stop_server
+rm -f test_session tp_localhost xqc_token
+case_test_start_server stdbuf -oL ${SERVER_BIN} -l d -Q 65535 -e -U 1 \
+    -x 1201 > svr_stdlog
+sleep 1
+clear_log
+echo -e "1-RTT DATAGRAM frame allowed...\c"
+${CLIENT_BIN} -l d -T 1 -s 1000 -U 1 -Q 65535 -E -1 -x 1201 > stdlog
+cli_res=`grep "\[dgram\]|echo_check|same_content:yes|" stdlog`
+svr_res=`grep "\[dgram-encryption-level-test\]|1RTT|received:" svr_stdlog`
+errlog=`grep_err_log`
+if [ -n "$cli_res" ] && [ -n "$svr_res" ] && [ -z "$errlog" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "datagram_1rtt_frame_allowed" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "datagram_1rtt_frame_allowed" "fail"
+fi
+}
+
+case_transport_datagram_initial_frame_rejected()
+{
+case_test_stop_server
+rm -f test_session tp_localhost xqc_token
+case_test_start_server ${SERVER_BIN} -l d -Q 65535 -x 1202 > /dev/null
+sleep 1
+clear_log
+echo -e "Initial DATAGRAM frame rejected...\c"
+${CLIENT_BIN} -l d -T 1 -s 1 -Q 65535 -1 -x 1202 > stdlog
+write_res=`grep "\[dgram-encryption-level-test\]|initial_write_ret:0|" stdlog`
+reject_res=`grep "illegal DATAGRAM frame in INIT packet" slog`
+protocol_res=`grep "err:0xa" slog`
+if [ -n "$write_res" ] && [ -n "$reject_res" ] \
+    && [ -n "$protocol_res" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "datagram_initial_frame_rejected" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "datagram_initial_frame_rejected" "fail"
+fi
+}
+
 case_transport_datagram_send_1RTT_datagram_100KB_batch()
 {
 case_test_stop_server
@@ -1472,6 +1516,8 @@ case_test_case "datagram_mss_limited_by_max_datagram_frame_size" --id native --m
 case_test_case "send_0RTT_datagram_100KB" --id native --mode self-reporting --run case_transport_datagram_send_0RTT_datagram_100KB
 case_test_case "send_0RTT_datagram_100KB_batch" --id native --mode self-reporting --run case_transport_datagram_send_0RTT_datagram_100KB_batch
 case_test_case "send_1RTT_datagram_100KB" --id native --mode self-reporting --run case_transport_datagram_send_1RTT_datagram_100KB
+case_test_case "datagram_1rtt_frame_allowed" --id 1201 --mode self-reporting --run case_transport_datagram_1rtt_frame_allowed
+case_test_case "datagram_initial_frame_rejected" --id 1202 --mode self-reporting --run case_transport_datagram_initial_frame_rejected
 case_test_case "send_1RTT_datagram_100KB_batch" --id native --mode self-reporting --run case_transport_datagram_send_1RTT_datagram_100KB_batch
 case_test_case "send_0rtt_datagram_without_saved_datagram_tp" --id native --mode self-reporting --run case_transport_datagram_send_0rtt_datagram_without_saved_datagram_tp
 case_test_case "send_0rtt_datagram_without_saved_datagram_tp_batch" --id native --mode self-reporting --run case_transport_datagram_send_0rtt_datagram_without_saved_datagram_tp_batch

--- a/harness/spec/validation.md
+++ b/harness/spec/validation.md
@@ -105,7 +105,7 @@ its case is retired so later changes cannot reuse it.
 | `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1014`, `1017-1018` |
 | `[1100, 1149]` | QPACK | None |
 | `[1150, 1199]` | HTTP priority | None |
-| `[1200, 1299]` | QUIC DATAGRAM | None |
+| `[1200, 1299]` | QUIC DATAGRAM | `1201-1202` |
 | `[1300, 1399]` | Multipath QUIC | None |
 | `[1400, 1499]` | MoQT | None |
 | `[1500, 1599]` | LOC and MSF application protocols | None |

--- a/src/transport/xqc_frame.c
+++ b/src/transport/xqc_frame.c
@@ -1657,6 +1657,18 @@ xqc_process_new_token_frame(xqc_connection_t *conn, xqc_packet_in_t *packet_in)
 xqc_int_t
 xqc_process_datagram_frame(xqc_connection_t *conn, xqc_packet_in_t *packet_in)
 {
+    /* RFC 9221 Section 5 permits DATAGRAM only with 0-RTT or 1-RTT keys. */
+    if (packet_in->pi_pkt.pkt_type != XQC_PTYPE_0RTT
+        && packet_in->pi_pkt.pkt_type != XQC_PTYPE_SHORT_HEADER)
+    {
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|illegal DATAGRAM frame in %s packet, close with "
+                "PROTOCOL_VIOLATION|",
+                xqc_pkt_type_2_str(packet_in->pi_pkt.pkt_type));
+        XQC_CONN_ERR(conn, TRA_PROTOCOL_VIOLATION);
+        return -XQC_EPROTO;
+    }
+
     /* does not support datagram */
     if (conn->local_settings.max_datagram_frame_size == 0) {
         xqc_log(conn->log, XQC_LOG_ERROR,

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -91,6 +91,8 @@ printf_null(const char *format, ...)
 #define XQC_TEST_CASE_H3_GOAWAY_INCREASE 1018
 #define XQC_TEST_CASE_AEAD_CONFIDENTIALITY_BELOW_LIMIT 902
 #define XQC_TEST_CASE_AEAD_CONFIDENTIALITY_AT_LIMIT 903
+#define XQC_TEST_CASE_DATAGRAM_1RTT_ALLOWED 1201
+#define XQC_TEST_CASE_DATAGRAM_INITIAL_REJECTED 1202
 
 typedef struct user_conn_s user_conn_t;
 
@@ -104,6 +106,8 @@ static void xqc_client_send_test_goaway_ids(xqc_h3_conn_t *h3_conn,
     uint64_t first, uint64_t second);
 static void xqc_client_send_test_single_vint_frame(
     xqc_h3_conn_t *h3_conn, xqc_bool_t overlong);
+static xqc_int_t xqc_client_write_test_datagram_frame(
+    xqc_connection_t *conn, xqc_pkt_type_t pkt_type);
 
 
 #define XQC_TEST_DGRAM_BATCH_SZ 32
@@ -2129,6 +2133,28 @@ xqc_client_send_max_stream_data_test_frame(xqc_connection_t *conn)
     printf("[max-stream-data-test]|case:%d|stream_id:%"PRIu64
            "|limit:%"PRIu64"|\n", g_test_case, stream_id,
            XQC_MAX_FLOW_CONTROL_WINDOW);
+}
+
+static xqc_int_t
+xqc_client_write_test_datagram_frame(xqc_connection_t *conn,
+    xqc_pkt_type_t pkt_type)
+{
+    const unsigned char payload[1] = {0};
+    xqc_packet_out_t   *packet_out;
+    xqc_int_t           ret;
+
+    packet_out = xqc_write_new_packet(conn, pkt_type);
+    if (packet_out == NULL) {
+        return -XQC_ENOBUF;
+    }
+
+    ret = xqc_gen_datagram_frame(packet_out, payload, sizeof(payload));
+    if (ret == XQC_OK) {
+        printf("[dgram-encryption-level-test]|packet_type:%d|written|\n",
+               pkt_type);
+    }
+
+    return ret;
 }
 
 void
@@ -5734,6 +5760,14 @@ int main(int argc, char *argv[]) {
 
     /* copy cid to its own memory space to prevent crashes caused by internal cid being freed */
     memcpy(&user_conn->cid, cid, sizeof(*cid));
+
+    if (g_test_case == XQC_TEST_CASE_DATAGRAM_INITIAL_REJECTED
+        && user_conn->quic_conn != NULL)
+    {
+        xqc_int_t ret = xqc_client_write_test_datagram_frame(
+            user_conn->quic_conn, XQC_PTYPE_INIT);
+        printf("[dgram-encryption-level-test]|initial_write_ret:%d|\n", ret);
+    }
 
     user_conn->dgram_blk = calloc(1, sizeof(user_dgram_blk_t));
     user_conn->dgram_blk->data_sent = 0;

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -68,6 +68,7 @@ printf_null(const char *format, ...)
 #define XQC_TEST_CASE_H3_UPPERCASE_RESPONSE 1014
 #define XQC_TEST_CASE_AEAD_CONFIDENTIALITY_BELOW_LIMIT 902
 #define XQC_TEST_CASE_AEAD_CONFIDENTIALITY_AT_LIMIT 903
+#define XQC_TEST_CASE_DATAGRAM_1RTT_ALLOWED 1201
 
 extern long xqc_random(void);
 extern xqc_usec_t xqc_now();
@@ -387,6 +388,11 @@ static void
 xqc_server_datagram_read_callback(xqc_connection_t *conn, void *user_data, const void *data, size_t data_len, uint64_t dgram_ts)
 {
     user_conn_t *user_conn = (user_conn_t*)user_data;
+
+    if (g_test_case == XQC_TEST_CASE_DATAGRAM_1RTT_ALLOWED) {
+        printf("[dgram-encryption-level-test]|1RTT|received:%zu|\n",
+               data_len);
+    }
 
     if (g_send_dgram) {
         if (g_echo) {

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -334,6 +334,12 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite, "xqc_test_retry_same_length_dcid",
                         xqc_test_retry_same_length_dcid)
         || !CU_add_test(pSuite, "xqc_test_receive_invalid_dgram", xqc_test_receive_invalid_dgram)
+        || !CU_add_test(pSuite,
+                        "xqc_test_receive_dgram_at_valid_encryption_level",
+                        xqc_test_receive_dgram_at_valid_encryption_level)
+        || !CU_add_test(pSuite,
+                        "xqc_test_reject_dgram_at_invalid_encryption_level",
+                        xqc_test_reject_dgram_at_invalid_encryption_level)
         || !CU_add_test(pSuite, "xqc_test_h3_ext_frame", xqc_test_h3_ext_frame)
 #ifdef XQC_ENABLE_FEC
         || !CU_add_test(pSuite, "xqc_test_galois_calculation", xqc_test_galois_calculation)

--- a/tests/unittest/xqc_datagram_test.c
+++ b/tests/unittest/xqc_datagram_test.c
@@ -4,6 +4,7 @@
 
 #include "xqc_datagram_test.h"
 #include <CUnit/CUnit.h>
+#include <string.h>
 #include "src/transport/xqc_conn.h"
 #include "src/transport/xqc_engine.h"
 #include "src/transport/xqc_frame.h"
@@ -11,6 +12,19 @@
 #include "src/transport/xqc_packet_out.h"
 #include "src/transport/xqc_packet_in.h"
 #include "xqc_common_test.h"
+
+static void xqc_test_init_dgram_packet(xqc_packet_in_t *packet_in,
+    xqc_packet_out_t *packet_out, xqc_pkt_type_t pkt_type);
+
+static void
+xqc_test_init_dgram_packet(xqc_packet_in_t *packet_in,
+    xqc_packet_out_t *packet_out, xqc_pkt_type_t pkt_type)
+{
+    memset(packet_in, 0, sizeof(*packet_in));
+    packet_in->pos = packet_out->po_payload;
+    packet_in->last = packet_out->po_buf + packet_out->po_used_size;
+    packet_in->pi_pkt.pkt_type = pkt_type;
+}
 
 void
 xqc_test_receive_invalid_dgram()
@@ -20,7 +34,7 @@ xqc_test_receive_invalid_dgram()
     xqc_connection_t *conn = test_engine_connect();
     CU_ASSERT(conn != NULL);
 
-    const unsigned char payload[100];
+    const unsigned char payload[100] = {0};
 
     xqc_packet_out_t *packet_out;
     packet_out = xqc_write_new_packet(conn, XQC_PTYPE_SHORT_HEADER);
@@ -30,8 +44,8 @@ xqc_test_receive_invalid_dgram()
     CU_ASSERT(ret == XQC_OK);
 
     xqc_packet_in_t pkt_in;
-    pkt_in.pos = packet_out->po_payload;
-    pkt_in.last = packet_out->po_buf + packet_out->po_used_size;
+    xqc_test_init_dgram_packet(&pkt_in, packet_out,
+                               XQC_PTYPE_SHORT_HEADER);
     conn->local_settings.max_datagram_frame_size = 0;
 
     ret = xqc_process_datagram_frame(conn, &pkt_in);
@@ -46,4 +60,73 @@ xqc_test_receive_invalid_dgram()
     CU_ASSERT(ret == XQC_OK);
 
     xqc_engine_destroy(conn->engine);
+}
+
+void
+xqc_test_receive_dgram_at_valid_encryption_level()
+{
+    const xqc_pkt_type_t pkt_types[] = {
+        XQC_PTYPE_0RTT, XQC_PTYPE_SHORT_HEADER
+    };
+    const unsigned char payload[1] = {0};
+    xqc_connection_t   *conn;
+    xqc_packet_out_t   *packet_out;
+    xqc_packet_in_t     packet_in;
+    xqc_int_t           ret;
+
+    conn = test_engine_connect();
+    CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+    conn->local_settings.max_datagram_frame_size = 64;
+
+    packet_out = xqc_write_new_packet(conn, XQC_PTYPE_SHORT_HEADER);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(packet_out);
+    ret = xqc_gen_datagram_frame(packet_out, payload, sizeof(payload));
+    CU_ASSERT_EQUAL_FATAL(ret, XQC_OK);
+
+    for (size_t i = 0; i < sizeof(pkt_types) / sizeof(pkt_types[0]); i++) {
+        xqc_test_init_dgram_packet(&packet_in, packet_out, pkt_types[i]);
+
+        ret = xqc_process_datagram_frame(conn, &packet_in);
+
+        CU_ASSERT_EQUAL(ret, XQC_OK);
+        CU_ASSERT(packet_in.pi_frame_types & XQC_FRAME_BIT_DATAGRAM);
+        CU_ASSERT(packet_in.pos == packet_in.last);
+    }
+
+    xqc_engine_destroy(conn->engine);
+}
+
+void
+xqc_test_reject_dgram_at_invalid_encryption_level()
+{
+    const xqc_pkt_type_t pkt_types[] = {
+        XQC_PTYPE_INIT, XQC_PTYPE_HSK
+    };
+    const unsigned char payload[1] = {0};
+
+    for (size_t i = 0; i < sizeof(pkt_types) / sizeof(pkt_types[0]); i++) {
+        xqc_connection_t *conn = test_engine_connect();
+        CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+        conn->local_settings.max_datagram_frame_size = 64;
+
+        xqc_packet_out_t *packet_out =
+            xqc_write_new_packet(conn, XQC_PTYPE_SHORT_HEADER);
+        CU_ASSERT_PTR_NOT_NULL_FATAL(packet_out);
+        xqc_int_t ret = xqc_gen_datagram_frame(packet_out, payload,
+                                               sizeof(payload));
+        CU_ASSERT_EQUAL_FATAL(ret, XQC_OK);
+
+        xqc_packet_in_t packet_in;
+        xqc_test_init_dgram_packet(&packet_in, packet_out, pkt_types[i]);
+        unsigned char *frame_start = packet_in.pos;
+
+        ret = xqc_process_datagram_frame(conn, &packet_in);
+
+        CU_ASSERT_EQUAL(ret, -XQC_EPROTO);
+        CU_ASSERT_EQUAL(conn->conn_err, TRA_PROTOCOL_VIOLATION);
+        CU_ASSERT(packet_in.pos == frame_start);
+        CU_ASSERT_FALSE(packet_in.pi_frame_types & XQC_FRAME_BIT_DATAGRAM);
+
+        xqc_engine_destroy(conn->engine);
+    }
 }

--- a/tests/unittest/xqc_datagram_test.h
+++ b/tests/unittest/xqc_datagram_test.h
@@ -6,5 +6,7 @@
 #define _XQC_DATAGRAM_TEST_H_INCLUDED_
 
 void xqc_test_receive_invalid_dgram();
+void xqc_test_receive_dgram_at_valid_encryption_level();
+void xqc_test_reject_dgram_at_invalid_encryption_level();
 
 #endif /* _XQC_CUBIC_TEST_H_INCLUDED_ */


### PR DESCRIPTION
### Mechanism

Reject DATAGRAM frames carried in Initial or Handshake packets before frame
parsing or application delivery, and close the connection with
`PROTOCOL_VIOLATION`. DATAGRAM frames protected with 0-RTT or 1-RTT keys
remain accepted.

- RFC or draft: RFC 9221 Section 5; RFC 9000 Section 12.4

Fixes: #617

### Validation Cases

- 1201 — Accept a negotiated DATAGRAM frame in a 1-RTT packet and complete the echo exchange
- 1202 — Reject a DATAGRAM frame in an Initial packet with `PROTOCOL_VIOLATION`

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Incomplete — cases 1201 and 1202 were not rerun after rebase; the selector requires sudo preflight
- CI: Pending
