### PR TITLE
[~] Fix #618: Reject 0-RTT when DATAGRAM limits change

### DIFF
--- a/case_test/transport/core.sh
+++ b/case_test/transport/core.sh
@@ -845,9 +845,11 @@ sleep 1
 clear_log
 echo -e "check_clear_0rtt_ticket_flag_in_close_notify...\c"
 ${CLIENT_BIN} -l d -T 1 -s 4800 -U 1 -Q 65535 -E > stdlog
-cli_res2=`grep "conn_err:85, clear_0rtt_ticket:1" stdlog`
+cli_hsk=`grep "xqc_client_conn_handshake_finished" stdlog`
+cli_reject=`grep "early_data_flag:2, conn_err:0" stdlog`
+cli_ticket=`grep "clear_0rtt_ticket:0" stdlog`
 errlog=`grep_err_log`
-if [ -n "$cli_res2" ] && [ -n "$errlog" ]; then
+if [ -n "$cli_hsk" ] && [ -n "$cli_reject" ] && [ -n "$cli_ticket" ] && [ -z "$errlog" ]; then
     echo ">>>>>>>> pass:1"
     case_print_result "check_clear_0rtt_ticket_flag_in_close_notify" "pass"
 else
@@ -873,9 +875,11 @@ sleep 1
 clear_log
 echo -e "check_clear_0rtt_ticket_flag_in_h3_close_notify...\c"
 ${CLIENT_BIN} -l d -s 4800 -Q 65535 -E > stdlog
-cli_res2=`grep "conn_err:85, clear_0rtt_ticket:1" stdlog`
+cli_pass=`grep ">>>>>>>> pass:1" stdlog`
+cli_reject=`grep "early_data_flag:2, conn_err:0" stdlog`
+cli_ticket=`grep "clear_0rtt_ticket:0" stdlog`
 errlog=`grep_err_log`
-if [ -n "$cli_res2" ] && [ -n "$errlog" ]; then
+if [ -n "$cli_pass" ] && [ -n "$cli_reject" ] && [ -n "$cli_ticket" ] && [ -z "$errlog" ]; then
     echo ">>>>>>>> pass:1"
     case_print_result "check_clear_0rtt_ticket_flag_in_h3_close_notify" "pass"
 else

--- a/case_test/transport/datagram.sh
+++ b/case_test/transport/datagram.sh
@@ -52,13 +52,24 @@ fi
 case_transport_datagram__0rtt_max_datagram_frame_size_is_valid()
 {
 
+case_test_stop_server
+rm -f test_session tp_localhost xqc_token
+case_test_start_server ${SERVER_BIN} -l d -e -Q 65536 > /dev/null
+sleep 1
+# First connection: mint a ticket bound to max_datagram_frame_size 65536.
+${CLIENT_BIN} -s 1024 -l d -t 1 -T 1 -Q 65536 -E > /dev/null
 clear_log
 echo -e "0RTT max_datagram_frame_size is valid...\c"
-${CLIENT_BIN} -l d >> stdlog
-cli_result=`grep "|0RTT_transport_params|max_datagram_frame_size:65536|" clog`
-cli_result2=`grep "|1RTT_transport_params|max_datagram_frame_size:65536|" clog`
+${CLIENT_BIN} -s 1024 -l d -t 1 -T 1 -Q 65536 -E > stdlog
+cli_0rtt_tp=`grep "|0RTT_transport_params|max_datagram_frame_size:65536|" clog`
+cli_1rtt_tp=`grep "|1RTT_transport_params|max_datagram_frame_size:65536|" clog`
+flag=`grep "early_data_flag:1" stdlog`
+conn_err_zero=`grep -E "conn_err:0[^0-9]" stdlog`
+result=`grep ">>>>>>>> pass:1" stdlog`
 errlog=`grep_err_log`
-if [ -n "$cli_result" ] && [ -n "$cli_result2" ] && [ -z "$errlog" ]; then
+if [ -n "$cli_0rtt_tp" ] && [ -n "$cli_1rtt_tp" ] \
+    && [ -n "$flag" ] && [ -n "$conn_err_zero" ] \
+    && [ -n "$result" ] && [ -z "$errlog" ]; then
     echo ">>>>>>>> pass:1"
     case_print_result "0rtt_max_datagram_frame_size_is_valid" "pass"
 else
@@ -72,15 +83,26 @@ case_transport_datagram__0rtt_max_datagram_frame_size_is_invalid()
 {
 
 case_test_stop_server
-case_test_start_server ${SERVER_BIN} -l d -Q 8000 > /dev/null
+rm -f test_session tp_localhost xqc_token
+case_test_start_server ${SERVER_BIN} -l d -e -Q 65536 > /dev/null
+sleep 1
+# First connection: save the old ticket and its remembered DATAGRAM limit.
+${CLIENT_BIN} -s 1024 -l d -t 1 -T 1 -Q 65536 -E > /dev/null
+case_test_stop_server
+case_test_start_server ${SERVER_BIN} -l d -e -Q 8000 > /dev/null
 sleep 1
 clear_log
-echo -e "0RTT max_datagram_frame_size is invalid...\c"
-${CLIENT_BIN} -l d >> stdlog
-cli_result=`grep "|0RTT_transport_params|max_datagram_frame_size:65536|" clog`
-cli_err=`grep "[error].*err:0x55" clog`
-svr_err=`grep "[error].*err:0xa" slog`
-if [ -n "$cli_result" ] && [ -n "$cli_err" ] && [ -n "$svr_err" ]; then
+echo -e "old 0RTT ticket falls back to 1RTT after DATAGRAM limit change...\c"
+${CLIENT_BIN} -s 1024 -l d -t 1 -T 1 -Q 65536 -E > stdlog
+cli_0rtt_tp=`grep "|0RTT_transport_params|max_datagram_frame_size:65536|" clog`
+cli_1rtt_tp=`grep "|1RTT_transport_params|max_datagram_frame_size:8000|" clog`
+flag=`grep "early_data_flag:2" stdlog`
+conn_err_zero=`grep -E "conn_err:0[^0-9]" stdlog`
+result=`grep ">>>>>>>> pass:1" stdlog`
+errlog=`grep_err_log`
+if [ -n "$cli_0rtt_tp" ] && [ -n "$cli_1rtt_tp" ] \
+    && [ -n "$flag" ] && [ -n "$conn_err_zero" ] \
+    && [ -n "$result" ] && [ -z "$errlog" ]; then
     echo ">>>>>>>> pass:1"
     case_print_result "0rtt_max_datagram_frame_size_is_invalid" "pass"
 else

--- a/src/tls/xqc_tls.c
+++ b/src/tls/xqc_tls.c
@@ -259,10 +259,24 @@ xqc_tls_init_server_ssl(xqc_tls_t *tls, xqc_tls_config_t *cfg)
     /* configure ssl as server */
     SSL_set_accept_state(ssl);
 
-    /* enable early data and set context */
+    /* enable early data and bind its compatibility state to the ticket */
     xqc_ssl_enable_max_early_data(ssl);
-    SSL_set_quic_early_data_context(ssl, (const uint8_t *)XQC_EARLY_DATA_CONTEXT, 
-                                    XQC_EARLY_DATA_CONTEXT_LEN);
+
+    const uint8_t *context = cfg->early_data_context;
+    size_t context_len = cfg->early_data_context_len;
+    if (context == NULL || context_len == 0) {
+        context = (const uint8_t *)XQC_EARLY_DATA_CONTEXT;
+        context_len = XQC_EARLY_DATA_CONTEXT_LEN;
+    }
+
+    if (SSL_set_quic_early_data_context(ssl, context, context_len)
+        != XQC_SSL_SUCCESS)
+    {
+        xqc_log(tls->log, XQC_LOG_ERROR,
+                "|set quic early data context error|%s|",
+                ERR_error_string(ERR_get_error(), NULL));
+        return -XQC_TLS_INTERNAL;
+    }
 
     return ret;
 }

--- a/src/tls/xqc_tls_common.h
+++ b/src/tls/xqc_tls_common.h
@@ -108,6 +108,9 @@ typedef struct xqc_ssl_session_ticket_key_s {
 
 #define XQC_EARLY_DATA_CONTEXT          "xquic"
 #define XQC_EARLY_DATA_CONTEXT_LEN      (sizeof(XQC_EARLY_DATA_CONTEXT) - 1)
+#define XQC_EARLY_DATA_CONTEXT_VERSION  1
+#define XQC_EARLY_DATA_CONTEXT_V1_LEN   \
+    (XQC_EARLY_DATA_CONTEXT_LEN + 1 + sizeof(uint64_t))
 
 
 

--- a/src/tls/xqc_tls_defs.h
+++ b/src/tls/xqc_tls_defs.h
@@ -87,6 +87,10 @@ typedef struct xqc_tls_config_s {
     uint8_t                *trans_params;
     size_t                  trans_params_len;
 
+    /* ticket-bound compatibility context, only for server */
+    const uint8_t          *early_data_context;
+    size_t                  early_data_context_len;
+
     char                   *tls_groups;
 
 } xqc_tls_config_t;

--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -1123,6 +1123,27 @@ xqc_conn_encode_local_tp(xqc_connection_t *conn, uint8_t *dst, size_t dst_cap, s
 }
 
 
+static size_t
+xqc_conn_build_early_data_context(xqc_connection_t *conn, uint8_t *dst)
+{
+    size_t offset = 0;
+    uint64_t max_datagram_frame_size =
+        conn->local_settings.max_datagram_frame_size;
+
+    memcpy(dst + offset, XQC_EARLY_DATA_CONTEXT,
+           XQC_EARLY_DATA_CONTEXT_LEN);
+    offset += XQC_EARLY_DATA_CONTEXT_LEN;
+    dst[offset++] = XQC_EARLY_DATA_CONTEXT_VERSION;
+
+    for (size_t i = 0; i < sizeof(max_datagram_frame_size); i++) {
+        dst[offset + i] = (uint8_t)(max_datagram_frame_size
+                                    >> (56 - 8 * i));
+    }
+
+    return offset + sizeof(max_datagram_frame_size);
+}
+
+
 xqc_int_t
 xqc_conn_create_server_tls(xqc_connection_t *conn)
 {
@@ -1131,7 +1152,11 @@ xqc_conn_create_server_tls(xqc_connection_t *conn)
     /* init cfg */
     xqc_tls_config_t cfg = {0};
     char tp_buf[XQC_MAX_TRANSPORT_PARAM_BUF_LEN] = {0};
+    uint8_t early_data_context[XQC_EARLY_DATA_CONTEXT_V1_LEN] = {0};
     cfg.trans_params = tp_buf;
+    cfg.early_data_context = early_data_context;
+    cfg.early_data_context_len =
+        xqc_conn_build_early_data_context(conn, early_data_context);
 
     /* encode local transport parameters, and set to tls config */
     ret = xqc_conn_encode_local_tp(conn, cfg.trans_params,
@@ -6112,6 +6137,113 @@ xqc_check_fec_trans_param(xqc_connection_t *conn, xqc_transport_params_t params)
     }
 }
 
+
+xqc_int_t
+xqc_conn_check_0rtt_transport_params(xqc_connection_t *conn,
+    const xqc_transport_params_t *params, xqc_bool_t early_data_accepted)
+{
+    if (conn->conn_type != XQC_CONN_TYPE_CLIENT
+        || !(conn->conn_flag & XQC_CONN_FLAG_HAS_0RTT)
+        || !early_data_accepted)
+    {
+        return XQC_OK;
+    }
+
+    xqc_trans_settings_t *remembered = &conn->remote_settings;
+
+    if (params->initial_max_data < remembered->max_data) {
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|0rtt_param_reduced|initial_max_data|"
+                "remembered:%ui|new:%ui|",
+                remembered->max_data, params->initial_max_data);
+        XQC_CONN_ERR(conn, TRA_0RTT_TRANS_PARAMS_ERROR);
+        return TRA_0RTT_TRANS_PARAMS_ERROR;
+    }
+
+    if (params->initial_max_stream_data_bidi_local
+        < remembered->max_stream_data_bidi_local)
+    {
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|0rtt_param_reduced|initial_max_stream_data_bidi_local|"
+                "remembered:%ui|new:%ui|",
+                remembered->max_stream_data_bidi_local,
+                params->initial_max_stream_data_bidi_local);
+        XQC_CONN_ERR(conn, TRA_0RTT_TRANS_PARAMS_ERROR);
+        return TRA_0RTT_TRANS_PARAMS_ERROR;
+    }
+
+    if (params->initial_max_stream_data_bidi_remote
+        < remembered->max_stream_data_bidi_remote)
+    {
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|0rtt_param_reduced|initial_max_stream_data_bidi_remote|"
+                "remembered:%ui|new:%ui|",
+                remembered->max_stream_data_bidi_remote,
+                params->initial_max_stream_data_bidi_remote);
+        XQC_CONN_ERR(conn, TRA_0RTT_TRANS_PARAMS_ERROR);
+        return TRA_0RTT_TRANS_PARAMS_ERROR;
+    }
+
+    if (params->initial_max_stream_data_uni
+        < remembered->max_stream_data_uni)
+    {
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|0rtt_param_reduced|initial_max_stream_data_uni|"
+                "remembered:%ui|new:%ui|",
+                remembered->max_stream_data_uni,
+                params->initial_max_stream_data_uni);
+        XQC_CONN_ERR(conn, TRA_0RTT_TRANS_PARAMS_ERROR);
+        return TRA_0RTT_TRANS_PARAMS_ERROR;
+    }
+
+    if (params->initial_max_streams_bidi < remembered->max_streams_bidi) {
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|0rtt_param_reduced|initial_max_streams_bidi|"
+                "remembered:%ui|new:%ui|",
+                remembered->max_streams_bidi,
+                params->initial_max_streams_bidi);
+        XQC_CONN_ERR(conn, TRA_0RTT_TRANS_PARAMS_ERROR);
+        return TRA_0RTT_TRANS_PARAMS_ERROR;
+    }
+
+    if (params->initial_max_streams_uni < remembered->max_streams_uni) {
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|0rtt_param_reduced|initial_max_streams_uni|"
+                "remembered:%ui|new:%ui|",
+                remembered->max_streams_uni,
+                params->initial_max_streams_uni);
+        XQC_CONN_ERR(conn, TRA_0RTT_TRANS_PARAMS_ERROR);
+        return TRA_0RTT_TRANS_PARAMS_ERROR;
+    }
+
+    if (params->active_connection_id_limit
+        < remembered->active_connection_id_limit)
+    {
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|0rtt_param_reduced|active_connection_id_limit|"
+                "remembered:%ui|new:%ui|",
+                remembered->active_connection_id_limit,
+                params->active_connection_id_limit);
+        XQC_CONN_ERR(conn, TRA_0RTT_TRANS_PARAMS_ERROR);
+        return TRA_0RTT_TRANS_PARAMS_ERROR;
+    }
+
+    if (params->max_datagram_frame_size
+        < remembered->max_datagram_frame_size)
+    {
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|0rtt_param_reduced|max_datagram_frame_size|"
+                "remembered:%ui|new:%ui|",
+                remembered->max_datagram_frame_size,
+                params->max_datagram_frame_size);
+        XQC_CONN_ERR(conn, TRA_0RTT_DGRAM_PARAMS_ERROR);
+        return TRA_0RTT_DGRAM_PARAMS_ERROR;
+    }
+
+    return XQC_OK;
+}
+
+
 void
 xqc_conn_tls_transport_params_cb(const uint8_t *tp, size_t len, void *user_data)
 {
@@ -6143,117 +6275,14 @@ xqc_conn_tls_transport_params_cb(const uint8_t *tp, size_t len, void *user_data)
     }
 
     /*
-     * RFC 9000 Section 7.4.1: when a client has sent 0-RTT data AND the
-     * server accepted early data, the server MUST NOT reduce certain
-     * transport parameters below the remembered values.  The client MUST
-     * validate this and close with TRANSPORT_PARAMETER_ERROR if any MUST
-     * parameter was reduced.
-     *
-     * We only run this check when early data was actually accepted; if the
-     * server rejected 0-RTT the remembered values are irrelevant.
-     *
-     * At this point conn->remote_settings still holds the remembered (0-RTT)
-     * values set by xqc_conn_set_early_remote_transport_params; the new 1-RTT
-     * values are in `params`.
+     * RFC 9000 Section 7.4.1 and RFC 9221 Section 3 only apply remembered
+     * limits when this client attempted 0-RTT and the server accepted it.
      */
-    if (conn->conn_type == XQC_CONN_TYPE_CLIENT
-        && (conn->conn_flag & XQC_CONN_FLAG_HAS_0RTT)
-        && xqc_tls_is_early_data_accepted(conn->tls) == XQC_TLS_EARLY_DATA_ACCEPT)
-    {
-        xqc_trans_settings_t *remembered = &conn->remote_settings;
-
-        /*
-         * MUST parameters -- server MUST NOT reduce these after 0-RTT is
-         * accepted (RFC 9000 Section 7.4.1):
-         *   - active_connection_id_limit
-         *   - initial_max_data
-         *   - initial_max_stream_data_bidi_local
-         *   - initial_max_stream_data_bidi_remote
-         *   - initial_max_stream_data_uni
-         *   - initial_max_streams_bidi
-         *   - initial_max_streams_uni
-         */
-        if (params.initial_max_data < remembered->max_data) {
-            xqc_log(conn->log, XQC_LOG_ERROR,
-                    "|0rtt_param_reduced|initial_max_data|"
-                    "remembered:%ui|new:%ui|",
-                    remembered->max_data, params.initial_max_data);
-            XQC_CONN_ERR(conn, TRA_0RTT_TRANS_PARAMS_ERROR);
-            return;
-        }
-
-        if (params.initial_max_stream_data_bidi_local < remembered->max_stream_data_bidi_local) {
-            xqc_log(conn->log, XQC_LOG_ERROR,
-                    "|0rtt_param_reduced|initial_max_stream_data_bidi_local|"
-                    "remembered:%ui|new:%ui|",
-                    remembered->max_stream_data_bidi_local,
-                    params.initial_max_stream_data_bidi_local);
-            XQC_CONN_ERR(conn, TRA_0RTT_TRANS_PARAMS_ERROR);
-            return;
-        }
-
-        if (params.initial_max_stream_data_bidi_remote < remembered->max_stream_data_bidi_remote) {
-            xqc_log(conn->log, XQC_LOG_ERROR,
-                    "|0rtt_param_reduced|initial_max_stream_data_bidi_remote|"
-                    "remembered:%ui|new:%ui|",
-                    remembered->max_stream_data_bidi_remote,
-                    params.initial_max_stream_data_bidi_remote);
-            XQC_CONN_ERR(conn, TRA_0RTT_TRANS_PARAMS_ERROR);
-            return;
-        }
-
-        if (params.initial_max_stream_data_uni < remembered->max_stream_data_uni) {
-            xqc_log(conn->log, XQC_LOG_ERROR,
-                    "|0rtt_param_reduced|initial_max_stream_data_uni|"
-                    "remembered:%ui|new:%ui|",
-                    remembered->max_stream_data_uni,
-                    params.initial_max_stream_data_uni);
-            XQC_CONN_ERR(conn, TRA_0RTT_TRANS_PARAMS_ERROR);
-            return;
-        }
-
-        if (params.initial_max_streams_bidi < remembered->max_streams_bidi) {
-            xqc_log(conn->log, XQC_LOG_ERROR,
-                    "|0rtt_param_reduced|initial_max_streams_bidi|"
-                    "remembered:%ui|new:%ui|",
-                    remembered->max_streams_bidi,
-                    params.initial_max_streams_bidi);
-            XQC_CONN_ERR(conn, TRA_0RTT_TRANS_PARAMS_ERROR);
-            return;
-        }
-
-        if (params.initial_max_streams_uni < remembered->max_streams_uni) {
-            xqc_log(conn->log, XQC_LOG_ERROR,
-                    "|0rtt_param_reduced|initial_max_streams_uni|"
-                    "remembered:%ui|new:%ui|",
-                    remembered->max_streams_uni,
-                    params.initial_max_streams_uni);
-            XQC_CONN_ERR(conn, TRA_0RTT_TRANS_PARAMS_ERROR);
-            return;
-        }
-
-        if (params.active_connection_id_limit < remembered->active_connection_id_limit) {
-            xqc_log(conn->log, XQC_LOG_ERROR,
-                    "|0rtt_param_reduced|active_connection_id_limit|"
-                    "remembered:%ui|new:%ui|",
-                    remembered->active_connection_id_limit,
-                    params.active_connection_id_limit);
-            XQC_CONN_ERR(conn, TRA_0RTT_TRANS_PARAMS_ERROR);
-            return;
-        }
-
-    }
-
-    /* check datagram parameter -- unconditional, not gated on early_data
-     * accepted.  For non-0RTT connections remote_settings.max_datagram_frame_size
-     * is 0, so this is a no-op. */
-    if (params.max_datagram_frame_size < conn->remote_settings.max_datagram_frame_size) {
-        xqc_log(conn->log, XQC_LOG_ERROR,
-                "|0rtt_param_reduced|max_datagram_frame_size|"
-                "remembered:%ui|new:%ui|",
-                conn->remote_settings.max_datagram_frame_size,
-                params.max_datagram_frame_size);
-        XQC_CONN_ERR(conn, TRA_0RTT_DGRAM_PARAMS_ERROR);
+    ret = xqc_conn_check_0rtt_transport_params(
+        conn, &params,
+        xqc_tls_is_early_data_accepted(conn->tls)
+            == XQC_TLS_EARLY_DATA_ACCEPT);
+    if (ret != XQC_OK) {
         return;
     }
 

--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -4171,8 +4171,17 @@ xqc_conn_resend_0rtt_datagram(xqc_connection_t *conn)
         if (iov_size >= XQC_MAX_SEND_MSG_ONCE) {
             ret = xqc_datagram_send_multiple_internal(conn, iov, dgram_id_list, XQC_MAX_SEND_MSG_ONCE, &sent, &sent_bytes, dgram_buffer->qos_level, XQC_TRUE);
             if (ret < 0) {
-                xqc_log(conn->log, XQC_LOG_ERROR, "|unable_to_resend_0rtt_pkts_in_1rtt_way|");
-                XQC_CONN_ERR(conn, TRA_INTERNAL_ERROR);
+                if (ret == -XQC_EDGRAM_NOT_SUPPORTED
+                    || ret == -XQC_EDGRAM_TOO_LARGE)
+                {
+                    xqc_log(conn->log, XQC_LOG_INFO,
+                            "|drop_0rtt_datagrams_after_reject|ret:%d|", ret);
+
+                } else {
+                    xqc_log(conn->log, XQC_LOG_ERROR,
+                            "|unable_to_resend_0rtt_pkts_in_1rtt_way|");
+                    XQC_CONN_ERR(conn, TRA_INTERNAL_ERROR);
+                }
                 iov_size = 0;
                 break;
             }
@@ -4183,8 +4192,17 @@ xqc_conn_resend_0rtt_datagram(xqc_connection_t *conn)
     if (iov_size > 0) {
         ret = xqc_datagram_send_multiple_internal(conn, iov, dgram_id_list, iov_size, &sent, &sent_bytes, dgram_buffer->qos_level, XQC_TRUE);
         if (ret < 0) {
-            xqc_log(conn->log, XQC_LOG_ERROR, "|unbale_to_resend_0rtt_pkts_in_1rtt_way|");
-            XQC_CONN_ERR(conn, TRA_INTERNAL_ERROR);
+            if (ret == -XQC_EDGRAM_NOT_SUPPORTED
+                || ret == -XQC_EDGRAM_TOO_LARGE)
+            {
+                xqc_log(conn->log, XQC_LOG_INFO,
+                        "|drop_0rtt_datagrams_after_reject|ret:%d|", ret);
+
+            } else {
+                xqc_log(conn->log, XQC_LOG_ERROR,
+                        "|unable_to_resend_0rtt_pkts_in_1rtt_way|");
+                XQC_CONN_ERR(conn, TRA_INTERNAL_ERROR);
+            }
         }
     }
 

--- a/src/transport/xqc_conn.h
+++ b/src/transport/xqc_conn.h
@@ -689,6 +689,10 @@ xqc_int_t xqc_conn_encode_local_tp(xqc_connection_t *conn, uint8_t *dst, size_t 
 
 xqc_int_t xqc_conn_on_recv_retry(xqc_connection_t *conn, xqc_cid_t *retry_scid);
 
+/* validate remembered peer limits after the server accepted 0-RTT */
+xqc_int_t xqc_conn_check_0rtt_transport_params(xqc_connection_t *conn,
+    const xqc_transport_params_t *params, xqc_bool_t early_data_accepted);
+
 /* exposed for unit tests; validates the peer's transport parameters per RFC 9000 7.3 */
 xqc_int_t xqc_conn_check_transport_params(xqc_connection_t *conn,
     const xqc_transport_params_t *params);

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -93,6 +93,8 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite, "xqc_test_conn_pmtud_legacy_compatibility",
                         xqc_test_conn_pmtud_legacy_compatibility)
         || !CU_add_test(pSuite, "xqc_test_conn_early_data_reject", xqc_test_conn_early_data_reject)
+        || !CU_add_test(pSuite, "xqc_test_conn_early_data_reject_datagram_fallback",
+                        xqc_test_conn_early_data_reject_datagram_fallback)
         || !CU_add_test(pSuite, "xqc_test_conn_early_data_reject_flow_ctl", xqc_test_conn_early_data_reject_flow_ctl)
         /* RFC 9000 §20.1 CRYPTO_ERROR dynamic construction */
         || !CU_add_test(pSuite, "xqc_test_conn_tls_error_cb_constructs_crypto_error", xqc_test_conn_tls_error_cb_constructs_crypto_error)

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -282,6 +282,8 @@ main(int argc, char *argv[])
                         xqc_test_tls_default_cert_with_sni)
         || !CU_add_test(pSuite, "xqc_test_tls_default_cert_without_sni",
                         xqc_test_tls_default_cert_without_sni)
+        || !CU_add_test(pSuite, "xqc_test_tls_legacy_ticket_compatibility",
+                        xqc_test_tls_legacy_ticket_compatibility)
         || !CU_add_test(pSuite, "xqc_test_tls", xqc_test_tls)
         || !CU_add_test(pSuite, "xqc_test_h3_stream", xqc_test_stream)
         || !CU_add_test(pSuite, "xqc_test_h3_critical_stream_close", xqc_test_h3_critical_stream_close)
@@ -442,6 +444,8 @@ main(int argc, char *argv[])
                         xqc_test_0rtt_params_all_increased)
         || !CU_add_test(pSuite, "xqc_test_0rtt_params_each_reduced",
                         xqc_test_0rtt_params_each_reduced)
+        || !CU_add_test(pSuite, "xqc_test_0rtt_params_validation_guards",
+                        xqc_test_0rtt_params_validation_guards)
         || !CU_add_test(pSuite, "xqc_test_early_params_forbidden_fields_reset",
                         xqc_test_early_params_forbidden_fields_reset)
         || !CU_add_test(pSuite, "xqc_test_0rtt_calc_pto_ignores_stale_max_ack_delay",

--- a/tests/unittest/xqc_conn_test.c
+++ b/tests/unittest/xqc_conn_test.c
@@ -738,40 +738,16 @@ xqc_0rtt_test_init_params(xqc_transport_params_t *params,
     params->max_ack_delay      = XQC_DEFAULT_MAX_ACK_DELAY;
 }
 
-/*
- * Directly validate 0-RTT parameters against remembered settings,
- * mirroring the checks in xqc_conn_tls_transport_params_cb (RFC 9000
- * §7.4.1).  We cannot call xqc_conn_tls_transport_params_cb because
- * xqc_tls_is_early_data_accepted() requires a real TLS handshake
- * (tls->resumption + SSL early-data status) that the unit-test
- * fixture cannot provide.
- */
+/* Exercise the production 0-RTT compatibility check without a TLS fixture. */
 static xqc_int_t
-xqc_0rtt_test_fire(xqc_connection_t *conn, xqc_transport_params_t *params)
+xqc_0rtt_test_fire(xqc_connection_t *conn, xqc_transport_params_t *params,
+    xqc_bool_t early_data_accepted)
 {
-    xqc_trans_settings_t *remembered = &conn->remote_settings;
-
     conn->conn_err = 0;
     conn->conn_flag &= ~XQC_CONN_FLAG_ERROR;
 
-    if (params->initial_max_data < remembered->max_data
-        || params->initial_max_stream_data_bidi_local < remembered->max_stream_data_bidi_local
-        || params->initial_max_stream_data_bidi_remote < remembered->max_stream_data_bidi_remote
-        || params->initial_max_stream_data_uni < remembered->max_stream_data_uni
-        || params->initial_max_streams_bidi < remembered->max_streams_bidi
-        || params->initial_max_streams_uni < remembered->max_streams_uni
-        || params->active_connection_id_limit
-           < remembered->active_connection_id_limit)
-    {
-        XQC_CONN_ERR(conn, TRA_0RTT_TRANS_PARAMS_ERROR);
-
-    } else if (params->max_datagram_frame_size
-               < remembered->max_datagram_frame_size)
-    {
-        XQC_CONN_ERR(conn, TRA_0RTT_DGRAM_PARAMS_ERROR);
-    }
-
-    return conn->conn_err;
+    return xqc_conn_check_0rtt_transport_params(
+        conn, params, early_data_accepted);
 }
 
 /* ---- individual test cases ---- */
@@ -786,8 +762,40 @@ xqc_test_0rtt_params_all_equal(void)
     xqc_0rtt_test_init_params(&params, conn, &server_scid);
     /* all values equal to remembered -- must succeed */
 
-    xqc_int_t err = xqc_0rtt_test_fire(conn, &params);
+    xqc_int_t err = xqc_0rtt_test_fire(conn, &params, XQC_TRUE);
     CU_ASSERT_EQUAL(err, 0);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
+void
+xqc_test_0rtt_params_validation_guards(void)
+{
+    xqc_cid_t server_scid;
+    xqc_connection_t *conn = xqc_0rtt_test_make_conn(&server_scid);
+    xqc_transport_params_t params;
+
+    xqc_0rtt_test_init_params(&params, conn, &server_scid);
+    params.max_datagram_frame_size = REMEMBERED_MAX_DGRAM_FRAME_SIZE - 1;
+
+    /* Rejected early data makes every remembered limit inapplicable. */
+    CU_ASSERT_EQUAL(
+        xqc_0rtt_test_fire(conn, &params, XQC_FALSE), XQC_OK);
+    CU_ASSERT_EQUAL(conn->conn_err, 0);
+
+    /* A client that did not attempt 0-RTT must not validate old limits. */
+    conn->conn_flag &= ~XQC_CONN_FLAG_HAS_0RTT;
+    CU_ASSERT_EQUAL(
+        xqc_0rtt_test_fire(conn, &params, XQC_TRUE), XQC_OK);
+    CU_ASSERT_EQUAL(conn->conn_err, 0);
+
+    /* Peer parameters on a server are client settings, not remembered state. */
+    conn->conn_flag |= XQC_CONN_FLAG_HAS_0RTT;
+    conn->conn_type = XQC_CONN_TYPE_SERVER;
+    CU_ASSERT_EQUAL(
+        xqc_0rtt_test_fire(conn, &params, XQC_TRUE), XQC_OK);
+    CU_ASSERT_EQUAL(conn->conn_err, 0);
 
     xqc_engine_destroy(conn->engine);
 }
@@ -1075,7 +1083,7 @@ xqc_test_0rtt_params_all_increased(void)
     params.active_connection_id_limit         *= 2;
     params.max_datagram_frame_size            *= 2;
 
-    xqc_int_t err = xqc_0rtt_test_fire(conn, &params);
+    xqc_int_t err = xqc_0rtt_test_fire(conn, &params, XQC_TRUE);
     CU_ASSERT_EQUAL(err, 0);
 
     xqc_engine_destroy(conn->engine);
@@ -1150,7 +1158,7 @@ xqc_test_0rtt_params_each_reduced(void)
         uint64_t *field = (uint64_t *)((char *)&params + cases[i].tp_offset);
         *field = cases[i].remembered_val - 1;
 
-        xqc_int_t err = xqc_0rtt_test_fire(conn, &params);
+        xqc_int_t err = xqc_0rtt_test_fire(conn, &params, XQC_TRUE);
         CU_ASSERT_EQUAL(err, cases[i].expected_err);
 
         xqc_engine_destroy(conn->engine);

--- a/tests/unittest/xqc_conn_test.c
+++ b/tests/unittest/xqc_conn_test.c
@@ -515,6 +515,59 @@ xqc_test_conn_early_data_reject()
 }
 
 
+void
+xqc_test_conn_early_data_reject_datagram_fallback()
+{
+    static const unsigned char dgram[] = "0rtt";
+    xqc_connection_t *conn;
+    xqc_engine_t *engine;
+    xqc_int_t ret;
+
+    /* A peer that disables DATAGRAM cannot receive the rejected payload. */
+    conn = test_engine_connect();
+    CU_ASSERT_FATAL(conn != NULL);
+    engine = conn->engine;
+
+    conn->conn_flag |= XQC_CONN_FLAG_CAN_SEND_1RTT;
+    conn->remote_settings.max_datagram_frame_size = 0;
+    ret = xqc_conn_buff_0rtt_datagram(conn, (void *)dgram,
+                                      sizeof(dgram), 1,
+                                      XQC_DATA_QOS_NORMAL);
+    CU_ASSERT_EQUAL_FATAL(ret, XQC_OK);
+    CU_ASSERT_FALSE(xqc_list_empty(&conn->dgram_0rtt_buffer_list));
+
+    ret = xqc_conn_early_data_reject(conn);
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    CU_ASSERT_EQUAL(conn->conn_err, 0);
+    CU_ASSERT_FALSE(conn->conn_flag & XQC_CONN_FLAG_ERROR);
+    CU_ASSERT_TRUE(xqc_list_empty(&conn->dgram_0rtt_buffer_list));
+
+    xqc_engine_destroy(engine);
+
+    /* A reduced limit can also make an individual 0-RTT DATAGRAM too large. */
+    conn = test_engine_connect();
+    CU_ASSERT_FATAL(conn != NULL);
+    engine = conn->engine;
+
+    conn->conn_flag |= XQC_CONN_FLAG_CAN_SEND_1RTT;
+    conn->remote_settings.max_datagram_frame_size = 65535;
+    conn->dgram_mss = sizeof(dgram) - 1;
+    ret = xqc_conn_buff_0rtt_datagram(conn, (void *)dgram,
+                                      sizeof(dgram), 2,
+                                      XQC_DATA_QOS_NORMAL);
+    CU_ASSERT_EQUAL_FATAL(ret, XQC_OK);
+    CU_ASSERT_FALSE(xqc_list_empty(&conn->dgram_0rtt_buffer_list));
+
+    ret = xqc_conn_early_data_reject(conn);
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    CU_ASSERT_EQUAL(conn->conn_err, 0);
+    CU_ASSERT_FALSE(conn->conn_flag & XQC_CONN_FLAG_ERROR);
+    CU_ASSERT_TRUE(xqc_list_empty(&conn->dgram_0rtt_buffer_list));
+
+    xqc_engine_destroy(engine);
+}
+
+
 /*
  * Regression guard for issue #767. When 0-RTT is rejected, the client
  * branch of xqc_conn_early_data_reject must reset the connection-level

--- a/tests/unittest/xqc_conn_test.h
+++ b/tests/unittest/xqc_conn_test.h
@@ -32,6 +32,7 @@ void xqc_test_conn_tls_error_cb_max_alert();
 void xqc_test_0rtt_params_all_equal(void);
 void xqc_test_0rtt_params_all_increased(void);
 void xqc_test_0rtt_params_each_reduced(void);
+void xqc_test_0rtt_params_validation_guards(void);
 
 /* RFC 9000 §7.4.1: forbidden remembered fields must be reset (issue #672) */
 void xqc_test_early_params_forbidden_fields_reset(void);

--- a/tests/unittest/xqc_conn_test.h
+++ b/tests/unittest/xqc_conn_test.h
@@ -12,6 +12,7 @@ void xqc_test_conn_idle_timeout();
 void xqc_test_conn_pmtud_force_enable();
 void xqc_test_conn_pmtud_legacy_compatibility();
 void xqc_test_conn_early_data_reject();
+void xqc_test_conn_early_data_reject_datagram_fallback();
 void xqc_test_conn_early_data_reject_flow_ctl();
 
 /* RFC 9000 §20.1 CRYPTO_ERROR dynamic construction */

--- a/tests/unittest/xqc_tls_test.c
+++ b/tests/unittest/xqc_tls_test.c
@@ -7,6 +7,7 @@
 #include "src/transport/xqc_conn.h"
 #include "src/tls/xqc_tls_ctx.h"
 #include "src/tls/xqc_tls.h"
+#include "src/tls/xqc_tls_common.h"
 
 #define XQC_TEST_MAX_CRYPTO_DATA_BUF 16 * 1024
 
@@ -255,6 +256,166 @@ static xqc_tls_ctx_t *ctx_cli, *ctx_svr;
 #define TEST_ALPN_1 "transport"
 #define TEST_ALPN_2 "h3"
 
+typedef struct {
+    unsigned char                  *ticket;
+    size_t                          ticket_len;
+    xqc_bool_t                      client_handshake_completed;
+    xqc_bool_t                      server_handshake_completed;
+    int                             client_session_reused;
+    int                             server_session_reused;
+    xqc_tls_early_data_accept_t     client_early_data;
+    xqc_tls_early_data_accept_t     server_early_data;
+} xqc_tls_handshake_result_t;
+
+
+static xqc_int_t
+xqc_test_tls_run_handshake(xqc_tls_ctx_t *client_ctx,
+    xqc_tls_ctx_t *server_ctx, xqc_log_t *log,
+    const unsigned char *ticket, size_t ticket_len,
+    const uint8_t *server_context, size_t server_context_len,
+    xqc_tls_handshake_result_t *result)
+{
+    xqc_int_t              ret = -XQC_TLS_INTERNAL;
+    uint8_t               *data_buf = NULL;
+    size_t                 data_len;
+    xqc_tls_t             *tls_cli = NULL;
+    xqc_tls_t             *tls_svr = NULL;
+    xqc_tls_test_buff_t   *ttbuf_cli = NULL;
+    xqc_tls_test_buff_t   *ttbuf_svr = NULL;
+    xqc_cid_t              odcid = {1};
+    xqc_tls_config_t       tls_config = {0};
+
+    memset(result, 0, sizeof(*result));
+    tls_config.session_ticket = (unsigned char *)ticket;
+    tls_config.session_ticket_len = ticket_len;
+    tls_config.hostname = "test.xquic.com";
+    tls_config.alpn = TEST_ALPN_1;
+    tls_config.trans_params = (uint8_t *)"10086";
+    tls_config.trans_params_len = 5;
+    tls_config.early_data_context = server_context;
+    tls_config.early_data_context_len = server_context_len;
+
+    data_buf = xqc_malloc(XQC_TEST_MAX_CRYPTO_DATA_BUF);
+    ttbuf_cli = xqc_create_tls_test_buffer();
+    ttbuf_svr = xqc_create_tls_test_buffer();
+    if (data_buf == NULL || ttbuf_cli == NULL || ttbuf_svr == NULL) {
+        ret = -XQC_EMALLOC;
+        goto end;
+    }
+
+    tls_cli = xqc_tls_create(client_ctx, &tls_config, log, ttbuf_cli);
+    tls_svr = xqc_tls_create(server_ctx, &tls_config, log, ttbuf_svr);
+    if (tls_cli == NULL || tls_svr == NULL) {
+        goto end;
+    }
+
+    ret = xqc_tls_init(tls_cli, XQC_VERSION_V1, &odcid);
+    if (ret != XQC_OK) {
+        goto end;
+    }
+    ret = xqc_tls_init(tls_svr, XQC_VERSION_V1, &odcid);
+    if (ret != XQC_OK) {
+        goto end;
+    }
+
+    data_len = xqc_crypto_data_list_get_buf(
+        &ttbuf_cli->initial_crypto_data_list, data_buf);
+    if (data_len == 0 || data_len > XQC_TEST_MAX_CRYPTO_DATA_BUF) {
+        ret = -XQC_TLS_INTERNAL;
+        goto end;
+    }
+    ret = xqc_tls_process_crypto_data(tls_svr, XQC_ENC_LEV_INIT,
+                                      data_buf, data_len);
+    if (ret != XQC_OK) {
+        goto end;
+    }
+
+    data_len = xqc_crypto_data_list_get_buf(
+        &ttbuf_svr->initial_crypto_data_list, data_buf);
+    if (data_len == 0 || data_len > XQC_TEST_MAX_CRYPTO_DATA_BUF) {
+        ret = -XQC_TLS_INTERNAL;
+        goto end;
+    }
+    ret = xqc_tls_process_crypto_data(tls_cli, XQC_ENC_LEV_INIT,
+                                      data_buf, data_len);
+    if (ret != XQC_OK) {
+        goto end;
+    }
+
+    data_len = xqc_crypto_data_list_get_buf(
+        &ttbuf_svr->hsk_crypto_data_list, data_buf);
+    if (data_len == 0 || data_len > XQC_TEST_MAX_CRYPTO_DATA_BUF) {
+        ret = -XQC_TLS_INTERNAL;
+        goto end;
+    }
+    ret = xqc_tls_process_crypto_data(tls_cli, XQC_ENC_LEV_HSK,
+                                      data_buf, data_len);
+    if (ret != XQC_OK) {
+        goto end;
+    }
+
+    data_len = xqc_crypto_data_list_get_buf(
+        &ttbuf_cli->hsk_crypto_data_list, data_buf);
+    if (data_len == 0 || data_len > XQC_TEST_MAX_CRYPTO_DATA_BUF) {
+        ret = -XQC_TLS_INTERNAL;
+        goto end;
+    }
+    ret = xqc_tls_process_crypto_data(tls_svr, XQC_ENC_LEV_HSK,
+                                      data_buf, data_len);
+    if (ret != XQC_OK) {
+        goto end;
+    }
+
+    result->client_handshake_completed = ttbuf_cli->handshake_completed;
+    result->server_handshake_completed = ttbuf_svr->handshake_completed;
+    result->client_session_reused = SSL_session_reused(
+        xqc_tls_get_ssl(tls_cli));
+    result->server_session_reused = SSL_session_reused(
+        xqc_tls_get_ssl(tls_svr));
+    result->client_early_data = xqc_tls_is_early_data_accepted(tls_cli);
+    result->server_early_data = xqc_tls_is_early_data_accepted(tls_svr);
+
+    data_len = xqc_crypto_data_list_get_buf(
+        &ttbuf_svr->application_crypto_data_list, data_buf);
+    if (data_len > XQC_TEST_MAX_CRYPTO_DATA_BUF) {
+        ret = -XQC_TLS_INTERNAL;
+        goto end;
+    }
+    if (data_len > 0) {
+        ret = xqc_tls_process_crypto_data(tls_cli, XQC_ENC_LEV_1RTT,
+                                          data_buf, data_len);
+        if (ret != XQC_OK) {
+            goto end;
+        }
+    }
+
+    if (ttbuf_cli->new_session_ticket != NULL) {
+        result->ticket = ttbuf_cli->new_session_ticket;
+        result->ticket_len = ttbuf_cli->new_session_ticket_len;
+        ttbuf_cli->new_session_ticket = NULL;
+        ttbuf_cli->new_session_ticket_len = 0;
+    }
+    ret = XQC_OK;
+
+end:
+    if (tls_cli != NULL) {
+        xqc_tls_destroy(tls_cli);
+    }
+    if (tls_svr != NULL) {
+        xqc_tls_destroy(tls_svr);
+    }
+    if (ttbuf_cli != NULL) {
+        xqc_destroy_tls_test_buffer(ttbuf_cli);
+    }
+    if (ttbuf_svr != NULL) {
+        xqc_destroy_tls_test_buffer(ttbuf_svr);
+    }
+    if (data_buf != NULL) {
+        xqc_free(data_buf);
+    }
+    return ret;
+}
+
 static xqc_int_t
 xqc_test_tls_default_cert_handshake(xqc_bool_t with_sni,
                                     int *cert_cb_called)
@@ -409,6 +570,105 @@ xqc_test_tls_default_cert_without_sni(void)
         XQC_FALSE, &cert_cb_called), XQC_OK);
     CU_ASSERT_EQUAL(cert_cb_called, 0);
 }
+
+void
+xqc_test_tls_legacy_ticket_compatibility(void)
+{
+    static const uint8_t current_context[] = {
+        'x', 'q', 'u', 'i', 'c', XQC_EARLY_DATA_CONTEXT_VERSION,
+        0, 0, 0, 0, 0, 1, 0, 0
+    };
+    xqc_tls_handshake_result_t initial = {0};
+    xqc_tls_handshake_result_t migrated = {0};
+    xqc_tls_handshake_result_t current_initial = {0};
+    xqc_tls_handshake_result_t current = {0};
+    xqc_log_callbacks_t log_cb = xqc_null_log_cb;
+    xqc_log_t *log = NULL;
+    xqc_tls_ctx_t *client_ctx = NULL;
+    xqc_tls_ctx_t *server_ctx = NULL;
+    def_engine_ssl_config_cli;
+    def_engine_ssl_config_svr;
+
+    log = xqc_log_init(0, 0, 0, 0, 0, NULL, &log_cb, NULL);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(log);
+
+    client_ctx = xqc_tls_ctx_create(XQC_TLS_TYPE_CLIENT,
+        &engine_ssl_config_cli, &tls_test_cbs, log);
+    server_ctx = xqc_tls_ctx_create(XQC_TLS_TYPE_SERVER,
+        &engine_ssl_config_svr, &tls_test_cbs, log);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(client_ctx);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(server_ctx);
+    CU_ASSERT_EQUAL_FATAL(xqc_tls_ctx_register_alpn(
+        server_ctx, TEST_ALPN_1, sizeof(TEST_ALPN_1) - 1), XQC_OK);
+
+    /* Mint a ticket exactly as servers before the context migration did. */
+    CU_ASSERT_EQUAL_FATAL(xqc_test_tls_run_handshake(
+        client_ctx, server_ctx, log, NULL, 0,
+        (const uint8_t *)XQC_EARLY_DATA_CONTEXT,
+        XQC_EARLY_DATA_CONTEXT_LEN, &initial), XQC_OK);
+    CU_ASSERT_TRUE(initial.client_handshake_completed);
+    CU_ASSERT_TRUE(initial.server_handshake_completed);
+    CU_ASSERT_FALSE(initial.client_session_reused);
+    CU_ASSERT_FALSE(initial.server_session_reused);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(initial.ticket);
+
+    /*
+     * A legacy ticket remains resumable after the server changes context.
+     * Only 0-RTT is rejected; the full 1-RTT handshake still succeeds.
+     */
+    CU_ASSERT_EQUAL_FATAL(xqc_test_tls_run_handshake(
+        client_ctx, server_ctx, log, initial.ticket, initial.ticket_len,
+        current_context, sizeof(current_context), &migrated), XQC_OK);
+    CU_ASSERT_TRUE(migrated.client_handshake_completed);
+    CU_ASSERT_TRUE(migrated.server_handshake_completed);
+    CU_ASSERT_TRUE(migrated.client_session_reused);
+    CU_ASSERT_TRUE(migrated.server_session_reused);
+    CU_ASSERT_EQUAL(migrated.client_early_data,
+                    XQC_TLS_EARLY_DATA_REJECT);
+    CU_ASSERT_EQUAL(migrated.server_early_data,
+                    XQC_TLS_EARLY_DATA_REJECT);
+
+    /* Mint and resume a ticket bound to the current context. */
+    CU_ASSERT_EQUAL_FATAL(xqc_test_tls_run_handshake(
+        client_ctx, server_ctx, log, NULL, 0,
+        current_context, sizeof(current_context), &current_initial), XQC_OK);
+    CU_ASSERT_TRUE(current_initial.client_handshake_completed);
+    CU_ASSERT_TRUE(current_initial.server_handshake_completed);
+    CU_ASSERT_FALSE(current_initial.client_session_reused);
+    CU_ASSERT_FALSE(current_initial.server_session_reused);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(current_initial.ticket);
+
+    /* A ticket minted with the current context can use 0-RTT again. */
+    CU_ASSERT_EQUAL_FATAL(xqc_test_tls_run_handshake(
+        client_ctx, server_ctx, log, current_initial.ticket,
+        current_initial.ticket_len, current_context,
+        sizeof(current_context), &current), XQC_OK);
+    CU_ASSERT_TRUE(current.client_handshake_completed);
+    CU_ASSERT_TRUE(current.server_handshake_completed);
+    CU_ASSERT_TRUE(current.client_session_reused);
+    CU_ASSERT_TRUE(current.server_session_reused);
+    CU_ASSERT_EQUAL(current.client_early_data,
+                    XQC_TLS_EARLY_DATA_ACCEPT);
+    CU_ASSERT_EQUAL(current.server_early_data,
+                    XQC_TLS_EARLY_DATA_ACCEPT);
+
+    if (initial.ticket != NULL) {
+        xqc_free(initial.ticket);
+    }
+    if (migrated.ticket != NULL) {
+        xqc_free(migrated.ticket);
+    }
+    if (current_initial.ticket != NULL) {
+        xqc_free(current_initial.ticket);
+    }
+    if (current.ticket != NULL) {
+        xqc_free(current.ticket);
+    }
+    xqc_tls_ctx_destroy(client_ctx);
+    xqc_tls_ctx_destroy(server_ctx);
+    xqc_free(log);
+}
+
 
 void
 xqc_test_create_client_tls_ctx()

--- a/tests/unittest/xqc_tls_test.h
+++ b/tests/unittest/xqc_tls_test.h
@@ -8,5 +8,6 @@
 void xqc_test_tls(void);
 void xqc_test_tls_default_cert_with_sni(void);
 void xqc_test_tls_default_cert_without_sni(void);
+void xqc_test_tls_legacy_ticket_compatibility(void);
 
 #endif


### PR DESCRIPTION
### Mechanism
Bind early-data context to DATAGRAM limits; validate remembered limits only after 0-RTT acceptance. Discard rejected DATAGRAMs that cannot be replayed under the negotiated 1-RTT limit without failing the connection.
- RFC: RFC 9221 §3; RFC 9000 §7.4.1

Fixes: #618

### Validation Cases
- native — Same limit accepts 0-RTT.
- native — Legacy ticket rejects 0-RTT and connects via 1-RTT.
- native — Disabled DATAGRAM drops rejected payload and preserves transport fallback.
- native — H3 request succeeds after 0-RTT rejection.

### CONTRIBUTING.md
- Overall: Complete
- Local regression: Complete
- CI: Complete