### PR TITLE
[~] Fix #568: Reject MAX_STREAM_DATA on receive-only streams

### DIFF
--- a/case_test/transport/stream.sh
+++ b/case_test/transport/stream.sh
@@ -649,6 +649,63 @@ fi
 
 }
 
+case_transport_stream_max_stream_data_on_send_only_stream()
+{
+
+case_test_stop_server
+clear_log
+rm -f test_session xqc_token tp_localhost
+case_test_start_server ${SERVER_BIN} -l d -e > /dev/null
+sleep 1
+echo -e "max_stream_data_on_send_only_stream ...\c"
+${CLIENT_BIN} -s 1024 -l d -t 1 -E -x 718 > stdlog
+sleep 1
+result=`grep ">>>>>>>> pass:1" stdlog`
+server_received=`grep \
+    "xqc_parse_max_stream_data_frame|type:9|"\
+"stream_id:3|max_stream_data:4611686018427387903|" \
+    slog`
+server_applied=`grep \
+    "xqc_process_max_stream_data_frame|"\
+"max_stream_data=4611686018427387903|"\
+"max_stream_data_old=16777216|" \
+    slog`
+client_close_code=`grep "xqc_parse_conn_close_frame|type:18|err_code:5|" clog`
+if [ -n "$result" ] && [ -n "$server_received" ] \
+    && [ -n "$server_applied" ] \
+    && [ -z "$client_close_code" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "max_stream_data_on_send_only_stream" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "max_stream_data_on_send_only_stream" "fail"
+fi
+
+}
+
+case_transport_stream_max_stream_data_on_recv_only_stream()
+{
+
+case_test_stop_server
+clear_log
+rm -f test_session xqc_token tp_localhost
+case_test_start_server ${SERVER_BIN} -l d -e > /dev/null
+sleep 1
+echo -e "max_stream_data_on_recv_only_stream ...\c"
+${CLIENT_BIN} -s 1024 -l d -t 1 -E -x 719 >> clog
+sleep 1
+server_rejected=`grep "MAX_STREAM_DATA on recv-only stream|stream_id:2|" slog`
+client_close_code=`grep "xqc_parse_conn_close_frame|type:18|err_code:5|" clog`
+if [ -n "$server_rejected" ] && [ -n "$client_close_code" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "max_stream_data_on_recv_only_stream" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "max_stream_data_on_recv_only_stream" "fail"
+fi
+
+}
+
 case_test_case "server_inited_stream" --id native --mode self-reporting --run case_transport_stream_server_inited_stream
 case_test_case "stream_send_pure_fin" --id native --mode self-reporting --run case_transport_stream_stream_send_pure_fin
 case_test_case "stream_read_notify_fail" --id native --mode self-reporting --run case_transport_stream_stream_read_notify_fail
@@ -678,6 +735,12 @@ case_test_case "reset_stream_on_recv_only_stream" --id native --mode self-report
 case_test_case "stop_sending_on_recv_only_stream" --id native --mode self-reporting --run case_transport_stream_stop_sending_on_recv_only_stream
 case_test_case "stream_frame_on_send_only_stream" --id native --mode self-reporting --run case_transport_stream_stream_frame_on_send_only_stream
 case_test_case "stream_frame_on_local_uncreated_stream" --id native --mode self-reporting --run case_transport_stream_stream_frame_on_local_uncreated_stream
+case_test_case "max_stream_data_on_send_only_stream" --id native \
+    --mode self-reporting \
+    --run case_transport_stream_max_stream_data_on_send_only_stream
+case_test_case "max_stream_data_on_recv_only_stream" --id native \
+    --mode self-reporting \
+    --run case_transport_stream_max_stream_data_on_recv_only_stream
 
 if case_test_is_discovery; then
     case_test_run

--- a/harness/spec/validation.md
+++ b/harness/spec/validation.md
@@ -99,7 +99,7 @@ its case is retired so later changes cannot reuse it.
 
 | Range | New-case namespace | Allocated IDs |
 |-------|--------------------|---------------|
-| `[705, 799]` | QUIC Transport core | `705-714`, `717` |
+| `[705, 799]` | QUIC Transport core | `705-714`, `717-719` |
 | `[800, 899]` | Recovery and congestion control | `800` |
 | `[900, 999]` | QUIC-TLS | `902-903` |
 | `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1014`, `1017-1018` |

--- a/src/transport/xqc_frame_parser.c
+++ b/src/transport/xqc_frame_parser.c
@@ -1871,6 +1871,15 @@ xqc_parse_max_stream_data_frame(xqc_packet_in_t *packet_in, xqc_stream_id_t *str
     }
     p += vlen;
 
+    /* RFC 9000 Section 19.10: a receiver cannot grant itself send credit. */
+    if (xqc_stream_is_recv_only(conn->conn_type, *stream_id)) {
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|MAX_STREAM_DATA on recv-only stream|stream_id:%ui|",
+                *stream_id);
+        XQC_CONN_ERR(conn, TRA_STREAM_STATE_ERROR);
+        return -XQC_EPROTO;
+    }
+
     vlen = xqc_vint_read(p, end, max_stream_data);
     if (vlen < 0) {
         return -XQC_EVINTREAD;

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -289,6 +289,7 @@ uint64_t g_last_sock_op_time;
  * 711/712 for PMTUD peer-option omission validation
  * 713/714 for max_ack_delay boundary validation
  * 717 for RESET_STREAM on a peer-initiated unidirectional stream
+ * 718/719 for MAX_STREAM_DATA stream direction validation
  * 902/903 for AEAD confidentiality-limit validation
  * 1000-1014 for HTTP/3 protocol validation
  */
@@ -2101,6 +2102,35 @@ xqc_client_send_wrong_direction_frame(xqc_connection_t *conn)
     printf("test case %d, wrong direction frame written\n", g_test_case);
 }
 
+static void
+xqc_client_send_max_stream_data_test_frame(xqc_connection_t *conn)
+{
+    xqc_packet_out_t *packet_out;
+    xqc_stream_id_t   stream_id;
+    ssize_t           ret;
+
+    packet_out = xqc_write_new_packet(conn, XQC_PTYPE_SHORT_HEADER);
+    if (packet_out == NULL) {
+        printf("test case %d, xqc_write_new_packet error\n", g_test_case);
+        return;
+    }
+
+    stream_id = g_test_case == 718 ? 3 : 2;
+    ret = xqc_gen_max_stream_data_frame(packet_out, stream_id,
+                                        XQC_MAX_FLOW_CONTROL_WINDOW);
+    if (ret < 0) {
+        printf("test case %d, MAX_STREAM_DATA generation error:%zd\n",
+               g_test_case, ret);
+        xqc_maybe_recycle_packet_out(packet_out, conn);
+        return;
+    }
+
+    packet_out->po_used_size += ret;
+    printf("[max-stream-data-test]|case:%d|stream_id:%"PRIu64
+           "|limit:%"PRIu64"|\n", g_test_case, stream_id,
+           XQC_MAX_FLOW_CONTROL_WINDOW);
+}
+
 void
 xqc_client_h3_conn_handshake_finished(xqc_h3_conn_t *h3_conn, void *user_data)
 {
@@ -2121,6 +2151,10 @@ xqc_client_h3_conn_handshake_finished(xqc_h3_conn_t *h3_conn, void *user_data)
     /* issues #565/#566/#567: wrong direction frame, 1-RTT is available here */
     if (g_test_case >= 705 && g_test_case <= 708) {
         xqc_client_send_wrong_direction_frame(h3_conn->conn);
+    }
+
+    if (g_test_case == 718 || g_test_case == 719) {
+        xqc_client_send_max_stream_data_test_frame(h3_conn->conn);
     }
 
     xqc_conn_stats_t stats = xqc_conn_get_stats(p_ctx->engine, &user_conn->cid);

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -219,7 +219,7 @@ main(int argc, char *argv[])
                         xqc_test_conn_close_app_error_in_handshake_rejected)
         || !CU_add_test(pSuite, "xqc_test_peer_key_update_error_not_0rtt",
                         xqc_test_peer_key_update_error_not_0rtt)
-        /* issues #565/#566/#567: RFC 9000 stream directionality checks */
+        /* RFC 9000 stream directionality checks */
         || !CU_add_test(pSuite, "xqc_test_reset_stream_on_send_only_stream",
                         xqc_test_reset_stream_on_send_only_stream)
         || !CU_add_test(pSuite, "xqc_test_reset_stream_on_send_only_stream_server",
@@ -238,6 +238,15 @@ main(int argc, char *argv[])
                         xqc_test_stop_sending_on_recv_only_stream_server)
         || !CU_add_test(pSuite, "xqc_test_stop_sending_on_send_only_stream_accepted",
                         xqc_test_stop_sending_on_send_only_stream_accepted)
+        || !CU_add_test(pSuite,
+                        "xqc_test_max_stream_data_on_recv_only_stream",
+                        xqc_test_max_stream_data_on_recv_only_stream)
+        || !CU_add_test(pSuite,
+                        "xqc_test_max_stream_data_on_recv_only_stream_server",
+                        xqc_test_max_stream_data_on_recv_only_stream_server)
+        || !CU_add_test(pSuite,
+                        "xqc_test_max_stream_data_on_send_only_stream",
+                        xqc_test_max_stream_data_on_send_only_stream)
         || !CU_add_test(pSuite, "xqc_test_stream_frame_on_send_only_stream",
                         xqc_test_stream_frame_on_send_only_stream)
         || !CU_add_test(pSuite, "xqc_test_stream_frame_on_send_only_stream_server",

--- a/tests/unittest/xqc_process_frame_test.c
+++ b/tests/unittest/xqc_process_frame_test.c
@@ -1533,6 +1533,74 @@ xqc_test_stop_sending_on_send_only_stream_accepted(void)
 }
 
 
+/* ---- RFC 9000 Section 19.10 MAX_STREAM_DATA direction ---- */
+
+void
+xqc_test_max_stream_data_on_recv_only_stream(void)
+{
+    /* client + SVR_UNI: the client has no sending side on stream 3 */
+    xqc_connection_t *conn = xqc_test_dir_make_conn(XQC_CONN_TYPE_CLIENT);
+    CU_ASSERT_FATAL(conn != NULL);
+
+    unsigned char frame_buf[] = {0x11, 0x03, 0x10};
+    xqc_packet_in_t pi;
+    xqc_test_dir_init_pi(&pi, frame_buf, sizeof(frame_buf));
+
+    xqc_int_t ret = xqc_process_max_stream_data_frame(conn, &pi);
+    CU_ASSERT(ret == -XQC_EPROTO);
+    CU_ASSERT(conn->conn_err == TRA_STREAM_STATE_ERROR);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+void
+xqc_test_max_stream_data_on_recv_only_stream_server(void)
+{
+    /* server + CLI_UNI: the server has no sending side on stream 2 */
+    xqc_connection_t *conn = xqc_test_dir_make_conn(XQC_CONN_TYPE_SERVER);
+    CU_ASSERT_FATAL(conn != NULL);
+
+    unsigned char frame_buf[] = {0x11, 0x02, 0x10};
+    xqc_packet_in_t pi;
+    xqc_test_dir_init_pi(&pi, frame_buf, sizeof(frame_buf));
+
+    xqc_int_t ret = xqc_process_max_stream_data_frame(conn, &pi);
+    CU_ASSERT(ret == -XQC_EPROTO);
+    CU_ASSERT(conn->conn_err == TRA_STREAM_STATE_ERROR);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+void
+xqc_test_max_stream_data_on_send_only_stream(void)
+{
+    xqc_connection_t *conn = xqc_test_dir_make_conn(XQC_CONN_TYPE_CLIENT);
+    CU_ASSERT_FATAL(conn != NULL);
+
+    xqc_stream_t *stream = xqc_stream_create_with_direction(
+        conn, XQC_STREAM_UNI, NULL);
+    CU_ASSERT_FATAL(stream != NULL);
+    CU_ASSERT(stream->stream_id == 2);
+
+    stream->stream_flow_ctl.fc_max_stream_data_can_send = 0;
+    stream->stream_flag |= XQC_STREAM_FLAG_DATA_BLOCKED;
+
+    unsigned char frame_buf[] = {0x11, 0x02, 0x10};
+    xqc_packet_in_t pi;
+    xqc_test_dir_init_pi(&pi, frame_buf, sizeof(frame_buf));
+
+    xqc_int_t ret = xqc_process_max_stream_data_frame(conn, &pi);
+    CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(conn->conn_err == 0);
+    CU_ASSERT(stream->stream_flow_ctl.fc_max_stream_data_can_send == 16);
+    CU_ASSERT(!(stream->stream_flag & XQC_STREAM_FLAG_DATA_BLOCKED));
+    CU_ASSERT(pi.pi_frame_types & XQC_FRAME_BIT_MAX_STREAM_DATA);
+    CU_ASSERT(pi.pos == frame_buf + sizeof(frame_buf));
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
 /* ---- issue #565: STREAM frame direction and locally initiated stream ---- */
 
 void

--- a/tests/unittest/xqc_process_frame_test.h
+++ b/tests/unittest/xqc_process_frame_test.h
@@ -63,7 +63,7 @@ void xqc_test_conn_close_app_error_in_handshake_rejected(void);
 
 void xqc_test_peer_key_update_error_not_0rtt(void);
 
-/* issues #565 / #566 / #567: RFC 9000 stream directionality checks */
+/* RFC 9000 stream directionality checks */
 void xqc_test_reset_stream_on_send_only_stream(void);
 
 void xqc_test_reset_stream_on_send_only_stream_server(void);
@@ -79,6 +79,12 @@ void xqc_test_stop_sending_on_recv_only_stream(void);
 void xqc_test_stop_sending_on_recv_only_stream_server(void);
 
 void xqc_test_stop_sending_on_send_only_stream_accepted(void);
+
+void xqc_test_max_stream_data_on_recv_only_stream(void);
+
+void xqc_test_max_stream_data_on_recv_only_stream_server(void);
+
+void xqc_test_max_stream_data_on_send_only_stream(void);
 
 void xqc_test_stream_frame_on_send_only_stream(void);
 


### PR DESCRIPTION
### Mechanism

Reject `MAX_STREAM_DATA` frames for receive-only streams with
`STREAM_STATE_ERROR`, while preserving flow-control updates for streams on
which the receiver can send, as required by RFC 9000 Section 19.10.

Fixes: #568

- RFC or draft: RFC 9000 Section 19.10

### Validation Cases

- 718 — accepts MAX_STREAM_DATA for a send-only stream and updates its limit
- 719 — rejects MAX_STREAM_DATA for a receive-only stream with error 0x05

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Complete
- CI: Pending
