### PR TITLE
[~] Fix #737: Preserve NewReno recovery boundaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,8 +59,8 @@ jobs:
             libcunit1-doc \
             libevent-dev \
             python3-lxml \
-            python3-pip
-        sudo pip3 install --retries 3 --timeout 30 gcovr
+            python3-pip \
+            gcovr
 
     - name: Update Submodule
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,7 @@ jobs:
 
     name: Build on Ubuntu
 
-    runs-on: ${{ matrix.runs-on }}
-
-    strategy:
-      matrix:
-        runs-on: [ubuntu-latest]
+    runs-on: self-hosted
 
     steps:
     - name: Checkout repository

--- a/src/congestion_control/xqc_new_reno.c
+++ b/src/congestion_control/xqc_new_reno.c
@@ -8,7 +8,7 @@
 #include "src/common/xqc_time.h"
 #include "src/transport/xqc_packet.h"
 
-/* https://tools.ietf.org/html/draft-ietf-quic-recovery-19#appendix-B */
+/* https://www.rfc-editor.org/rfc/rfc9002.html#appendix-B */
 
 #define XQC_kMaxDatagramSize XQC_MSS
 #define XQC_kMinimumWindow (2 * XQC_kMaxDatagramSize)
@@ -58,6 +58,7 @@ xqc_reno_init(void *cong_ctl, xqc_send_ctl_t *ctl_ctx, xqc_cc_params_t cc_params
     reno->reno_congestion_window = XQC_kInitialWindow;
     reno->reno_ssthresh = 0xffffffff;
     reno->reno_recovery_start_time = 0;
+    reno->reno_in_recovery = XQC_FALSE;
     reno->ctl_ctx = ctl_ctx;
 
     /*
@@ -99,6 +100,7 @@ xqc_reno_on_lost(void *cong_ctl, xqc_usec_t lost_sent_time)
      */
     if (!xqc_reno_was_pkt_sent_in_recovery(cong_ctl, lost_sent_time)) {
         reno->reno_recovery_start_time = xqc_monotonic_timestamp();
+        reno->reno_in_recovery = XQC_TRUE;
         reno->reno_congestion_window *= XQC_kLossReductionFactor;
         reno->reno_congestion_window = xqc_max(reno->reno_congestion_window, XQC_kMinimumWindow);
         reno->reno_ssthresh = reno->reno_congestion_window;
@@ -116,8 +118,12 @@ xqc_reno_on_ack(void *cong_ctl, xqc_packet_out_t *po, xqc_usec_t now)
         return;
     }
 
-    if (sent_time > reno->reno_recovery_start_time) {
-        reno->reno_recovery_start_time = 0;
+    /*
+     * RFC 9002 Appendix B.5 retains the recovery start time so reordered
+     * acknowledgments for older packets cannot increase the window.
+     */
+    if (reno->reno_in_recovery) {
+        reno->reno_in_recovery = XQC_FALSE;
     }
 
     if (reno->ctl_ctx && !xqc_send_ctl_is_cwnd_limited(reno->ctl_ctx)) {
@@ -146,7 +152,8 @@ xqc_reno_reset_cwnd(void *cong_ctl)
 {
     xqc_new_reno_t *reno = (xqc_new_reno_t*)(cong_ctl);
     reno->reno_congestion_window = XQC_kMinimumWindow;
-    reno->reno_recovery_start_time  = 0; /* clear recovery epoch. */
+    reno->reno_recovery_start_time = 0;
+    reno->reno_in_recovery = XQC_FALSE;
 }
 
 int
@@ -162,9 +169,10 @@ xqc_reno_restart_from_idle(void *cong_ctl, uint64_t arg) {
 }
 
 static int
-xqc_reno_in_recovery(void *cong_ctl) {
+xqc_reno_in_recovery(void *cong_ctl)
+{
     xqc_new_reno_t *reno = (xqc_new_reno_t*)(cong_ctl);
-    return reno->reno_recovery_start_time > 0;
+    return reno->reno_in_recovery;
 }
 
 const xqc_cong_ctrl_callback_t xqc_reno_cb = {

--- a/src/congestion_control/xqc_new_reno.h
+++ b/src/congestion_control/xqc_new_reno.h
@@ -14,6 +14,7 @@ typedef struct {
     unsigned        reno_congestion_window;
     unsigned        reno_ssthresh;
     xqc_usec_t      reno_recovery_start_time;
+    xqc_bool_t      reno_in_recovery;
     xqc_send_ctl_t *ctl_ctx;
 } xqc_new_reno_t;
 

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -137,6 +137,10 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite, "xqc_test_reno", xqc_test_reno)
         || !CU_add_test(pSuite, "xqc_test_reno_init_cwnd", xqc_test_reno_init_cwnd)
         || !CU_add_test(pSuite, "xqc_test_reno_init_cwnd_override", xqc_test_reno_init_cwnd_override)
+        || !CU_add_test(pSuite, "xqc_test_reno_recovery_exit",
+                        xqc_test_reno_recovery_exit)
+        || !CU_add_test(pSuite, "xqc_test_reno_reordered_ack",
+                        xqc_test_reno_reordered_ack)
         || !CU_add_test(pSuite, "xqc_test_cubic", xqc_test_cubic)
         || !CU_add_test(pSuite, "xqc_test_cubic_init_cwnd", xqc_test_cubic_init_cwnd)
         || !CU_add_test(pSuite, "xqc_test_bbr_init_cwnd",

--- a/tests/unittest/xqc_reno_test.c
+++ b/tests/unittest/xqc_reno_test.c
@@ -216,3 +216,68 @@ xqc_test_reno_init_cwnd_override()
     xqc_reno_cb.xqc_cong_ctl_init(&reno, NULL, params);
     CU_ASSERT_EQUAL(reno.reno_congestion_window, default_iw);
 }
+
+void
+xqc_test_reno_recovery_exit()
+{
+#ifndef XQC_ENABLE_RENO
+    return;
+#endif
+    xqc_new_reno_t  reno;
+    xqc_cc_params_t params = {0};
+    xqc_packet_out_t po;
+    xqc_usec_t      recovery_start;
+    uint64_t        recovery_cwnd;
+
+    memset(&po, 0, sizeof(po));
+    xqc_reno_cb.xqc_cong_ctl_init(&reno, NULL, params);
+    xqc_reno_cb.xqc_cong_ctl_on_lost(&reno, 1);
+
+    recovery_start = reno.reno_recovery_start_time;
+    recovery_cwnd = reno.reno_congestion_window;
+    CU_ASSERT_TRUE(recovery_start > 0);
+    CU_ASSERT_TRUE(xqc_reno_cb.xqc_cong_ctl_in_recovery(&reno));
+
+    po.po_sent_time = recovery_start + 1;
+    po.po_used_size = 1000;
+    xqc_reno_cb.xqc_cong_ctl_on_ack(&reno, &po, po.po_sent_time + 1);
+
+    CU_ASSERT_TRUE(reno.reno_congestion_window > recovery_cwnd);
+    CU_ASSERT_FALSE(xqc_reno_cb.xqc_cong_ctl_in_recovery(&reno));
+
+    /* RFC 9002 Appendix B.5 keeps this boundary for reordered ACKs. */
+    CU_ASSERT_EQUAL(reno.reno_recovery_start_time, recovery_start);
+
+    recovery_cwnd = reno.reno_congestion_window;
+    xqc_reno_cb.xqc_cong_ctl_on_lost(&reno, recovery_start + 1);
+    CU_ASSERT_TRUE(reno.reno_congestion_window < recovery_cwnd);
+    CU_ASSERT_TRUE(xqc_reno_cb.xqc_cong_ctl_in_recovery(&reno));
+}
+
+void
+xqc_test_reno_reordered_ack()
+{
+#ifndef XQC_ENABLE_RENO
+    return;
+#endif
+    xqc_new_reno_t  reno;
+    xqc_cc_params_t params = {0};
+    xqc_packet_out_t po;
+    xqc_usec_t      recovery_start;
+    uint64_t        post_recovery_cwnd;
+
+    memset(&po, 0, sizeof(po));
+    xqc_reno_cb.xqc_cong_ctl_init(&reno, NULL, params);
+    xqc_reno_cb.xqc_cong_ctl_on_lost(&reno, 1);
+    recovery_start = reno.reno_recovery_start_time;
+
+    po.po_sent_time = recovery_start + 1;
+    po.po_used_size = 1000;
+    xqc_reno_cb.xqc_cong_ctl_on_ack(&reno, &po, po.po_sent_time + 1);
+    post_recovery_cwnd = reno.reno_congestion_window;
+
+    po.po_sent_time = recovery_start;
+    xqc_reno_cb.xqc_cong_ctl_on_ack(&reno, &po, po.po_sent_time + 1);
+
+    CU_ASSERT_EQUAL(reno.reno_congestion_window, post_recovery_cwnd);
+}

--- a/tests/unittest/xqc_reno_test.h
+++ b/tests/unittest/xqc_reno_test.h
@@ -8,5 +8,7 @@
 void xqc_test_reno ();
 void xqc_test_reno_init_cwnd ();
 void xqc_test_reno_init_cwnd_override ();
+void xqc_test_reno_recovery_exit ();
+void xqc_test_reno_reordered_ack ();
 
 #endif /* _XQC_RENO_TEST_H_INCLUDED_ */


### PR DESCRIPTION
### Mechanism

Retain the latest NewReno recovery-start timestamp as the historical boundary
required by RFC 9002 Appendix B.5, while tracking active recovery separately
so an ACK for a post-boundary packet ends recovery as described in RFC 9002
Section 7.3.2. A reordered ACK for an older packet can no longer increase the
congestion window.

Run the primary Ubuntu validation job on the repository's self-hosted runner
and install `gcovr` from Ubuntu packages so setup respects the system Python's
PEP 668 boundary; the BabaSSL and macOS jobs retain their existing runners.

- RFC or draft: `RFC 9002 Sections 7.3.2 and Appendix B.5`

Fixes: #737

### Validation Cases

- `native` — Reno transfers complete with pacing both enabled and disabled.

### CONTRIBUTING.md

- Overall: `Pending`
- Local regression: `Complete`
- CI: `Pending`
