### PR TITLE
[~] Fix #669: Enforce PTO-based path validation timeout

### DIFF
--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -5176,6 +5176,12 @@ xqc_conn_process_packet_recved_path(xqc_connection_t *conn, xqc_cid_t *scid,
 
     xqc_send_ctl_on_dgram_received(path->path_send_ctl, packet_in_size);
 
+    /*
+     * RFC 9000 Section 8.2.4: retain the abandonment deadline armed when
+     * PATH_CHALLENGE is sent. Unrelated packets must not extend validation.
+     * A matching PATH_RESPONSE changes the path to ACTIVE before this point,
+     * so the ordinary idle timeout is then restarted below.
+     */
     if (path->path_state != XQC_PATH_STATE_VALIDATING) {
         xqc_timer_set(&path->path_send_ctl->path_timer_manager,
                       XQC_TIMER_PATH_IDLE, recv_time,

--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -5176,8 +5176,11 @@ xqc_conn_process_packet_recved_path(xqc_connection_t *conn, xqc_cid_t *scid,
 
     xqc_send_ctl_on_dgram_received(path->path_send_ctl, packet_in_size);
 
-    xqc_timer_set(&path->path_send_ctl->path_timer_manager, XQC_TIMER_PATH_IDLE,
-                  recv_time, xqc_path_get_idle_timeout(path) * 1000);
+    if (path->path_state != XQC_PATH_STATE_VALIDATING) {
+        xqc_timer_set(&path->path_send_ctl->path_timer_manager,
+                      XQC_TIMER_PATH_IDLE, recv_time,
+                      xqc_path_get_idle_timeout(path) * 1000);
+    }
 
     return;
 }

--- a/src/transport/xqc_multipath.c
+++ b/src/transport/xqc_multipath.c
@@ -210,6 +210,9 @@ xqc_path_init(xqc_path_ctx_t *path, xqc_connection_t *conn)
         }
 
         xqc_set_path_state(path, XQC_PATH_STATE_VALIDATING);
+        xqc_timer_set(&path->path_send_ctl->path_timer_manager,
+                      XQC_TIMER_PATH_IDLE, xqc_monotonic_timestamp(),
+                      xqc_path_get_validation_timeout(path));
     }
 
     xqc_log(conn->log, XQC_LOG_DEBUG, 
@@ -1079,6 +1082,16 @@ xqc_path_get_idle_timeout(xqc_path_ctx_t *path)
     return xqc_conn_get_idle_timeout(path->parent_conn);
 }
 
+xqc_usec_t
+xqc_path_get_validation_timeout(xqc_path_ctx_t *path)
+{
+    xqc_usec_t current_pto = xqc_conn_get_max_pto(path->parent_conn);
+    xqc_usec_t new_path_pto = xqc_send_ctl_calc_pto(path->path_send_ctl);
+
+    /* RFC 9000 Section 8.2.4: allow multiple PTOs before abandoning. */
+    return 3 * xqc_max(current_pto, new_path_pto);
+}
+
 void
 xqc_path_validate(xqc_path_ctx_t *path)
 {
@@ -1087,6 +1100,9 @@ xqc_path_validate(xqc_path_ctx_t *path)
     if (path->path_state == XQC_PATH_STATE_VALIDATING) {
         xqc_set_path_state(path, XQC_PATH_STATE_ACTIVE);
         path->parent_conn->validated_path_count++;
+        xqc_timer_set(&path->path_send_ctl->path_timer_manager,
+                      XQC_TIMER_PATH_IDLE, xqc_monotonic_timestamp(),
+                      xqc_path_get_idle_timeout(path) * 1000);
 
         xqc_log(conn->log, XQC_LOG_DEBUG, 
                 "|path validated|path_id:%ui|validated_path_count:%ud|", 

--- a/src/transport/xqc_multipath.h
+++ b/src/transport/xqc_multipath.h
@@ -190,6 +190,8 @@ xqc_bool_t xqc_is_same_addr_as_any_path(xqc_connection_t *conn, const struct soc
 
 xqc_int_t xqc_generate_path_challenge_data(xqc_connection_t *conn, xqc_path_ctx_t *path);
 
+xqc_int_t xqc_path_init(xqc_path_ctx_t *path, xqc_connection_t *conn);
+
 /* check mp support */
 xqc_multipath_mode_t xqc_conn_enable_multipath(xqc_connection_t *conn);
 
@@ -244,6 +246,8 @@ void xqc_stream_path_metrics_on_recv(xqc_connection_t *conn, xqc_stream_t *strea
 
 xqc_msec_t xqc_path_get_idle_timeout(xqc_path_ctx_t *path);
 
+xqc_usec_t xqc_path_get_validation_timeout(xqc_path_ctx_t *path);
+
 void xqc_path_validate(xqc_path_ctx_t *path);
 
 xqc_int_t xqc_conn_is_current_mp_version_supported(xqc_multipath_version_t mp_version);
@@ -263,5 +267,4 @@ double xqc_path_recent_loss_rate(xqc_path_ctx_t *path);
 double xqc_conn_recent_loss_rate(xqc_connection_t *conn);
 
 #endif /* XQC_MULTIPATH_H */
-
 

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -350,6 +350,17 @@ main(int argc, char *argv[])
                         xqc_test_pto_uses_remote_max_ack_delay)
         || !CU_add_test(pSuite, "xqc_test_pto_remote_default_when_unset",
                         xqc_test_pto_remote_default_when_unset)
+        || !CU_add_test(pSuite,
+                        "xqc_test_path_validation_timeout_"
+                        "current_pto_dominates",
+                        xqc_test_path_validation_timeout_current_pto_dominates)
+        || !CU_add_test(pSuite,
+                        "xqc_test_path_validation_timeout_"
+                        "new_path_pto_dominates",
+                        xqc_test_path_validation_timeout_new_path_pto_dominates)
+        || !CU_add_test(pSuite,
+                        "xqc_test_path_validation_timer_not_extended_by_packet",
+                        xqc_test_path_validation_timer_not_extended_by_packet)
         || !CU_add_test(pSuite, "xqc_test_send_ctl_update_rtt_ack_delay_cap",
                         xqc_test_send_ctl_update_rtt_ack_delay_cap)
         || !CU_add_test(pSuite,

--- a/tests/unittest/xqc_send_ctl_test.c
+++ b/tests/unittest/xqc_send_ctl_test.c
@@ -107,6 +107,147 @@ xqc_test_pto_remote_default_when_unset(void)
 }
 
 
+static xqc_path_ctx_t *
+xqc_test_path_validation_create_path(xqc_connection_t *conn)
+{
+    xqc_path_ctx_t *path = xqc_calloc(1, sizeof(xqc_path_ctx_t));
+    if (path == NULL) {
+        return NULL;
+    }
+
+    path->parent_conn = conn;
+    path->path_id = 1;
+    path->app_path_status = XQC_APP_PATH_STATUS_AVAILABLE;
+    path->path_send_ctl = xqc_send_ctl_create(path);
+    if (path->path_send_ctl == NULL) {
+        xqc_free(path);
+        return NULL;
+    }
+
+    return path;
+}
+
+
+static void
+xqc_test_path_validation_destroy_path(xqc_path_ctx_t *path)
+{
+    xqc_send_ctl_destroy(path->path_send_ctl);
+    xqc_free(path);
+}
+
+
+void
+xqc_test_path_validation_timeout_current_pto_dominates(void)
+{
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_FATAL(conn != NULL);
+
+    conn->enable_multipath = XQC_TRUE;
+    conn->remote_settings.max_ack_delay = 25;
+    conn->conn_settings.initial_rtt = 100000;
+
+    xqc_send_ctl_t *current = conn->conn_initial_path->path_send_ctl;
+    current->ctl_srtt = 400000;
+    current->ctl_rttvar = 50000;
+
+    xqc_path_ctx_t *path = xqc_test_path_validation_create_path(conn);
+    CU_ASSERT_FATAL(path != NULL);
+
+    xqc_usec_t current_pto = 400000 + 4 * 50000 + 25 * 1000;
+    xqc_usec_t new_path_pto = 100000 + 4 * 50000 + 25 * 1000;
+    CU_ASSERT(current_pto > new_path_pto);
+
+    xqc_usec_t before = xqc_monotonic_timestamp();
+    xqc_int_t ret = xqc_path_init(path, conn);
+    xqc_usec_t after = xqc_monotonic_timestamp();
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+
+    xqc_timer_t *timer = &path->path_send_ctl->path_timer_manager
+                          .timer[XQC_TIMER_PATH_IDLE];
+    xqc_usec_t expected = 3 * current_pto;
+    CU_ASSERT(timer->timer_is_set);
+    CU_ASSERT(timer->expire_time >= before + expected);
+    CU_ASSERT(timer->expire_time <= after + expected);
+    CU_ASSERT_EQUAL(path->path_state, XQC_PATH_STATE_VALIDATING);
+
+    xqc_test_path_validation_destroy_path(path);
+    xqc_engine_destroy(conn->engine);
+}
+
+
+void
+xqc_test_path_validation_timeout_new_path_pto_dominates(void)
+{
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_FATAL(conn != NULL);
+
+    conn->enable_multipath = XQC_TRUE;
+    conn->remote_settings.max_ack_delay = 25;
+    conn->conn_settings.initial_rtt = 400000;
+
+    xqc_send_ctl_t *current = conn->conn_initial_path->path_send_ctl;
+    current->ctl_srtt = 10000;
+    current->ctl_rttvar = 0;
+
+    xqc_path_ctx_t *path = xqc_test_path_validation_create_path(conn);
+    CU_ASSERT_FATAL(path != NULL);
+
+    xqc_usec_t current_pto = 10000 + XQC_kGranularity * 1000
+                             + 25 * 1000;
+    xqc_usec_t new_path_pto = 400000 + 4 * 200000 + 25 * 1000;
+    CU_ASSERT(new_path_pto > current_pto);
+
+    xqc_usec_t before = xqc_monotonic_timestamp();
+    xqc_int_t ret = xqc_path_init(path, conn);
+    xqc_usec_t after = xqc_monotonic_timestamp();
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+
+    xqc_timer_t *timer = &path->path_send_ctl->path_timer_manager
+                          .timer[XQC_TIMER_PATH_IDLE];
+    xqc_usec_t expected = 3 * new_path_pto;
+    CU_ASSERT(timer->timer_is_set);
+    CU_ASSERT(timer->expire_time >= before + expected);
+    CU_ASSERT(timer->expire_time <= after + expected);
+
+    xqc_test_path_validation_destroy_path(path);
+    xqc_engine_destroy(conn->engine);
+}
+
+
+void
+xqc_test_path_validation_timer_not_extended_by_packet(void)
+{
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_FATAL(conn != NULL);
+    CU_ASSERT_FATAL(conn->conn_initial_path != NULL);
+
+    conn->enable_multipath = XQC_TRUE;
+    xqc_path_ctx_t *path = conn->conn_initial_path;
+    CU_ASSERT_FATAL(xqc_conn_find_path_by_scid(conn, &path->path_scid)
+                    == path);
+
+    path->path_state = XQC_PATH_STATE_VALIDATING;
+    xqc_timer_t *timer = &path->path_send_ctl->path_timer_manager
+                          .timer[XQC_TIMER_PATH_IDLE];
+    timer->timer_is_set = XQC_TRUE;
+    timer->expire_time = 123456789;
+
+    xqc_conn_process_packet_recved_path(conn, &path->path_scid, 1200,
+                                        200000000);
+    CU_ASSERT_EQUAL(timer->expire_time, 123456789);
+
+    xqc_usec_t before = xqc_monotonic_timestamp();
+    xqc_path_validate(path);
+    xqc_usec_t after = xqc_monotonic_timestamp();
+    xqc_usec_t idle = xqc_path_get_idle_timeout(path) * 1000;
+    CU_ASSERT_EQUAL(path->path_state, XQC_PATH_STATE_ACTIVE);
+    CU_ASSERT(timer->expire_time >= before + idle);
+    CU_ASSERT(timer->expire_time <= after + idle);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
 typedef struct xqc_rtt_case_s {
     const char     *name;
     xqc_bool_t      hsk_confirmed;

--- a/tests/unittest/xqc_send_ctl_test.h
+++ b/tests/unittest/xqc_send_ctl_test.h
@@ -13,6 +13,11 @@
 void xqc_test_pto_uses_remote_max_ack_delay(void);
 void xqc_test_pto_remote_default_when_unset(void);
 
+/* RFC 9000 Section 8.2.4 path-validation timeout behavior. */
+void xqc_test_path_validation_timeout_current_pto_dominates(void);
+void xqc_test_path_validation_timeout_new_path_pto_dominates(void);
+void xqc_test_path_validation_timer_not_extended_by_packet(void);
+
 /*
  * Regression test for issue #724 (RFC 9002 5.3):
  * xqc_send_ctl_update_rtt must cap ack_delay by max_ack_delay


### PR DESCRIPTION
### Mechanism

Non-initial paths now use a path-validation deadline of three times the
larger of the current active-path PTO and the new-path PTO. Packets that do
not validate the path cannot extend that deadline, while successful
validation restores the ordinary path idle timeout.

- RFC or draft: [RFC 9000 Section 8.2.4](https://www.rfc-editor.org/rfc/rfc9000.html#section-8.2.4) and [RFC 9002 Section 6.2.1](https://www.rfc-editor.org/rfc/rfc9002.html#section-6.2.1)

Fixes: #669

### Validation Cases

- No targeted client-to-server case ID isolates the path-validation deadline lifecycle; paired unit coverage and the complete local unit suite passed.

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Complete
- CI: Pending — required GitHub checks are running
