### PR TITLE
[~] Fix #629: Reject undersized RESET_STREAM final sizes

### DIFF
--- a/case_test/transport/stream.sh
+++ b/case_test/transport/stream.sh
@@ -580,6 +580,76 @@ fi
 
 }
 
+# RFC 9000 Section 4.5: RESET_STREAM final size must account for the largest
+# stream-data offset already received.
+case_transport_stream_reset_final_size_accepted()
+{
+
+case_test_stop_server
+clear_log
+rm -f test_session xqc_token tp_localhost
+case_test_start_server ${SERVER_BIN} -l d -e -x 722 > /dev/null
+sleep 1
+echo -e "reset_final_size_accepted ...\c"
+${CLIENT_BIN} -s 1024 -l d -t 1 -E -T 1 -x 722 > stdlog
+sleep 1
+result=`grep ">>>>>>>> pass:1" stdlog`
+client_injected=`grep \
+    "\[reset-final-size-test\]|case:722|stream_id:2|offset:5|"\
+"data_length:1|final_size:6|written|" stdlog`
+server_parsed=`grep \
+    "xqc_parse_reset_stream_frame|type:3|stream_id:2|"\
+"err_code:0|final_size:6|" slog`
+server_accepted=`grep \
+    "xqc_process_reset_stream_frame|stream_id:2|stream_state_recv:0|" slog`
+server_rejected=`grep "RESET_STREAM final size too small" slog`
+client_close_code=`grep "xqc_parse_conn_close_frame|type:18|err_code:6|" clog`
+if [ -n "$result" ] && [ -n "$client_injected" ] \
+    && [ -n "$server_parsed" ] && [ -n "$server_accepted" ] \
+    && [ -z "$server_rejected" ] && [ -z "$client_close_code" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "reset_final_size_accepted" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "reset_final_size_accepted" "fail"
+fi
+
+}
+
+
+case_transport_stream_reset_final_size_too_small()
+{
+
+case_test_stop_server
+clear_log
+rm -f test_session xqc_token tp_localhost
+case_test_start_server ${SERVER_BIN} -l d -e -x 723 > /dev/null
+sleep 1
+echo -e "reset_final_size_too_small ...\c"
+${CLIENT_BIN} -s 1024 -l d -t 1 -E -T 1 -x 723 > stdlog
+sleep 1
+client_injected=`grep \
+    "\[reset-final-size-test\]|case:723|stream_id:2|offset:5|"\
+"data_length:1|final_size:5|written|" stdlog`
+server_parsed=`grep \
+    "xqc_parse_reset_stream_frame|type:3|stream_id:2|"\
+"err_code:0|final_size:5|" slog`
+server_rejected=`grep \
+    "RESET_STREAM final size too small|stream_id:2|"\
+"final_size:5|max_recv_offset:6|" slog`
+client_close_code=`grep "xqc_parse_conn_close_frame|type:18|err_code:6|" clog`
+if [ -n "$client_injected" ] && [ -n "$server_parsed" ] \
+    && [ -n "$server_rejected" ] && [ -n "$client_close_code" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "reset_final_size_too_small" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "reset_final_size_too_small" "fail"
+fi
+
+}
+
+
 case_transport_stream_stop_sending_on_recv_only_stream()
 {
 
@@ -732,6 +802,11 @@ case_test_case "conn_rate_throttling" --id native --mode self-reporting --run ca
 case_test_case "stream_rate_throttling" --id native --mode self-reporting --run case_transport_stream_stream_rate_throttling
 case_test_case "reset_stream_on_send_only_stream" --id native --mode self-reporting --run case_transport_stream_reset_stream_on_send_only_stream
 case_test_case "reset_stream_on_recv_only_stream" --id native --mode self-reporting --run case_transport_stream_reset_stream_on_recv_only_stream
+case_test_case "reset_final_size_accepted" --id 722 \
+    --mode self-reporting --run case_transport_stream_reset_final_size_accepted
+case_test_case "reset_final_size_too_small" --id 723 \
+    --mode self-reporting \
+    --run case_transport_stream_reset_final_size_too_small
 case_test_case "stop_sending_on_recv_only_stream" --id native --mode self-reporting --run case_transport_stream_stop_sending_on_recv_only_stream
 case_test_case "stream_frame_on_send_only_stream" --id native --mode self-reporting --run case_transport_stream_stream_frame_on_send_only_stream
 case_test_case "stream_frame_on_local_uncreated_stream" --id native --mode self-reporting --run case_transport_stream_stream_frame_on_local_uncreated_stream

--- a/harness/spec/validation.md
+++ b/harness/spec/validation.md
@@ -99,7 +99,7 @@ its case is retired so later changes cannot reuse it.
 
 | Range | New-case namespace | Allocated IDs |
 |-------|--------------------|---------------|
-| `[705, 799]` | QUIC Transport core | `705-719` |
+| `[705, 799]` | QUIC Transport core | `705-719`, `722-723` |
 | `[800, 899]` | Recovery and congestion control | `800` |
 | `[900, 999]` | QUIC-TLS | `902-903` |
 | `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1018` |

--- a/src/transport/xqc_frame.c
+++ b/src/transport/xqc_frame.c
@@ -1288,6 +1288,22 @@ xqc_process_reset_stream_frame(xqc_connection_t *conn, xqc_packet_in_t *packet_i
             return XQC_OK;
         }
     }
+
+    /*
+     * RFC 9000 Section 4.5: the final size cannot be smaller than the
+     * largest offset of stream data already received.
+     */
+    if (stream->stream_state_recv < XQC_RECV_STREAM_ST_RESET_RECVD
+        && final_size < stream->stream_max_recv_offset)
+    {
+        xqc_log(conn->log, XQC_LOG_ERROR,
+                "|RESET_STREAM final size too small|stream_id:%ui|"
+                "final_size:%ui|max_recv_offset:%ui|",
+                stream_id, final_size, stream->stream_max_recv_offset);
+        XQC_CONN_ERR(conn, TRA_FINAL_SIZE_ERROR);
+        return -XQC_EPROTO;
+    }
+
     stream->stream_err = err_code;
 
     XQC_STREAM_CLOSE_MSG(stream, "remote reset");

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -97,6 +97,8 @@ printf_null(const char *format, ...)
 #define XQC_TEST_CASE_DATAGRAM_INITIAL_REJECTED 1202
 #define XQC_TEST_CASE_RETRY_INVALID_TOKEN_CLOSE 715
 #define XQC_TEST_CASE_RETRY_IGNORE_OLD_INITIAL_DCID 716
+#define XQC_TEST_CASE_RESET_FINAL_SIZE_VALID 722
+#define XQC_TEST_CASE_RESET_FINAL_SIZE_TOO_SMALL 723
 
 typedef struct user_conn_s user_conn_t;
 
@@ -112,6 +114,7 @@ static void xqc_client_send_test_single_vint_frame(
     xqc_h3_conn_t *h3_conn, xqc_bool_t overlong);
 static xqc_int_t xqc_client_write_test_datagram_frame(
     xqc_connection_t *conn, xqc_pkt_type_t pkt_type);
+static void xqc_client_send_reset_final_size_frames(xqc_connection_t *conn);
 
 
 #define XQC_TEST_DGRAM_BATCH_SZ 32
@@ -304,6 +307,7 @@ uint64_t g_last_sock_op_time;
  * 715/716 for Retry invalid token and old Initial validation
  * 717 for RESET_STREAM on a peer-initiated unidirectional stream
  * 718/719 for MAX_STREAM_DATA stream direction validation
+ * 722/723 for RESET_STREAM final-size validation
  * 902/903 for AEAD confidentiality-limit validation
  * 1000-1014 for HTTP/3 protocol validation
  */
@@ -2078,6 +2082,12 @@ xqc_client_conn_handshake_finished(xqc_connection_t *conn, void *user_data, void
         printf("====>SCID:%s\n", xqc_scid_str(ctx.engine, &user_conn->cid));
     }
 
+    if (g_test_case == XQC_TEST_CASE_RESET_FINAL_SIZE_VALID
+        || g_test_case == XQC_TEST_CASE_RESET_FINAL_SIZE_TOO_SMALL)
+    {
+        xqc_client_send_reset_final_size_frames(conn);
+    }
+
     hsk_completed = 1;
 
     user_conn->dgram_mss = xqc_datagram_get_mss(conn);
@@ -2242,6 +2252,50 @@ xqc_client_send_wrong_direction_frame(xqc_connection_t *conn)
     packet_out->po_used_size += ret;
     printf("test case %d, wrong direction frame written\n", g_test_case);
 }
+
+
+static void
+xqc_client_send_reset_final_size_frames(xqc_connection_t *conn)
+{
+    const unsigned char payload[1] = {0x00};
+    xqc_packet_out_t *packet_out;
+    uint64_t final_size;
+    size_t written = 0;
+    ssize_t ret;
+
+    packet_out = xqc_write_new_packet(conn, XQC_PTYPE_SHORT_HEADER);
+    if (packet_out == NULL) {
+        printf("[reset-final-size-test]|case:%d|new_packet_failed|\n",
+               g_test_case);
+        return;
+    }
+
+    ret = xqc_gen_stream_frame(packet_out, 2, 5, 0, payload,
+                               sizeof(payload), &written);
+    if (ret < 0 || written != sizeof(payload)) {
+        printf("[reset-final-size-test]|case:%d|stream_frame_failed:%zd|\n",
+               g_test_case, ret);
+        xqc_maybe_recycle_packet_out(packet_out, conn);
+        return;
+    }
+    packet_out->po_used_size += ret;
+
+    final_size = g_test_case == XQC_TEST_CASE_RESET_FINAL_SIZE_VALID
+                 ? 6 : 5;
+    ret = xqc_gen_reset_stream_frame(packet_out, 2, 0, final_size);
+    if (ret < 0) {
+        printf("[reset-final-size-test]|case:%d|reset_frame_failed:%zd|\n",
+               g_test_case, ret);
+        xqc_maybe_recycle_packet_out(packet_out, conn);
+        return;
+    }
+    packet_out->po_used_size += ret;
+
+    printf("[reset-final-size-test]|case:%d|stream_id:2|offset:5|"
+           "data_length:1|final_size:%"PRIu64"|written|\n",
+           g_test_case, final_size);
+}
+
 
 static void
 xqc_client_send_max_stream_data_test_frame(xqc_connection_t *conn)

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -253,6 +253,11 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite,
                         "xqc_test_process_reset_stream_on_recv_only_stream",
                         xqc_test_process_reset_stream_on_recv_only_stream)
+        || !CU_add_test(pSuite, "xqc_test_reset_stream_final_size_accepted",
+                        xqc_test_reset_stream_final_size_accepted)
+        || !CU_add_test(pSuite,
+                        "xqc_test_reset_stream_final_size_too_small",
+                        xqc_test_reset_stream_final_size_too_small)
         || !CU_add_test(pSuite, "xqc_test_stop_sending_on_recv_only_stream",
                         xqc_test_stop_sending_on_recv_only_stream)
         || !CU_add_test(pSuite, "xqc_test_stop_sending_on_recv_only_stream_server",

--- a/tests/unittest/xqc_process_frame_test.c
+++ b/tests/unittest/xqc_process_frame_test.c
@@ -1495,6 +1495,78 @@ xqc_test_process_reset_stream_on_recv_only_stream(void)
 }
 
 
+static xqc_connection_t *
+xqc_test_reset_stream_final_size_setup(xqc_stream_t **stream)
+{
+    xqc_connection_t *conn;
+
+    conn = xqc_test_dir_make_conn(XQC_CONN_TYPE_CLIENT);
+    if (conn == NULL) {
+        return NULL;
+    }
+
+    *stream = xqc_passive_create_stream(conn, 3, NULL);
+    if (*stream == NULL) {
+        xqc_engine_destroy(conn->engine);
+        return NULL;
+    }
+
+    (*stream)->stream_max_recv_offset = 5;
+    (*stream)->stream_data_in.next_read_offset = 2;
+    conn->conn_flow_ctl.fc_data_recved = 5;
+    conn->conn_flow_ctl.fc_data_read = 2;
+    return conn;
+}
+
+
+void
+xqc_test_reset_stream_final_size_accepted(void)
+{
+    unsigned char frame_buf[] = {0x04, 0x03, 0x00, 0x07};
+    xqc_packet_in_t pi;
+    xqc_connection_t *conn;
+    xqc_stream_t *stream = NULL;
+    xqc_int_t ret;
+
+    conn = xqc_test_reset_stream_final_size_setup(&stream);
+    CU_ASSERT_FATAL(conn != NULL);
+    xqc_test_dir_init_pi(&pi, frame_buf, sizeof(frame_buf));
+
+    ret = xqc_process_reset_stream_frame(conn, &pi);
+    CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(conn->conn_err == 0);
+    CU_ASSERT(stream->stream_state_recv == XQC_RECV_STREAM_ST_RESET_RECVD);
+    CU_ASSERT(conn->conn_flow_ctl.fc_data_recved == 7);
+    CU_ASSERT(conn->conn_flow_ctl.fc_data_read == 7);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
+void
+xqc_test_reset_stream_final_size_too_small(void)
+{
+    unsigned char frame_buf[] = {0x04, 0x03, 0x00, 0x04};
+    xqc_packet_in_t pi;
+    xqc_connection_t *conn;
+    xqc_stream_t *stream = NULL;
+    xqc_int_t ret;
+
+    conn = xqc_test_reset_stream_final_size_setup(&stream);
+    CU_ASSERT_FATAL(conn != NULL);
+    xqc_test_dir_init_pi(&pi, frame_buf, sizeof(frame_buf));
+
+    ret = xqc_process_reset_stream_frame(conn, &pi);
+    CU_ASSERT(ret == -XQC_EPROTO);
+    CU_ASSERT(conn->conn_err == TRA_FINAL_SIZE_ERROR);
+    CU_ASSERT(stream->stream_state_recv == XQC_RECV_STREAM_ST_RECV);
+    CU_ASSERT(conn->conn_flow_ctl.fc_data_recved == 5);
+    CU_ASSERT(conn->conn_flow_ctl.fc_data_read == 2);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
 /* ---- issue #567: STOP_SENDING on a recv-only stream ---- */
 
 void

--- a/tests/unittest/xqc_process_frame_test.h
+++ b/tests/unittest/xqc_process_frame_test.h
@@ -76,6 +76,10 @@ void xqc_test_process_reset_stream_on_bidirectional_stream(void);
 
 void xqc_test_process_reset_stream_on_recv_only_stream(void);
 
+void xqc_test_reset_stream_final_size_accepted(void);
+
+void xqc_test_reset_stream_final_size_too_small(void);
+
 void xqc_test_stop_sending_on_recv_only_stream(void);
 
 void xqc_test_stop_sending_on_recv_only_stream_server(void);


### PR DESCRIPTION
### Mechanism

Reject a first RESET_STREAM Final Size below the largest received stream
offset before changing stream state or connection flow-control accounting, and
report FINAL_SIZE_ERROR as described by RFC 9000 Sections 4.5 and 20.1.

Fixes: #629

- RFC or draft: RFC 9000 Sections 4.5 and 20.1

### Validation Cases

- 722 — accepts a Final Size that accounts for all received stream data
- 723 — rejects a Final Size below received data with FINAL_SIZE_ERROR

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Complete
- CI: Pending — Build and CodeQL; Codacy and CLA passed
