### PR TITLE
[+] Fix #664: Send CONNECTION_CLOSE reason phrases

### DIFF
--- a/case_test/transport/core.sh
+++ b/case_test/transport/core.sh
@@ -169,7 +169,10 @@ sleep 1
 clear_log
 echo -e "user close connection ...\c"
 ${CLIENT_BIN} -s 1024000 -l d -t 1 -E -x 2 >> clog
-if grep "<==.*CONNECTION_CLOSE" clog >/dev/null && grep "==>.*CONNECTION_CLOSE" clog >/dev/null; then
+if grep "<==.*CONNECTION_CLOSE" clog >/dev/null \
+    && grep "==>.*CONNECTION_CLOSE" clog >/dev/null \
+    && grep "frames_processed.*reason_len:11" slog >/dev/null
+then
     echo ">>>>>>>> pass:1"
     case_print_result "user_close_connection" "pass"
 else
@@ -187,7 +190,11 @@ grep_err_log
 clear_log
 echo -e "close connection with error ...\c"
 ${CLIENT_BIN} -s 1024000 -l d -t 1 -E -x 3 >> stdlog
-if grep "<==.*CONNECTION_CLOSE" clog >/dev/null && grep "==>.*CONNECTION_CLOSE" clog >/dev/null && grep "conn closing: 1" stdlog >/dev/null; then
+if grep "<==.*CONNECTION_CLOSE" clog >/dev/null \
+    && grep "==>.*CONNECTION_CLOSE" clog >/dev/null \
+    && grep "conn closing: 1" stdlog >/dev/null \
+    && grep "frames_processed.*reason_len:11" slog >/dev/null
+then
     echo ">>>>>>>> pass:1"
     case_print_result "close_connection_with_error" "pass"
 else

--- a/src/common/xqc_log_event_callback.c
+++ b/src/common/xqc_log_event_callback.c
@@ -474,8 +474,10 @@ xqc_log_TRA_FRAMES_PROCESSED_callback(xqc_log_t *log, const char *func, ...)
 
     case XQC_FRAME_CONNECTION_CLOSE: {
         uint64_t err_code = va_arg(args, uint64_t);
+        uint64_t reason_len = va_arg(args, uint64_t);
         xqc_qlog_implement(log, TRA_FRAMES_PROCESSED, func,
-                          "|type:%d|err_code:%ui|", frame_type, err_code);
+                          "|type:%d|err_code:%ui|reason_len:%ui|",
+                          frame_type, err_code, reason_len);
         break;
     }
 

--- a/src/transport/xqc_frame_parser.c
+++ b/src/transport/xqc_frame_parser.c
@@ -1347,7 +1347,10 @@ xqc_gen_conn_close_frame(xqc_packet_out_t *packet_out,
         return -XQC_ENOBUF;
     }
 
-    if (reason == NULL || reason_len > remained - need) {
+    if (reason == NULL
+        || reason_len > XQC_MAX_CONN_CLOSE_REASON_LEN
+        || reason_len > remained - need)
+    {
         reason_len = 0;
 
     } else {

--- a/src/transport/xqc_frame_parser.c
+++ b/src/transport/xqc_frame_parser.c
@@ -1328,25 +1328,35 @@ xqc_parse_ack_frame(xqc_packet_in_t *packet_in, xqc_connection_t *conn, xqc_ack_
  */
 ssize_t
 xqc_gen_conn_close_frame(xqc_packet_out_t *packet_out, 
-    uint64_t err_code, int is_app, int frame_type)
+    uint64_t err_code, int is_app, int frame_type,
+    const unsigned char *reason, size_t reason_len)
 {
     unsigned char *dst_buf = packet_out->po_buf + packet_out->po_used_size;
     const unsigned char *begin = dst_buf;
-
-    unsigned char *reason = NULL;
-    int reason_len = 0;
+    size_t remained = xqc_get_po_remained_size(packet_out);
 
     unsigned frame_type_bits = xqc_vint_get_2bit(frame_type);
-    unsigned reason_len_bits = xqc_vint_get_2bit(reason_len);
+    unsigned reason_len_bits = 0;
     unsigned err_code_len_bits = xqc_vint_get_2bit(err_code);
 
-    unsigned need = 1
-                    + xqc_vint_len(err_code_len_bits)
-                    + xqc_vint_len(frame_type_bits)
-                    + xqc_vint_len(reason_len_bits)
-                    + reason_len;
-    if (need > xqc_get_po_remained_size(packet_out)) {
+    size_t need = 1
+                  + xqc_vint_len(err_code_len_bits)
+                  + (is_app ? 0 : xqc_vint_len(frame_type_bits))
+                  + xqc_vint_len(reason_len_bits);
+    if (need > remained) {
         return -XQC_ENOBUF;
+    }
+
+    if (reason == NULL || reason_len > remained - need) {
+        reason_len = 0;
+
+    } else {
+        reason_len_bits = xqc_vint_get_2bit(reason_len);
+        need += xqc_vint_len(reason_len_bits) - 1 + reason_len;
+        if (need > remained) {
+            reason_len = 0;
+            reason_len_bits = 0;
+        }
     }
 
     if (is_app) {
@@ -1367,12 +1377,10 @@ xqc_gen_conn_close_frame(xqc_packet_out_t *packet_out,
     xqc_vint_write(dst_buf, reason_len, reason_len_bits, xqc_vint_len(reason_len_bits));
     dst_buf += xqc_vint_len(reason_len_bits);
 
-#if 0   /* TODO: reason not supported yet */
     if (reason_len > 0) {
         memcpy(dst_buf, reason, reason_len);
         dst_buf += reason_len;
     }
-#endif
 
     packet_out->po_frame_types |= XQC_FRAME_BIT_CONNECTION_CLOSE;
 
@@ -1411,7 +1419,10 @@ xqc_parse_conn_close_frame(xqc_packet_in_t *packet_in, uint64_t *err_code, xqc_c
     }
     p += vlen;
 
-    /* TODO: get reason string */
+    if (reason_len > (uint64_t) (end - p)) {
+        return -XQC_EILLEGAL_FRAME;
+    }
+
     p += reason_len;
 
     packet_in->pos = p;
@@ -1429,7 +1440,8 @@ xqc_parse_conn_close_frame(xqc_packet_in_t *packet_in, uint64_t *err_code, xqc_c
                               : XQC_CONN_ERR_TYPE_APPLICATION;
     }
 
-    xqc_log_event(conn->log, TRA_FRAMES_PROCESSED, XQC_FRAME_CONNECTION_CLOSE, *err_code);
+    xqc_log_event(conn->log, TRA_FRAMES_PROCESSED,
+                  XQC_FRAME_CONNECTION_CLOSE, *err_code, reason_len);
     return XQC_OK;
 }
 

--- a/src/transport/xqc_frame_parser.h
+++ b/src/transport/xqc_frame_parser.h
@@ -71,7 +71,9 @@ ssize_t xqc_gen_ack_frame(xqc_connection_t *conn, xqc_packet_out_t *packet_out, 
 
 xqc_int_t xqc_parse_ack_frame(xqc_packet_in_t *packet_in, xqc_connection_t *conn, xqc_ack_info_t *ack_info);
 
-ssize_t xqc_gen_conn_close_frame(xqc_packet_out_t *packet_out, uint64_t err_code, int is_app, int frame_type);
+ssize_t xqc_gen_conn_close_frame(xqc_packet_out_t *packet_out,
+    uint64_t err_code, int is_app, int frame_type,
+    const unsigned char *reason, size_t reason_len);
 
 xqc_int_t xqc_parse_conn_close_frame(xqc_packet_in_t *packet_in, uint64_t *err_code, xqc_connection_t *conn);
 

--- a/src/transport/xqc_frame_parser.h
+++ b/src/transport/xqc_frame_parser.h
@@ -71,6 +71,8 @@ ssize_t xqc_gen_ack_frame(xqc_connection_t *conn, xqc_packet_out_t *packet_out, 
 
 xqc_int_t xqc_parse_ack_frame(xqc_packet_in_t *packet_in, xqc_connection_t *conn, xqc_ack_info_t *ack_info);
 
+#define XQC_MAX_CONN_CLOSE_REASON_LEN 128
+
 ssize_t xqc_gen_conn_close_frame(xqc_packet_out_t *packet_out,
     uint64_t err_code, int is_app, int frame_type,
     const unsigned char *reason, size_t reason_len);

--- a/src/transport/xqc_packet_out.c
+++ b/src/transport/xqc_packet_out.c
@@ -819,7 +819,14 @@ xqc_write_conn_close_to_packet(xqc_connection_t *conn, uint64_t err_code)
     err_code = XQC_CONN_ERR_CODE(err_code);
     err_code = xqc_conn_close_wire_error_code(err_code);
     reason = (const unsigned char *) conn->conn_close_msg;
-    reason_len = conn->conn_close_msg ? strlen(conn->conn_close_msg) : 0;
+    reason_len = conn->conn_close_msg
+                 ? strnlen(conn->conn_close_msg,
+                           XQC_MAX_CONN_CLOSE_REASON_LEN + 1)
+                 : 0;
+    if (reason_len > XQC_MAX_CONN_CLOSE_REASON_LEN) {
+        reason = NULL;
+        reason_len = 0;
+    }
 
     /*
      * RFC 9000 Section 10.2.3: application close frames sent in Initial or
@@ -1726,11 +1733,13 @@ xqc_write_path_status_frame_to_packet(xqc_connection_t *conn, xqc_path_ctx_t *pa
 size_t
 xqc_get_po_remained_size(xqc_packet_out_t *po)
 {
-    size_t res;
+    if (po->po_used_size > po->po_buf_size
+        || po->po_reserved_size > po->po_buf_size - po->po_used_size)
+    {
+        return 0;
+    }
 
-    res = po->po_buf_size - po->po_used_size - po->po_reserved_size;
-
-    return xqc_max(res, 0);
+    return po->po_buf_size - po->po_used_size - po->po_reserved_size;
 }
 
 size_t

--- a/src/transport/xqc_packet_out.c
+++ b/src/transport/xqc_packet_out.c
@@ -2,6 +2,7 @@
  * @copyright Copyright (c) 2022, Alibaba Group Holding Limited
  */
 
+#include <string.h>
 
 #include "src/common/utils/vint/xqc_variable_len_int.h"
 #include "src/transport/xqc_packet_out.h"
@@ -793,6 +794,8 @@ xqc_write_conn_close_to_packet(xqc_connection_t *conn, uint64_t err_code)
     xqc_packet_out_t *packet_out;
     xqc_pkt_type_t pkt_type = XQC_PTYPE_INIT;
     xqc_bool_t is_app;
+    const unsigned char *reason;
+    size_t reason_len;
 
     /* select packet type */
     if (xqc_tls_is_key_ready(conn->tls, XQC_ENC_LEV_HSK, XQC_KEY_TYPE_TX_WRITE)) {
@@ -815,6 +818,8 @@ xqc_write_conn_close_to_packet(xqc_connection_t *conn, uint64_t err_code)
     is_app = XQC_CONN_ERR_IS_APPLICATION(err_code);
     err_code = XQC_CONN_ERR_CODE(err_code);
     err_code = xqc_conn_close_wire_error_code(err_code);
+    reason = (const unsigned char *) conn->conn_close_msg;
+    reason_len = conn->conn_close_msg ? strlen(conn->conn_close_msg) : 0;
 
     /*
      * RFC 9000 Section 10.2.3: application close frames sent in Initial or
@@ -825,9 +830,12 @@ xqc_write_conn_close_to_packet(xqc_connection_t *conn, uint64_t err_code)
     {
         is_app = XQC_FALSE;
         err_code = TRA_APPLICATION_ERROR;
+        reason = NULL;
+        reason_len = 0;
     }
 
-    ret = xqc_gen_conn_close_frame(packet_out, err_code, is_app, 0);
+    ret = xqc_gen_conn_close_frame(packet_out, err_code, is_app, 0,
+                                   reason, reason_len);
     if (ret < 0) {
         xqc_log(conn->log, XQC_LOG_ERROR, "|xqc_gen_conn_close_frame error|");
         goto error;

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -102,6 +102,10 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite,
                         "xqc_test_conn_close_application_namespace",
                         xqc_test_conn_close_application_namespace)
+        || !CU_add_test(pSuite, "xqc_test_conn_close_reason_phrase",
+                        xqc_test_conn_close_reason_phrase)
+        || !CU_add_test(pSuite, "xqc_test_conn_close_reason_no_space",
+                        xqc_test_conn_close_reason_no_space)
         || !CU_add_test(pSuite, "xqc_test_conn_tls_error_first_writer_wins", xqc_test_conn_tls_error_first_writer_wins)
         || !CU_add_test(pSuite, "xqc_test_conn_tls_error_cb_alert_zero", xqc_test_conn_tls_error_cb_alert_zero)
         || !CU_add_test(pSuite, "xqc_test_conn_tls_error_cb_max_alert", xqc_test_conn_tls_error_cb_max_alert)
@@ -212,6 +216,8 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite,
                         "xqc_test_conn_close_transport_error_type_overlap",
                         xqc_test_conn_close_transport_error_type_overlap)
+        || !CU_add_test(pSuite, "xqc_test_conn_close_reason_truncated",
+                        xqc_test_conn_close_reason_truncated)
         || !CU_add_test(pSuite, "xqc_test_conn_close_valid_packet_types",
                         xqc_test_conn_close_valid_packet_types)
         || !CU_add_test(pSuite,

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -106,6 +106,8 @@ main(int argc, char *argv[])
                         xqc_test_conn_close_reason_phrase)
         || !CU_add_test(pSuite, "xqc_test_conn_close_reason_no_space",
                         xqc_test_conn_close_reason_no_space)
+        || !CU_add_test(pSuite, "xqc_test_conn_close_reason_too_long",
+                        xqc_test_conn_close_reason_too_long)
         || !CU_add_test(pSuite, "xqc_test_conn_tls_error_first_writer_wins", xqc_test_conn_tls_error_first_writer_wins)
         || !CU_add_test(pSuite, "xqc_test_conn_tls_error_cb_alert_zero", xqc_test_conn_tls_error_cb_alert_zero)
         || !CU_add_test(pSuite, "xqc_test_conn_tls_error_cb_max_alert", xqc_test_conn_tls_error_cb_max_alert)
@@ -136,6 +138,8 @@ main(int argc, char *argv[])
                         xqc_test_client_discards_received_zero_rtt)
         || !CU_add_test(pSuite, "xqc_test_server_buffers_received_zero_rtt",
                         xqc_test_server_buffers_received_zero_rtt)
+        || !CU_add_test(pSuite, "xqc_test_packet_out_remained_size",
+                        xqc_test_packet_out_remained_size)
         || !CU_add_test(pSuite, "xqc_test_crypto_frame_flood", xqc_test_crypto_frame_flood)
         || !CU_add_test(pSuite, "xqc_test_crypto_frame_bytes_limit", xqc_test_crypto_frame_bytes_limit)
         || !CU_add_test(pSuite, "xqc_test_crypto_frame_recycle", xqc_test_crypto_frame_recycle)

--- a/tests/unittest/xqc_conn_test.c
+++ b/tests/unittest/xqc_conn_test.c
@@ -925,6 +925,51 @@ xqc_test_conn_close_reason_no_space(void)
 
 
 void
+xqc_test_conn_close_reason_too_long(void)
+{
+    unsigned char reason[XQC_MAX_CONN_CLOSE_REASON_LEN + 1];
+    xqc_connection_t *conn;
+    xqc_packet_out_t *packet_out;
+    ssize_t written;
+
+    memset(reason, 'x', sizeof(reason));
+
+    conn = test_engine_connect();
+    CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+    conn->conn_close_msg = (const char *) reason;
+    CU_ASSERT_EQUAL(
+        xqc_write_conn_close_to_packet(conn, TRA_PROTOCOL_VIOLATION),
+        XQC_OK);
+    xqc_test_conn_close_packet_reason(conn, 0x1c, NULL, 0);
+    xqc_engine_destroy(conn->engine);
+
+    packet_out = xqc_packet_out_create(sizeof(reason) + 4);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(packet_out);
+
+    written = xqc_gen_conn_close_frame(
+        packet_out, TRA_PROTOCOL_VIOLATION, 0, 0,
+        reason, XQC_MAX_CONN_CLOSE_REASON_LEN);
+    CU_ASSERT_EQUAL(written, sizeof(reason) + 4);
+    CU_ASSERT_EQUAL(
+        memcmp(packet_out->po_buf + 5, reason,
+               XQC_MAX_CONN_CLOSE_REASON_LEN), 0);
+
+    xqc_packet_out_destroy(packet_out);
+
+    packet_out = xqc_packet_out_create(sizeof(reason) + 4);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(packet_out);
+
+    written = xqc_gen_conn_close_frame(packet_out,
+                                       TRA_PROTOCOL_VIOLATION, 0, 0,
+                                       reason, sizeof(reason));
+    CU_ASSERT_EQUAL(written, 4);
+    CU_ASSERT_EQUAL(packet_out->po_buf[3], 0);
+
+    xqc_packet_out_destroy(packet_out);
+}
+
+
+void
 xqc_test_conn_tls_error_first_writer_wins()
 {
     xqc_connection_t *conn = test_engine_connect();

--- a/tests/unittest/xqc_conn_test.c
+++ b/tests/unittest/xqc_conn_test.c
@@ -4,6 +4,7 @@
 
 #include <CUnit/CUnit.h>
 #include <stdint.h>
+#include <string.h>
 #include "xquic/xquic.h"
 #include "xquic/xqc_errno.h"
 #include "src/transport/xqc_conn.h"
@@ -37,6 +38,9 @@ static xqc_packet_out_t *xqc_test_get_conn_close_packet(
     xqc_connection_t *conn);
 static void xqc_test_conn_close_packet_value(xqc_connection_t *conn,
     xqc_pkt_type_t pkt_type, unsigned char frame_type, uint64_t err_code);
+static void xqc_test_conn_close_packet_reason(xqc_connection_t *conn,
+    unsigned char frame_type, const unsigned char *expected,
+    size_t expected_len);
 
 
 static xqc_packet_out_t *
@@ -76,6 +80,61 @@ xqc_test_conn_close_packet_value(xqc_connection_t *conn,
     CU_ASSERT(len > 0);
     if (len > 0) {
         CU_ASSERT_EQUAL(parsed_err_code, err_code);
+    }
+}
+
+
+static void
+xqc_test_conn_close_packet_reason(xqc_connection_t *conn,
+    unsigned char frame_type, const unsigned char *expected,
+    size_t expected_len)
+{
+    xqc_packet_out_t *packet_out;
+    unsigned char *pos;
+    const unsigned char *end;
+    uint64_t value;
+    ssize_t len;
+
+    packet_out = xqc_test_get_conn_close_packet(conn);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(packet_out);
+
+    pos = packet_out->po_payload;
+    end = packet_out->po_buf + packet_out->po_used_size;
+    CU_ASSERT_FATAL(pos < end);
+    CU_ASSERT_EQUAL(*pos++, frame_type);
+
+    len = xqc_vint_read(pos, end, &value);
+    CU_ASSERT(len > 0);
+    if (len <= 0) {
+        return;
+    }
+    pos += len;
+
+    if (frame_type == 0x1c) {
+        len = xqc_vint_read(pos, end, &value);
+        CU_ASSERT(len > 0);
+        if (len <= 0) {
+            return;
+        }
+        pos += len;
+    }
+
+    len = xqc_vint_read(pos, end, &value);
+    CU_ASSERT(len > 0);
+    if (len <= 0) {
+        return;
+    }
+    pos += len;
+
+    CU_ASSERT_EQUAL(value, expected_len);
+    CU_ASSERT((uint64_t) (end - pos) >= value);
+    if ((uint64_t) (end - pos) < value) {
+        return;
+    }
+
+    if (expected_len > 0) {
+        CU_ASSERT_PTR_NOT_NULL_FATAL(expected);
+        CU_ASSERT_EQUAL(memcmp(pos, expected, expected_len), 0);
     }
 }
 
@@ -794,7 +853,74 @@ xqc_test_conn_close_application_namespace(void)
      */
     xqc_test_conn_close_packet_value(conn, XQC_PTYPE_INIT, 0x1c,
                                      TRA_APPLICATION_ERROR);
+    xqc_test_conn_close_packet_reason(conn, 0x1c, NULL, 0);
     xqc_engine_destroy(conn->engine);
+}
+
+
+void
+xqc_test_conn_close_reason_phrase(void)
+{
+    static const unsigned char reason[] = "local error";
+    xqc_connection_t *conn;
+
+    conn = test_engine_connect();
+    CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+    conn->conn_close_msg = (const char *) reason;
+    CU_ASSERT_EQUAL(
+        xqc_write_conn_close_to_packet(conn, TRA_PROTOCOL_VIOLATION),
+        XQC_OK);
+    xqc_test_conn_close_packet_reason(conn, 0x1c, reason,
+                                      sizeof(reason) - 1);
+    xqc_engine_destroy(conn->engine);
+
+    conn = test_engine_connect();
+    CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+    conn->conn_flag |= XQC_CONN_FLAG_HANDSHAKE_COMPLETED
+                       | XQC_CONN_FLAG_HSK_ACKED;
+    conn->conn_close_msg = (const char *) reason;
+    CU_ASSERT_EQUAL(
+        xqc_write_conn_close_to_packet(
+            conn, XQC_CONN_ERR_ENCODE_APPLICATION(
+                H3_GENERAL_PROTOCOL_ERROR)),
+        XQC_OK);
+    xqc_test_conn_close_packet_reason(conn, 0x1d, reason,
+                                      sizeof(reason) - 1);
+    xqc_engine_destroy(conn->engine);
+}
+
+
+void
+xqc_test_conn_close_reason_no_space(void)
+{
+    static const unsigned char reason[] = "reason";
+    xqc_packet_out_t *packet_out;
+    ssize_t written;
+
+    packet_out = xqc_packet_out_create(4);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(packet_out);
+
+    written = xqc_gen_conn_close_frame(packet_out,
+                                       TRA_PROTOCOL_VIOLATION, 0, 0,
+                                       NULL, 0);
+    CU_ASSERT_EQUAL(written, 4);
+    CU_ASSERT_EQUAL(packet_out->po_buf[3], 0);
+
+    xqc_packet_out_destroy(packet_out);
+
+    packet_out = xqc_packet_out_create(4);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(packet_out);
+
+    written = xqc_gen_conn_close_frame(packet_out,
+                                       TRA_PROTOCOL_VIOLATION, 0, 0,
+                                       reason, sizeof(reason) - 1);
+    CU_ASSERT_EQUAL(written, 4);
+    CU_ASSERT_EQUAL(packet_out->po_buf[0], 0x1c);
+    CU_ASSERT_EQUAL(packet_out->po_buf[1], TRA_PROTOCOL_VIOLATION);
+    CU_ASSERT_EQUAL(packet_out->po_buf[2], 0);
+    CU_ASSERT_EQUAL(packet_out->po_buf[3], 0);
+
+    xqc_packet_out_destroy(packet_out);
 }
 
 

--- a/tests/unittest/xqc_conn_test.h
+++ b/tests/unittest/xqc_conn_test.h
@@ -21,6 +21,7 @@ void xqc_test_conn_close_transport_crypto_namespace(void);
 void xqc_test_conn_close_application_namespace(void);
 void xqc_test_conn_close_reason_phrase(void);
 void xqc_test_conn_close_reason_no_space(void);
+void xqc_test_conn_close_reason_too_long(void);
 void xqc_test_conn_tls_error_first_writer_wins();
 void xqc_test_conn_tls_error_cb_alert_zero();
 void xqc_test_conn_tls_error_cb_max_alert();

--- a/tests/unittest/xqc_conn_test.h
+++ b/tests/unittest/xqc_conn_test.h
@@ -19,6 +19,8 @@ void xqc_test_transport_error_code_passthrough(void);
 void xqc_test_0rtt_error_wire_codes(void);
 void xqc_test_conn_close_transport_crypto_namespace(void);
 void xqc_test_conn_close_application_namespace(void);
+void xqc_test_conn_close_reason_phrase(void);
+void xqc_test_conn_close_reason_no_space(void);
 void xqc_test_conn_tls_error_first_writer_wins();
 void xqc_test_conn_tls_error_cb_alert_zero();
 void xqc_test_conn_tls_error_cb_max_alert();

--- a/tests/unittest/xqc_packet_test.c
+++ b/tests/unittest/xqc_packet_test.c
@@ -125,6 +125,32 @@ xqc_test_server_buffers_received_zero_rtt(void)
 }
 
 
+void
+xqc_test_packet_out_remained_size(void)
+{
+    xqc_packet_out_t *packet_out;
+
+    packet_out = xqc_packet_out_create(16);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(packet_out);
+
+    CU_ASSERT_EQUAL(xqc_get_po_remained_size(packet_out), 16);
+
+    packet_out->po_used_size = 4;
+    packet_out->po_reserved_size = 3;
+    CU_ASSERT_EQUAL(xqc_get_po_remained_size(packet_out), 9);
+
+    packet_out->po_used_size = 17;
+    packet_out->po_reserved_size = 0;
+    CU_ASSERT_EQUAL(xqc_get_po_remained_size(packet_out), 0);
+
+    packet_out->po_used_size = 15;
+    packet_out->po_reserved_size = 2;
+    CU_ASSERT_EQUAL(xqc_get_po_remained_size(packet_out), 0);
+
+    xqc_packet_out_destroy(packet_out);
+}
+
+
 
 
 

--- a/tests/unittest/xqc_packet_test.c
+++ b/tests/unittest/xqc_packet_test.c
@@ -563,7 +563,8 @@ xqc_test_build_initial(test_ctx *cli, const xqc_cid_t *dcid,
 
     if (connection_close) {
         written = xqc_gen_conn_close_frame(packet_out,
-                                           TRA_PROTOCOL_VIOLATION, 0, 0);
+                                           TRA_PROTOCOL_VIOLATION, 0, 0,
+                                           NULL, 0);
         if (written <= 0) {
             goto end;
         }

--- a/tests/unittest/xqc_packet_test.h
+++ b/tests/unittest/xqc_packet_test.h
@@ -9,6 +9,7 @@ void xqc_test_short_header_packet_parse_cid();
 void xqc_test_long_header_packet_parse_cid();
 void xqc_test_client_discards_received_zero_rtt(void);
 void xqc_test_server_buffers_received_zero_rtt(void);
+void xqc_test_packet_out_remained_size(void);
 void xqc_test_packet_encrypt_hp_sample_boundary();
 void xqc_test_empty_pkt();
 void xqc_test_stateless_reset_parse_boundary(void);

--- a/tests/unittest/xqc_process_frame_test.c
+++ b/tests/unittest/xqc_process_frame_test.c
@@ -289,6 +289,35 @@ xqc_test_conn_close_transport_error_type_overlap(void)
 }
 
 
+void
+xqc_test_conn_close_reason_truncated(void)
+{
+    unsigned char frame[] = {
+        0x1c, 0x0a, 0x00, 0x03, 'b', 'a'
+    };
+    xqc_connection_t *conn;
+    xqc_packet_in_t packet_in;
+    uint64_t err_code;
+    xqc_int_t ret;
+
+    conn = test_engine_connect();
+    CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+
+    memset(&packet_in, 0, sizeof(packet_in));
+    packet_in.pos = frame;
+    packet_in.last = frame + sizeof(frame);
+
+    ret = xqc_parse_conn_close_frame(&packet_in, &err_code, conn);
+
+    CU_ASSERT_EQUAL(ret, -XQC_EILLEGAL_FRAME);
+    CU_ASSERT(packet_in.pos == frame);
+    CU_ASSERT_EQUAL(xqc_conn_get_err_type(conn),
+                    XQC_CONN_ERR_TYPE_UNKNOWN);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
 static void
 xqc_test_conn_close_frame_accepted(unsigned char *frame, size_t frame_len,
     xqc_pkt_type_t pkt_type, xqc_conn_type_t conn_type,
@@ -325,6 +354,9 @@ xqc_test_conn_close_valid_packet_types(void)
 {
     unsigned char transport_frame[] = {0x1c, 0x00, 0x00, 0x00};
     unsigned char application_frame[] = {0x1d, 0x00, 0x00};
+    unsigned char reason_frame[] = {
+        0x1c, 0x00, 0x00, 0x03, 'b', 'y', 'e'
+    };
 
     xqc_test_conn_close_frame_accepted(transport_frame,
         sizeof(transport_frame), XQC_PTYPE_INIT, XQC_CONN_TYPE_CLIENT,
@@ -338,6 +370,9 @@ xqc_test_conn_close_valid_packet_types(void)
     xqc_test_conn_close_frame_accepted(application_frame,
         sizeof(application_frame), XQC_PTYPE_SHORT_HEADER,
         XQC_CONN_TYPE_CLIENT, XQC_CONN_ERR_TYPE_APPLICATION);
+    xqc_test_conn_close_frame_accepted(reason_frame,
+        sizeof(reason_frame), XQC_PTYPE_SHORT_HEADER,
+        XQC_CONN_TYPE_CLIENT, XQC_CONN_ERR_TYPE_TRANSPORT);
 }
 
 

--- a/tests/unittest/xqc_process_frame_test.h
+++ b/tests/unittest/xqc_process_frame_test.h
@@ -57,6 +57,8 @@ void xqc_test_conn_close_application_error_type(void);
 
 void xqc_test_conn_close_transport_error_type_overlap(void);
 
+void xqc_test_conn_close_reason_truncated(void);
+
 void xqc_test_conn_close_valid_packet_types(void);
 
 void xqc_test_conn_close_app_error_in_handshake_rejected(void);


### PR DESCRIPTION
### Mechanism

Serialize the connection's existing close diagnostic as the Reason Phrase in
transport and application CONNECTION_CLOSE frames. Bound diagnostics to 128
bytes and retain a valid zero-length phrase when the diagnostic is absent,
oversized, or cannot fit completely. Guard packet remaining-space calculations
against invalid used or reserved sizes. Application closes converted to
transport closes during the handshake also clear the phrase.

- RFC or draft: RFC 9000 Sections [19.19](https://www.rfc-editor.org/rfc/rfc9000.html#section-19.19) and [10.2.3](https://www.rfc-editor.org/rfc/rfc9000.html#section-10.2.3)

Fixes: #664

### Validation Cases

- Pending — normal-close and error-close endpoint coverage requires cached sudo credentials

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Incomplete — endpoint coverage requires cached sudo credentials
- CI: Pending
