### PR TITLE
[~] Fix #501: Preserve DATAGRAM transport parameter width

### DIFF
--- a/case_test/transport/datagram.sh
+++ b/case_test/transport/datagram.sh
@@ -55,8 +55,8 @@ case_transport_datagram__0rtt_max_datagram_frame_size_is_valid()
 clear_log
 echo -e "0RTT max_datagram_frame_size is valid...\c"
 ${CLIENT_BIN} -l d >> stdlog
-cli_result=`grep "|0RTT_transport_params|max_datagram_frame_size:9000|" clog`
-cli_result2=`grep "|1RTT_transport_params|max_datagram_frame_size:9000|" clog`
+cli_result=`grep "|0RTT_transport_params|max_datagram_frame_size:65536|" clog`
+cli_result2=`grep "|1RTT_transport_params|max_datagram_frame_size:65536|" clog`
 errlog=`grep_err_log`
 if [ -n "$cli_result" ] && [ -n "$cli_result2" ] && [ -z "$errlog" ]; then
     echo ">>>>>>>> pass:1"
@@ -77,7 +77,7 @@ sleep 1
 clear_log
 echo -e "0RTT max_datagram_frame_size is invalid...\c"
 ${CLIENT_BIN} -l d >> stdlog
-cli_result=`grep "|0RTT_transport_params|max_datagram_frame_size:9000|" clog`
+cli_result=`grep "|0RTT_transport_params|max_datagram_frame_size:65536|" clog`
 cli_err=`grep "[error].*err:0x55" clog`
 svr_err=`grep "[error].*err:0xa" slog`
 if [ -n "$cli_result" ] && [ -n "$cli_err" ] && [ -n "$svr_err" ]; then

--- a/case_test/transport/datagram.sh
+++ b/case_test/transport/datagram.sh
@@ -31,13 +31,13 @@ if [ -f stdlog ]; then
     rm -f stdlog
 fi
 
-case_test_start_server ${SERVER_BIN} -l d -Q 9000 > /dev/null
+case_test_start_server ${SERVER_BIN} -l d -Q 65536 > /dev/null
 sleep 1
 clear_log
 echo -e "datagram frame size negotiation...\c"
-${CLIENT_BIN} -l d -Q 9000 >> stdlog
-cli_result=`grep "|1RTT_transport_params|max_datagram_frame_size:9000|" clog`
-svr_result=`grep "|1RTT_transport_params|max_datagram_frame_size:9000|" slog`
+${CLIENT_BIN} -l d -Q 65536 >> stdlog
+cli_result=`grep "|1RTT_transport_params|max_datagram_frame_size:65536|" clog`
+svr_result=`grep "|1RTT_transport_params|max_datagram_frame_size:65536|" slog`
 errlog=`grep_err_log`
 if [ -n "$cli_result" ] && [ -n "$svr_result" ] && [ -z "$errlog" ]; then
     echo ">>>>>>>> pass:1"

--- a/include/xquic/xquic.h
+++ b/include/xquic/xquic.h
@@ -1364,12 +1364,13 @@ typedef struct xqc_conn_settings_s {
     size_t                      probing_pkt_out_size;
 
     /**
-     * datgram option
-     * 0: no support for datagram mode (default)
-     * >0: the max size of datagrams that the local end is willing to receive
-     * 65535: the local end is willing to receive a datagram with any length as long as it fits in a QUIC packet
+     * RFC 9221 Section 3 DATAGRAM transport parameter.
+     * 0: no support for DATAGRAM frames (default)
+     * >0: maximum DATAGRAM frame size the local endpoint accepts
+     * 65535: recommended when any DATAGRAM fitting in a QUIC packet is
+     * accepted
      */
-    uint16_t                    max_datagram_frame_size;
+    uint64_t                    max_datagram_frame_size;
     
     /** 
      * multipath option:

--- a/include/xquic/xquic_typedef.h
+++ b/include/xquic/xquic_typedef.h
@@ -251,12 +251,12 @@ typedef enum xqc_conn_settings_type_e {
 } xqc_conn_settings_type_t;
 
 typedef struct xqc_conn_public_local_trans_settings_s {
-    uint16_t max_datagram_frame_size;
+    uint64_t max_datagram_frame_size;
     uint8_t  datagram_redundancy;
 } xqc_conn_public_local_trans_settings_t;
 
 typedef struct xqc_conn_public_remote_trans_settings_s {
-    uint16_t max_datagram_frame_size;
+    uint64_t max_datagram_frame_size;
 } xqc_conn_public_remote_trans_settings_t;
 
 typedef struct xqc_stream_settings_s {

--- a/src/transport/xqc_client.c
+++ b/src/transport/xqc_client.c
@@ -298,7 +298,8 @@ xqc_client_create_connection(xqc_engine_t *engine, xqc_cid_t dcid, xqc_cid_t sci
                                         conn_ssl_config->transport_parameter_data_len, &tp);
         if (ret == XQC_OK) {
             xqc_conn_set_early_remote_transport_params(xc, &tp);
-            xqc_log(xc->log, XQC_LOG_DEBUG, "|0RTT_transport_params|max_datagram_frame_size:%ud|",
+            xqc_log(xc->log, XQC_LOG_DEBUG,
+                    "|0RTT_transport_params|max_datagram_frame_size:%ui|",
                     xc->remote_settings.max_datagram_frame_size);
         }
     }
@@ -317,4 +318,3 @@ fail:
     xqc_conn_destroy(xc);
     return NULL;
 }
-

--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -1335,8 +1335,8 @@ xqc_conn_server_on_alpn(xqc_connection_t *conn, const unsigned char *alpn, size_
         }
 
         conn->conn_flag &= ~XQC_CONN_FLAG_LOCAL_TP_UPDATED;
-        xqc_log(conn->log, XQC_LOG_INFO, 
-                "|update tp|max_datagram_frame_size:%ud|", 
+        xqc_log(conn->log, XQC_LOG_INFO,
+                "|update tp|max_datagram_frame_size:%ui|",
                 conn->local_settings.max_datagram_frame_size);
     }
 
@@ -6266,7 +6266,8 @@ xqc_conn_tls_transport_params_cb(const uint8_t *tp, size_t len, void *user_data)
         return;
     }
 
-    xqc_log(conn->log, XQC_LOG_DEBUG, "|1RTT_transport_params|max_datagram_frame_size:%ud|",
+    xqc_log(conn->log, XQC_LOG_DEBUG,
+            "|1RTT_transport_params|max_datagram_frame_size:%ui|",
             conn->remote_settings.max_datagram_frame_size);
 
     if ((conn->local_settings.extended_ack_features & XQC_ACK_EXT_FEATURE_BIT_RECV_TS)

--- a/src/transport/xqc_conn.h
+++ b/src/transport/xqc_conn.h
@@ -260,7 +260,7 @@ typedef struct {
     uint64_t                no_crypto;
     uint64_t                enable_multipath;
     xqc_multipath_version_t multipath_version;
-    uint16_t                max_datagram_frame_size;
+    uint64_t                max_datagram_frame_size;
     uint32_t                conn_options[XQC_CO_MAX_NUM];
     uint8_t                 conn_option_num;
 

--- a/src/transport/xqc_datagram.c
+++ b/src/transport/xqc_datagram.c
@@ -94,11 +94,9 @@ xqc_datagram_record_mss(xqc_connection_t *conn)
         mtu_limit = 0;
     }
 
-    dgram_frame_limit = conn->remote_settings.max_datagram_frame_size
-                        >= XQC_DATAGRAM_HEADER_BYTES
-                        ? conn->remote_settings.max_datagram_frame_size
-                          - XQC_DATAGRAM_HEADER_BYTES
-                        : 0;
+    dgram_frame_limit = conn->remote_settings.max_datagram_frame_size >= XQC_DATAGRAM_HEADER_BYTES ?
+                        conn->remote_settings.max_datagram_frame_size - XQC_DATAGRAM_HEADER_BYTES :
+                        0;
     dgram_frame_limit = xqc_min(dgram_frame_limit,
                                 (uint64_t) udp_payload_limit);
     conn->dgram_mss = xqc_min((size_t) dgram_frame_limit, mtu_limit);

--- a/src/transport/xqc_datagram.c
+++ b/src/transport/xqc_datagram.c
@@ -52,7 +52,8 @@ xqc_datagram_destroy_0rtt_buffer(xqc_datagram_0rtt_buffer_t* buffer)
 void 
 xqc_datagram_record_mss(xqc_connection_t *conn)
 {
-    size_t udp_payload_limit = 0, dgram_frame_limit = 0, mtu_limit = 0;
+    size_t udp_payload_limit = 0, mtu_limit = 0;
+    uint64_t dgram_frame_limit;
     size_t quic_header_size, headroom;
     size_t old_mss = conn->dgram_mss;
 
@@ -93,11 +94,14 @@ xqc_datagram_record_mss(xqc_connection_t *conn)
         mtu_limit = 0;
     }
 
-    dgram_frame_limit = conn->remote_settings.max_datagram_frame_size >= XQC_DATAGRAM_HEADER_BYTES ?
-                        conn->remote_settings.max_datagram_frame_size - XQC_DATAGRAM_HEADER_BYTES : 
-                        0;
-    
-    conn->dgram_mss = xqc_min(xqc_min(dgram_frame_limit, udp_payload_limit), mtu_limit);
+    dgram_frame_limit = conn->remote_settings.max_datagram_frame_size
+                        >= XQC_DATAGRAM_HEADER_BYTES
+                        ? conn->remote_settings.max_datagram_frame_size
+                          - XQC_DATAGRAM_HEADER_BYTES
+                        : 0;
+    dgram_frame_limit = xqc_min(dgram_frame_limit,
+                                (uint64_t) udp_payload_limit);
+    conn->dgram_mss = xqc_min((size_t) dgram_frame_limit, mtu_limit);
 end:
     if (conn->dgram_mss > old_mss) {
         conn->conn_flag |= XQC_CONN_FLAG_DGRAM_MSS_NOTIFY;

--- a/src/transport/xqc_frame.c
+++ b/src/transport/xqc_frame.c
@@ -1672,7 +1672,7 @@ xqc_process_datagram_frame(xqc_connection_t *conn, xqc_packet_in_t *packet_in)
     if (ret == -XQC_EPROTO) {
         xqc_log(conn->log, XQC_LOG_ERROR,
                 "|the endpoint receives a DATAGRAM frame larger than max_datagram_frame_size|"
-                "max_datagram_frame_size:%ud|frame_size:%ud|",
+                "max_datagram_frame_size:%ui|frame_size:%uz|",
                 conn->local_settings.max_datagram_frame_size,
                 data_len + XQC_DATAGRAM_HEADER_BYTES);
         XQC_CONN_ERR(conn, TRA_PROTOCOL_VIOLATION);

--- a/src/transport/xqc_transport_params.h
+++ b/src/transport/xqc_transport_params.h
@@ -142,7 +142,7 @@ typedef struct {
     /* 
     * support for datagram (RFC 9221).
     * default: 0, not supported
-    * special: 65535, accept datagram frames with any length in a QUIC packet
+    * recommended: 65535, accept any DATAGRAM frame fitting in a QUIC packet
     */
     uint64_t                max_datagram_frame_size;
 

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -82,6 +82,11 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite, "xqc_test_get_random", xqc_test_get_random)
         || !CU_add_test(pSuite, "xqc_test_engine_create", xqc_test_engine_create)
         || !CU_add_test(pSuite, "xqc_test_conn_create", xqc_test_conn_create)
+        || !CU_add_test(pSuite, "xqc_test_datagram_transport_param_65536",
+                        xqc_test_datagram_transport_param_65536)
+        || !CU_add_test(pSuite,
+                        "xqc_test_datagram_transport_param_varint_max",
+                        xqc_test_datagram_transport_param_varint_max)
         || !CU_add_test(pSuite, "xqc_test_conn_idle_timeout", xqc_test_conn_idle_timeout)
         || !CU_add_test(pSuite, "xqc_test_conn_pmtud_force_enable",
                         xqc_test_conn_pmtud_force_enable)

--- a/tests/unittest/xqc_conn_test.c
+++ b/tests/unittest/xqc_conn_test.c
@@ -91,6 +91,59 @@ xqc_test_conn_create()
     xqc_engine_destroy(engine);
 }
 
+
+void
+xqc_test_datagram_transport_param_65536(void)
+{
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+
+    xqc_transport_params_t params;
+    xqc_init_transport_params(&params);
+    params.max_datagram_frame_size = 65536;
+
+    CU_ASSERT_EQUAL(
+        xqc_conn_set_early_remote_transport_params(conn, &params), XQC_OK);
+    CU_ASSERT_EQUAL(conn->remote_settings.max_datagram_frame_size, 65536);
+
+    xqc_conn_public_remote_trans_settings_t public_settings;
+    public_settings = xqc_conn_get_public_remote_trans_settings(conn);
+    CU_ASSERT_EQUAL(public_settings.max_datagram_frame_size, 65536);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
+void
+xqc_test_datagram_transport_param_varint_max(void)
+{
+    const uint64_t varint_max = (1ULL << 62) - 1;
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+
+    xqc_transport_params_t remote_params;
+    xqc_init_transport_params(&remote_params);
+    remote_params.max_datagram_frame_size = varint_max;
+
+    CU_ASSERT_EQUAL(
+        xqc_conn_set_early_remote_transport_params(conn, &remote_params),
+        XQC_OK);
+    CU_ASSERT_EQUAL(conn->remote_settings.max_datagram_frame_size,
+                    varint_max);
+
+    xqc_conn_public_local_trans_settings_t public_settings = {0};
+    public_settings.max_datagram_frame_size = varint_max;
+    xqc_conn_set_public_local_trans_settings(conn, &public_settings);
+
+    xqc_transport_params_t local_params;
+    xqc_init_transport_params(&local_params);
+    CU_ASSERT_EQUAL(xqc_conn_get_local_transport_params(conn, &local_params),
+                    XQC_OK);
+    CU_ASSERT_EQUAL(local_params.max_datagram_frame_size, varint_max);
+
+    xqc_engine_destroy(conn->engine);
+}
+
 /* -------------------------------------------------------------------------
  * Idle-timeout negotiation tests for issue #559.
  *

--- a/tests/unittest/xqc_conn_test.c
+++ b/tests/unittest/xqc_conn_test.c
@@ -28,6 +28,9 @@
 #include "src/common/utils/vint/xqc_variable_len_int.h"
 
 extern void xqc_conn_tls_error_cb(xqc_int_t tls_err, void *user_data);
+extern xqc_int_t xqc_conn_set_remote_transport_params(
+    xqc_connection_t *conn, const xqc_transport_params_t *params,
+    xqc_transport_params_type_t exttype);
 
 /* forward-declare: defined in xqc_conn.c, exposed via xqc_conn_tls_cbs */
 xqc_int_t xqc_conn_tls_alpn_select_cb(const char *alpn,
@@ -102,13 +105,22 @@ xqc_test_datagram_transport_param_65536(void)
     xqc_init_transport_params(&params);
     params.max_datagram_frame_size = 65536;
 
-    CU_ASSERT_EQUAL(
-        xqc_conn_set_early_remote_transport_params(conn, &params), XQC_OK);
+    CU_ASSERT_EQUAL(xqc_conn_set_remote_transport_params(
+                        conn, &params, XQC_TP_TYPE_ENCRYPTED_EXTENSIONS),
+                    XQC_OK);
     CU_ASSERT_EQUAL(conn->remote_settings.max_datagram_frame_size, 65536);
 
     xqc_conn_public_remote_trans_settings_t public_settings;
     public_settings = xqc_conn_get_public_remote_trans_settings(conn);
     CU_ASSERT_EQUAL(public_settings.max_datagram_frame_size, 65536);
+
+    xqc_engine_destroy(conn->engine);
+
+    conn = test_engine_connect();
+    CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+    CU_ASSERT_EQUAL(
+        xqc_conn_set_early_remote_transport_params(conn, &params), XQC_OK);
+    CU_ASSERT_EQUAL(conn->remote_settings.max_datagram_frame_size, 65536);
 
     xqc_engine_destroy(conn->engine);
 }

--- a/tests/unittest/xqc_conn_test.h
+++ b/tests/unittest/xqc_conn_test.h
@@ -6,6 +6,8 @@
 #define XQC_CONN_TEST_H
 
 void xqc_test_conn_create();
+void xqc_test_datagram_transport_param_65536(void);
+void xqc_test_datagram_transport_param_varint_max(void);
 void xqc_test_conn_idle_timeout();
 void xqc_test_conn_pmtud_force_enable();
 void xqc_test_conn_pmtud_legacy_compatibility();


### PR DESCRIPTION
### Mechanism

Preserve `max_datagram_frame_size` as a 64-bit QUIC variable-length integer
across decoded transport parameters and public/internal connection settings,
then bound it by UDP payload and path-MTU limits before converting to the
platform size type. This prevents values above 65535 from truncating to zero
and being misread as no DATAGRAM support.

- RFC or draft: RFC 9221 Section 3; RFC 9000 Section 16

Fixes: #501

### Validation Cases

- native — negotiates a DATAGRAM limit of 65536 in both directions.
- native — preserves the remembered 65536 limit across valid 0-RTT resumption.
- native — rejects incompatible remembered 0-RTT state when the replacement
  peer advertises a smaller DATAGRAM limit.
- native — reports DATAGRAM sending as unsupported when the peer advertises
  zero.

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Complete
- CI: Pending — required checks
