### PR TITLE
[~] Fix #646: Start PMTUD after handshake completion

### DIFF
--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -4382,6 +4382,15 @@ xqc_conn_try_to_enable_pmtud(xqc_connection_t *conn)
              & pmtud_check_bit) != 0))
     {
         conn->enable_pmtud = 1;
+
+        /*
+         * RFC 9000 Section 14.3.1 starts QUIC DPLPMTUD after the
+         * handshake completes. Transport parameters can arrive earlier.
+         */
+        if (!(conn->conn_flag & XQC_CONN_FLAG_HANDSHAKE_COMPLETED)) {
+            return;
+        }
+
         now = xqc_monotonic_timestamp();
         if (conn->enable_multipath) {
             xqc_timer_set(&conn->conn_timer_manager, XQC_TIMER_PMTUD_PROBING, now, XQC_PMTUD_START_DELAY * 1000);
@@ -4483,6 +4492,8 @@ xqc_conn_handshake_complete(xqc_connection_t *conn)
             xqc_conn_early_data_accept(conn);
         }
     }
+
+    xqc_conn_try_to_enable_pmtud(conn);
 
     return XQC_OK;
 }
@@ -5387,29 +5398,13 @@ xqc_conn_ptmud_probing(xqc_connection_t *conn)
     if (conn->conn_state >= XQC_CONN_STATE_CLOSING) {
         xqc_log(conn->log, XQC_LOG_INFO, "|conn closing, cannot send PMTUD probing|");
     }
-    /* probing can only be sent in 0RTT/1RTT packets */
-
-    xqc_pkt_type_t pkt_type = XQC_PTYPE_SHORT_HEADER;
-    int support_0rtt = xqc_conn_is_ready_to_send_early_data(conn);
-
-    if (!(conn->conn_flag & XQC_CONN_FLAG_CAN_SEND_1RTT)) {
-        if ((conn->conn_type == XQC_CONN_TYPE_CLIENT) 
-            && (conn->conn_state == XQC_CONN_STATE_CLIENT_INITIAL_SENT) 
-            && support_0rtt)
-        {
-            pkt_type = XQC_PTYPE_0RTT;
-            conn->conn_flag |= XQC_CONN_FLAG_HAS_0RTT;
-
-        } else {
-            return;
-        }
-    }
-
-    if (pkt_type == XQC_PTYPE_0RTT 
-        && conn->zero_rtt_count >= XQC_PACKET_0RTT_MAX_COUNT) 
+    if (!(conn->conn_flag & XQC_CONN_FLAG_HANDSHAKE_COMPLETED)
+        || !(conn->conn_flag & XQC_CONN_FLAG_CAN_SEND_1RTT))
     {
         return;
     }
+
+    xqc_pkt_type_t pkt_type = XQC_PTYPE_SHORT_HEADER;
 
     /* generate PING packets */
     if (conn->probing_cnt >= 3) {

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -88,6 +88,12 @@ main(int argc, char *argv[])
                         "xqc_test_datagram_transport_param_varint_max",
                         xqc_test_datagram_transport_param_varint_max)
         || !CU_add_test(pSuite, "xqc_test_conn_idle_timeout", xqc_test_conn_idle_timeout)
+        || !CU_add_test(pSuite,
+                        "xqc_test_conn_pmtud_deferred_until_handshake",
+                        xqc_test_conn_pmtud_deferred_until_handshake)
+        || !CU_add_test(pSuite,
+                        "xqc_test_conn_pmtud_starts_after_handshake",
+                        xqc_test_conn_pmtud_starts_after_handshake)
         || !CU_add_test(pSuite, "xqc_test_conn_pmtud_force_enable",
                         xqc_test_conn_pmtud_force_enable)
         || !CU_add_test(pSuite, "xqc_test_conn_pmtud_legacy_compatibility",

--- a/tests/unittest/xqc_conn_test.c
+++ b/tests/unittest/xqc_conn_test.c
@@ -332,11 +332,68 @@ xqc_pmtud_case_set(xqc_connection_t *conn, xqc_conn_type_t role,
 }
 
 void
+xqc_test_conn_pmtud_deferred_until_handshake()
+{
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_FATAL(conn != NULL);
+
+    xqc_pmtud_case_set(conn, XQC_CONN_TYPE_CLIENT,
+                       XQC_PMTUD_FORCE_ENABLE, XQC_PMTUD_DISABLE);
+    CU_ASSERT(!(conn->conn_flag & XQC_CONN_FLAG_HANDSHAKE_COMPLETED));
+
+    xqc_conn_try_to_enable_pmtud(conn);
+
+    CU_ASSERT(conn->enable_pmtud == 1);
+    CU_ASSERT(!xqc_timer_is_set(&conn->conn_timer_manager,
+                                XQC_TIMER_PMTUD_PROBING));
+
+    conn->conn_flag |= XQC_CONN_FLAG_CAN_SEND_1RTT;
+    xqc_conn_ptmud_probing(conn);
+    CU_ASSERT(conn->probing_cnt == 0);
+    CU_ASSERT(!(conn->conn_flag & XQC_CONN_FLAG_HAS_0RTT));
+
+    xqc_engine_destroy(conn->engine);
+}
+
+void
+xqc_test_conn_pmtud_starts_after_handshake()
+{
+    xqc_connection_t *conn = test_engine_connect();
+    xqc_packet_out_t *packet_out;
+    xqc_list_head_t *head;
+    CU_ASSERT_FATAL(conn != NULL);
+
+    xqc_pmtud_case_set(conn, XQC_CONN_TYPE_SERVER,
+                       XQC_PMTUD_FORCE_ENABLE, XQC_PMTUD_DISABLE);
+    conn->conn_flag |= XQC_CONN_FLAG_TOKEN_OK;
+    xqc_conn_try_to_enable_pmtud(conn);
+    CU_ASSERT(!xqc_timer_is_set(&conn->conn_timer_manager,
+                                XQC_TIMER_PMTUD_PROBING));
+
+    CU_ASSERT(xqc_conn_handshake_complete(conn) == XQC_OK);
+    CU_ASSERT(conn->conn_flag & XQC_CONN_FLAG_HANDSHAKE_COMPLETED);
+    CU_ASSERT(xqc_timer_is_set(&conn->conn_timer_manager,
+                               XQC_TIMER_PMTUD_PROBING));
+
+    conn->conn_flag |= XQC_CONN_FLAG_CAN_SEND_1RTT;
+    xqc_conn_ptmud_probing(conn);
+    head = &conn->conn_send_queue->sndq_send_packets_high_pri;
+    CU_ASSERT(!xqc_list_empty(head));
+    packet_out = xqc_list_entry(head->prev, xqc_packet_out_t, po_list);
+    CU_ASSERT(packet_out->po_pkt.pkt_type == XQC_PTYPE_SHORT_HEADER);
+    CU_ASSERT(packet_out->po_flag & XQC_POF_PMTUD_PROBING);
+    CU_ASSERT(!(conn->conn_flag & XQC_CONN_FLAG_HAS_0RTT));
+
+    xqc_engine_destroy(conn->engine);
+}
+
+void
 xqc_test_conn_pmtud_force_enable()
 {
     xqc_connection_t *conn = test_engine_connect();
     xqc_transport_params_t params = {0};
     CU_ASSERT_FATAL(conn != NULL);
+    conn->conn_flag |= XQC_CONN_FLAG_HANDSHAKE_COMPLETED;
 
     xqc_pmtud_case_set(conn, XQC_CONN_TYPE_CLIENT,
                        XQC_PMTUD_FORCE_ENABLE, XQC_PMTUD_DISABLE);
@@ -377,6 +434,7 @@ xqc_test_conn_pmtud_legacy_compatibility()
     uint8_t local_flags, remote_flags, expected;
 
     CU_ASSERT_FATAL(conn != NULL);
+    conn->conn_flag |= XQC_CONN_FLAG_HANDSHAKE_COMPLETED;
 
     CU_ASSERT_EQUAL(XQC_PMTUD_DISABLE, 0x0);
     CU_ASSERT_EQUAL(XQC_PMTUD_ENABLE_CLIENT, 0x1);

--- a/tests/unittest/xqc_conn_test.h
+++ b/tests/unittest/xqc_conn_test.h
@@ -9,6 +9,8 @@ void xqc_test_conn_create();
 void xqc_test_datagram_transport_param_65536(void);
 void xqc_test_datagram_transport_param_varint_max(void);
 void xqc_test_conn_idle_timeout();
+void xqc_test_conn_pmtud_deferred_until_handshake();
+void xqc_test_conn_pmtud_starts_after_handshake();
 void xqc_test_conn_pmtud_force_enable();
 void xqc_test_conn_pmtud_legacy_compatibility();
 void xqc_test_conn_early_data_reject();


### PR DESCRIPTION
### Mechanism

PMTUD enablement is recorded when transport parameters arrive, but its probe
timer is not armed until the handshake completes. Probe generation now also
requires handshake completion and 1-RTT write capability, and emits only
short-header packets. This follows RFC 9000 Section 14.3.1.

- RFC or draft: RFC 9000 Section 14.3.1

Fixes: #646

### Validation Cases

- Missing endpoint coverage — no independently selectable client-to-server
  case rejects early data while asserting that no pre-handshake PMTUD probe
  was sent

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Complete
- CI: Pending
