### PR TITLE
[~] Fix #610: Reject HTTP/2-only settings in HTTP/3

### DIFF
--- a/src/http3/xqc_h3_conn.c
+++ b/src/http3/xqc_h3_conn.c
@@ -750,6 +750,20 @@ xqc_h3_conn_on_settings_entry_received(uint64_t identifier, uint64_t value, void
         }
         break;
 
+    case XQC_H3_SETTINGS_H2_ENABLE_PUSH:
+    case XQC_H3_SETTINGS_H2_MAX_CONCURRENT_STREAMS:
+    case XQC_H3_SETTINGS_H2_INITIAL_WINDOW_SIZE:
+    case XQC_H3_SETTINGS_H2_MAX_FRAME_SIZE:
+        /*
+         * RFC 9114 Section 7.2.4.1: HTTP/2 setting identifiers without
+         * corresponding HTTP/3 settings are connection errors.
+         */
+        xqc_log(h3c->log, XQC_LOG_ERROR,
+                "|reserved HTTP/2 setting|identifier:%ui|value:%ui|",
+                identifier, value);
+        XQC_H3_CONN_ERR(h3c, H3_SETTINGS_ERROR, -XQC_H3_SETTING_ERROR);
+        return -XQC_H3_SETTING_ERROR;
+
     default:
         xqc_log(h3c->log, XQC_LOG_INFO, "|ignore unknown setting|identifier%ui|value:%ui",
                 identifier, value);

--- a/src/http3/xqc_h3_defs.h
+++ b/src/http3/xqc_h3_defs.h
@@ -43,6 +43,12 @@ typedef enum {
     /* QPACK settings */
     XQC_H3_SETTINGS_QPACK_MAX_TABLE_CAPACITY    = 0x01,
     XQC_H3_SETTINGS_QPACK_BLOCKED_STREAMS       = 0x07,
+
+    /* HTTP/2-only settings reserved by RFC 9114 Section 7.2.4.1 */
+    XQC_H3_SETTINGS_H2_ENABLE_PUSH               = 0x02,
+    XQC_H3_SETTINGS_H2_MAX_CONCURRENT_STREAMS    = 0x03,
+    XQC_H3_SETTINGS_H2_INITIAL_WINDOW_SIZE       = 0x04,
+    XQC_H3_SETTINGS_H2_MAX_FRAME_SIZE            = 0x05,
 } xqc_h3_settings_id;
 
 

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -288,6 +288,11 @@ main(int argc, char *argv[])
                         xqc_test_h3_goaway_id_valid)
         || !CU_add_test(pSuite, "xqc_test_h3_goaway_id_increase_rejected",
                         xqc_test_h3_goaway_id_increase_rejected)
+        || !CU_add_test(pSuite, "xqc_test_h3_settings_accepted",
+                        xqc_test_h3_settings_accepted)
+        || !CU_add_test(pSuite,
+                        "xqc_test_h3_reserved_h2_settings_rejected",
+                        xqc_test_h3_reserved_h2_settings_rejected)
         || !CU_add_test(pSuite,
                         "xqc_test_h3_reserved_control_frame_accepted",
                         xqc_test_h3_reserved_control_frame_accepted)

--- a/tests/unittest/xqc_h3_test.c
+++ b/tests/unittest/xqc_h3_test.c
@@ -1394,6 +1394,95 @@ xqc_h3_ctrl_feed_settings(xqc_h3_stream_t *h3s)
 
 
 static ssize_t
+xqc_h3_ctrl_feed_setting(xqc_h3_stream_t *h3s, unsigned char identifier,
+    unsigned char value)
+{
+    unsigned char settings[] = {
+        XQC_H3_FRM_SETTINGS, 0x02, identifier, value
+    };
+    return xqc_h3_stream_process_control(h3s, settings, sizeof(settings));
+}
+
+
+void
+xqc_test_h3_settings_accepted()
+{
+    const xqc_conn_type_t roles[] = {
+        XQC_CONN_TYPE_CLIENT, XQC_CONN_TYPE_SERVER
+    };
+    const unsigned char identifiers[] = {
+        XQC_H3_SETTINGS_MAX_FIELD_SECTION_SIZE,
+        0x08,
+        0x21,
+    };
+
+    for (size_t i = 0; i < sizeof(roles) / sizeof(roles[0]); i++) {
+        for (size_t j = 0;
+             j < sizeof(identifiers) / sizeof(identifiers[0]); j++)
+        {
+            xqc_connection_t *conn = NULL;
+            xqc_h3_conn_t *h3c = NULL;
+            xqc_h3_stream_t *h3s = xqc_h3_ctrl_test_setup(&conn, &h3c);
+            CU_ASSERT_FATAL(h3s != NULL);
+
+            conn->conn_type = roles[i];
+            ssize_t processed = xqc_h3_ctrl_feed_setting(
+                h3s, identifiers[j], 1);
+
+            CU_ASSERT(processed == 4);
+            CU_ASSERT(conn->conn_err == 0);
+            CU_ASSERT(h3c->flags & XQC_H3_CONN_FLAG_SETTINGS_RECVED);
+            if (identifiers[j]
+                == XQC_H3_SETTINGS_MAX_FIELD_SECTION_SIZE)
+            {
+                CU_ASSERT(h3c->peer_h3_conn_settings.max_field_section_size
+                          == 1);
+            }
+
+            xqc_h3_ctrl_test_teardown(h3s, h3c, conn);
+        }
+    }
+}
+
+
+void
+xqc_test_h3_reserved_h2_settings_rejected()
+{
+    const xqc_conn_type_t roles[] = {
+        XQC_CONN_TYPE_CLIENT, XQC_CONN_TYPE_SERVER
+    };
+    const unsigned char identifiers[] = {
+        XQC_H3_SETTINGS_H2_ENABLE_PUSH,
+        XQC_H3_SETTINGS_H2_MAX_CONCURRENT_STREAMS,
+        XQC_H3_SETTINGS_H2_INITIAL_WINDOW_SIZE,
+        XQC_H3_SETTINGS_H2_MAX_FRAME_SIZE,
+    };
+
+    for (size_t i = 0; i < sizeof(roles) / sizeof(roles[0]); i++) {
+        for (size_t j = 0;
+             j < sizeof(identifiers) / sizeof(identifiers[0]); j++)
+        {
+            xqc_connection_t *conn = NULL;
+            xqc_h3_conn_t *h3c = NULL;
+            xqc_h3_stream_t *h3s = xqc_h3_ctrl_test_setup(&conn, &h3c);
+            CU_ASSERT_FATAL(h3s != NULL);
+
+            conn->conn_type = roles[i];
+            ssize_t processed = xqc_h3_ctrl_feed_setting(
+                h3s, identifiers[j], 0);
+
+            CU_ASSERT(processed == -H3_SETTINGS_ERROR);
+            CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err)
+                      == H3_SETTINGS_ERROR);
+            CU_ASSERT(conn->conn_flag & XQC_CONN_FLAG_ERROR);
+
+            xqc_h3_ctrl_test_teardown(h3s, h3c, conn);
+        }
+    }
+}
+
+
+static ssize_t
 xqc_h3_ctrl_feed_max_push_id(xqc_h3_stream_t *h3s, unsigned char push_id)
 {
     unsigned char frame[] = { XQC_H3_FRM_MAX_PUSH_ID, 0x01, push_id };

--- a/tests/unittest/xqc_h3_test.h
+++ b/tests/unittest/xqc_h3_test.h
@@ -19,6 +19,8 @@ void xqc_test_h3_max_push_id_valid();
 void xqc_test_h3_max_push_id_errors();
 void xqc_test_h3_goaway_id_valid();
 void xqc_test_h3_goaway_id_increase_rejected();
+void xqc_test_h3_settings_accepted();
+void xqc_test_h3_reserved_h2_settings_rejected();
 void xqc_test_h3_reserved_control_frame_accepted();
 void xqc_test_h3_cancel_push_rejected();
 void xqc_test_h3_uncompressed_fields_size();


### PR DESCRIPTION
### Mechanism

Reject HTTP/2-only setting identifiers `0x02` through `0x05` with
`H3_SETTINGS_ERROR`, while continuing to ignore other unsupported HTTP/3
settings. RFC 9114 Section 7.2.4.1 reserves those four identifiers, whereas
RFC 9220 Sections 3 and 5 register `0x08` for HTTP/3.

Fixes: #610

- RFC or draft: RFC 9114 Section 7.2.4.1; RFC 9220 Sections 3 and 5

### Validation Cases

- Not executed — the existing test applications cannot inject an identifier
  into the initial SETTINGS frame without exercising duplicate-SETTINGS
  rejection instead.

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Complete
- CI: Pending
