### PR TITLE
[~] Fix #752: Reject misplaced HTTP/3 pseudo-headers

### DIFF
--- a/case_test/http3/core.sh
+++ b/case_test/http3/core.sh
@@ -1232,6 +1232,53 @@ fi
 
 }
 
+case_http3_core_h3_pseudo_header_order_accepted()
+{
+
+case_test_stop_server
+clear_log
+rm -f test_session xqc_token tp_localhost
+case_test_start_server ${SERVER_BIN} -l d -e -x 1019 > /dev/null
+sleep 1
+echo -e "HTTP/3 pseudo-header before regular field is accepted ...\c"
+${CLIENT_BIN} -G -l d -t 1 -x 1019 >> clog
+header_ok=`grep "pseudo_header_order_received:1" clog`
+stream_ok=`grep "pseudo_header_order_request_succeeded:1" clog`
+if [ -n "$header_ok" ] && [ -n "$stream_ok" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "h3_pseudo_header_order_accepted" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "h3_pseudo_header_order_accepted" "fail"
+fi
+
+}
+
+case_http3_core_h3_pseudo_header_after_regular_rejected()
+{
+
+case_test_stop_server
+clear_log
+rm -f test_session xqc_token tp_localhost
+case_test_start_server ${SERVER_BIN} -l d -e -x 1020 > /dev/null
+sleep 1
+echo -e "HTTP/3 misplaced pseudo-header resets only stream ...\c"
+${CLIENT_BIN} -G -l d -n 2 -t 2 -x 1020 >> clog
+stream_error_ok=`grep "pseudo_header_order_stream_error:1" clog`
+connection_reuse_ok=`grep \
+    "post_pseudo_header_order_error_request_succeeded:1" clog`
+transport_error=`grep "conn_err:1" clog`
+if [ -n "$stream_error_ok" ] && [ -n "$connection_reuse_ok" ] \
+    && [ -z "$transport_error" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "h3_pseudo_header_after_regular_rejected" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "h3_pseudo_header_after_regular_rejected" "fail"
+fi
+
+}
+
 case_test_case "h3_stream_send_pure_fin" --id native --mode self-reporting --run case_http3_core_h3_stream_send_pure_fin
 case_test_case "header_header_data" --id native --mode self-reporting --run case_http3_core_header_header_data
 case_test_case "header_data_header" --id native --mode self-reporting --run case_http3_core_header_data_header
@@ -1276,6 +1323,8 @@ case_test_case "h3_field_section_within_limit_succeeds" --id native --mode self-
 case_test_case "h3_field_section_over_limit_is_stream_error" --id native --mode self-reporting --run case_http3_core_h3_field_section_over_limit_is_stream_error
 case_test_case "h3_lowercase_response_field_name_accepted" --id native --mode self-reporting --run case_http3_core_h3_lowercase_response_field_name_accepted
 case_test_case "h3_uppercase_response_field_name_rejected" --id native --mode self-reporting --run case_http3_core_h3_uppercase_response_field_name_rejected
+case_test_case "h3_pseudo_header_order_accepted" --id 1019 --mode self-reporting --run case_http3_core_h3_pseudo_header_order_accepted
+case_test_case "h3_pseudo_header_after_regular_rejected" --id 1020 --mode self-reporting --run case_http3_core_h3_pseudo_header_after_regular_rejected
 
 if case_test_is_discovery; then
     case_test_run

--- a/harness/spec/validation.md
+++ b/harness/spec/validation.md
@@ -102,7 +102,7 @@ its case is retired so later changes cannot reuse it.
 | `[705, 799]` | QUIC Transport core | `705-719` |
 | `[800, 899]` | Recovery and congestion control | `800` |
 | `[900, 999]` | QUIC-TLS | `902-903` |
-| `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1018` |
+| `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1020` |
 | `[1100, 1149]` | QPACK | None |
 | `[1150, 1199]` | HTTP priority | None |
 | `[1200, 1299]` | QUIC DATAGRAM | `1201-1202` |

--- a/src/http3/xqc_h3_request.c
+++ b/src/http3/xqc_h3_request.c
@@ -873,14 +873,30 @@ xqc_h3_request_on_recv_header(xqc_h3_request_t *h3r)
     }
 
     /*
-     * RFC 9114 4.2: a request or response containing uppercase characters
-     * in field names MUST be treated as malformed. 4.1.2 routes malformed
-     * messages through H3_MESSAGE_ERROR. The QPACK layer is purposefully
-     * byte-transparent (it round-trips arbitrary bytes for codec testing),
-     * so this HTTP-semantic check lives at the H3 boundary instead.
+     * RFC 9114 Sections 4.2 and 4.3 define field-name and pseudo-header
+     * constraints at the HTTP layer. The QPACK layer is purposefully
+     * byte-transparent, so enforce those constraints at the H3 boundary.
      */
+    xqc_bool_t regular_field_seen = XQC_FALSE;
     for (size_t i = 0; i < headers->count; i++) {
         xqc_http_header_t *hdr = &headers->headers[i];
+        xqc_bool_t is_pseudo = hdr->name.iov_len > 0
+            && *((unsigned char *)hdr->name.iov_base) == ':';
+
+        if (is_pseudo) {
+            if (regular_field_seen) {
+                xqc_log(h3r->h3_stream->log, XQC_LOG_ERROR,
+                        "|pseudo-header after regular field|conn:%p|"
+                        "stream_id:%ui|field_index:%uz|name_len:%uz|",
+                        h3r->h3_stream->h3c->conn,
+                        h3r->h3_stream->stream_id, i, hdr->name.iov_len);
+                return -XQC_H3_EMALFORMED_HEADER;
+            }
+
+        } else {
+            regular_field_seen = XQC_TRUE;
+        }
+
         if (xqc_qpack_field_name_has_uppercase(hdr->name.iov_base,
                                                hdr->name.iov_len))
         {

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -91,6 +91,8 @@ printf_null(const char *format, ...)
 #define XQC_TEST_CASE_H3_H2_RESERVED_CONTROL_FRAME 1016
 #define XQC_TEST_CASE_H3_GOAWAY_DECREASE 1017
 #define XQC_TEST_CASE_H3_GOAWAY_INCREASE 1018
+#define XQC_TEST_CASE_H3_PSEUDO_HEADER_ORDER_VALID 1019
+#define XQC_TEST_CASE_H3_PSEUDO_HEADER_ORDER_INVALID 1020
 #define XQC_TEST_CASE_AEAD_CONFIDENTIALITY_BELOW_LIMIT 902
 #define XQC_TEST_CASE_AEAD_CONFIDENTIALITY_AT_LIMIT 903
 #define XQC_TEST_CASE_DATAGRAM_1RTT_ALLOWED 1201
@@ -286,7 +288,7 @@ int g_spec_url;
 int g_is_get;
 uint64_t g_last_sock_op_time;
 /*
- * currently, the maximum used test case id is 1014
+ * currently, the maximum used test case id is 1020
  * please keep this comment updated if you are adding more test cases. :-D
  * 55 for RFC 9114 Section 4.2 forbidden header e2e validation
  * 99 for pure fin
@@ -305,7 +307,7 @@ uint64_t g_last_sock_op_time;
  * 717 for RESET_STREAM on a peer-initiated unidirectional stream
  * 718/719 for MAX_STREAM_DATA stream direction validation
  * 902/903 for AEAD confidentiality-limit validation
- * 1000-1014 for HTTP/3 protocol validation
+ * 1000-1020 for HTTP/3 protocol validation
  */
 int g_test_case;
 int g_ipv6;
@@ -3567,6 +3569,20 @@ xqc_client_request_read_notify(xqc_h3_request_t *h3_request, xqc_request_notify_
             {
                 printf("lowercase_header_received:1\n");
             }
+
+            if ((g_test_case
+                 == XQC_TEST_CASE_H3_PSEUDO_HEADER_ORDER_VALID
+                 || g_test_case
+                    == XQC_TEST_CASE_H3_PSEUDO_HEADER_ORDER_INVALID)
+                && headers->headers[i].name.iov_len == 14
+                && memcmp(headers->headers[i].name.iov_base,
+                          "x-pseudo-order", 14) == 0
+                && headers->headers[i].value.iov_len == 5
+                && memcmp(headers->headers[i].value.iov_base,
+                          "value", 5) == 0)
+            {
+                printf("pseudo_header_order_received:1\n");
+            }
         }
 
         user_stream->header_recvd = 1;
@@ -3729,10 +3745,28 @@ xqc_client_request_close_notify(xqc_h3_request_t *h3_request, void *user_data)
         }
     }
 
+    if (g_test_case == XQC_TEST_CASE_H3_PSEUDO_HEADER_ORDER_VALID
+        && stats.stream_err == 0
+        && user_stream->header_recvd)
+    {
+        printf("pseudo_header_order_request_succeeded:1\n");
+    }
+
+    if (g_test_case == XQC_TEST_CASE_H3_PSEUDO_HEADER_ORDER_INVALID) {
+        if (stats.stream_err == H3_MESSAGE_ERROR) {
+            printf("pseudo_header_order_stream_error:1\n");
+
+        } else if (stats.stream_err == 0 && user_stream->header_recvd) {
+            printf("post_pseudo_header_order_error_request_succeeded:1\n");
+        }
+    }
+
     if (g_echo_check
         && !(g_test_case == XQC_TEST_CASE_H3_FIELD_SECTION_OVER_LIMIT
              && stats.stream_err == H3_MESSAGE_ERROR)
         && !(g_test_case == XQC_TEST_CASE_H3_UPPERCASE_RESPONSE
+             && stats.stream_err == H3_MESSAGE_ERROR)
+        && !(g_test_case == XQC_TEST_CASE_H3_PSEUDO_HEADER_ORDER_INVALID
              && stats.stream_err == H3_MESSAGE_ERROR))
     {
         int pass = 0;

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -68,6 +68,8 @@ printf_null(const char *format, ...)
 #define XQC_TEST_CASE_H3_UPPERCASE_RESPONSE 1014
 #define XQC_TEST_CASE_H3_H2_RESERVED_REQUEST_FRAME 1015
 #define XQC_TEST_CASE_H3_H2_RESERVED_CONTROL_FRAME 1016
+#define XQC_TEST_CASE_H3_PSEUDO_HEADER_ORDER_VALID 1019
+#define XQC_TEST_CASE_H3_PSEUDO_HEADER_ORDER_INVALID 1020
 #define XQC_TEST_CASE_AEAD_CONFIDENTIALITY_BELOW_LIMIT 902
 #define XQC_TEST_CASE_AEAD_CONFIDENTIALITY_AT_LIMIT 903
 #define XQC_TEST_CASE_DATAGRAM_1RTT_ALLOWED 1201
@@ -1406,9 +1408,12 @@ int
 xqc_server_request_send(xqc_h3_request_t *h3_request, user_stream_t *user_stream)
 {
     static int uppercase_response_sent;
+    static int invalid_pseudo_header_order_sent;
     ssize_t ret = 0;
     int header_cnt = 6;
     int send_uppercase;
+    int send_pseudo_header_order;
+    int send_invalid_pseudo_header_order;
     xqc_http_header_t header[MAX_HEADER] = {
         {
             .name   = {.iov_base = ":method", .iov_len = 7},
@@ -1444,6 +1449,12 @@ xqc_server_request_send(xqc_h3_request_t *h3_request, user_stream_t *user_stream
 
     send_uppercase = g_test_case == XQC_TEST_CASE_H3_UPPERCASE_RESPONSE
                      && !uppercase_response_sent;
+    send_pseudo_header_order =
+        g_test_case == XQC_TEST_CASE_H3_PSEUDO_HEADER_ORDER_VALID
+        || g_test_case == XQC_TEST_CASE_H3_PSEUDO_HEADER_ORDER_INVALID;
+    send_invalid_pseudo_header_order =
+        g_test_case == XQC_TEST_CASE_H3_PSEUDO_HEADER_ORDER_INVALID
+        && !invalid_pseudo_header_order_sent;
     if (g_test_case == XQC_TEST_CASE_H3_LOWERCASE_RESPONSE
         || (g_test_case == XQC_TEST_CASE_H3_UPPERCASE_RESPONSE
             && !send_uppercase))
@@ -1479,6 +1490,46 @@ xqc_server_request_send(xqc_h3_request_t *h3_request, user_stream_t *user_stream
             .flags = 0,
         };
         header[header_cnt++] = uppercase_name_hdr;
+    }
+
+    if (send_pseudo_header_order) {
+        xqc_http_header_t status_hdr = {
+            .name = {
+                .iov_base = ":status",
+                .iov_len = 7,
+            },
+            .value = {
+                .iov_base = "200",
+                .iov_len = 3,
+            },
+            .flags = 0,
+        };
+        xqc_http_header_t regular_hdr = {
+            .name = {
+                .iov_base = "x-pseudo-order",
+                .iov_len = 14,
+            },
+            .value = {
+                .iov_base = "value",
+                .iov_len = 5,
+            },
+            .flags = 0,
+        };
+
+        /*
+         * RFC 9114 Section 4.3 requires pseudo-header fields to precede
+         * regular fields. Bypass the public sender's normalization in this
+         * test peer so the client receives the selected wire order.
+         */
+        if (send_invalid_pseudo_header_order) {
+            header[0] = regular_hdr;
+            header[1] = status_hdr;
+
+        } else {
+            header[0] = status_hdr;
+            header[1] = regular_hdr;
+        }
+        header_cnt = 2;
     }
 
     if (g_test_case == 9) {
@@ -1520,6 +1571,13 @@ xqc_server_request_send(xqc_h3_request_t *h3_request, user_stream_t *user_stream
             uppercase_response_sent = 1;
             ret = xqc_h3_stream_send_headers(h3_request->h3_stream, &headers,
                                              header_only && send_fin);
+
+        } else if (send_pseudo_header_order) {
+            ret = xqc_h3_stream_send_headers(h3_request->h3_stream, &headers,
+                                             header_only && send_fin);
+            if (ret >= 0 && send_invalid_pseudo_header_order) {
+                invalid_pseudo_header_order_sent = 1;
+            }
 
         } else {
             ret = xqc_h3_request_send_headers(h3_request, &headers,

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -347,6 +347,12 @@ main(int argc, char *argv[])
                         xqc_test_h3_lowercase_field_name_stream_accepted)
         || !CU_add_test(pSuite, "xqc_test_h3_uppercase_field_name_stream_rejected",
                         xqc_test_h3_uppercase_field_name_stream_rejected)
+        /* RFC 9114 §4.3 pseudo-header field ordering */
+        || !CU_add_test(pSuite, "xqc_test_h3_pseudo_header_order_accepted",
+                        xqc_test_h3_pseudo_header_order_accepted)
+        || !CU_add_test(pSuite,
+                        "xqc_test_h3_pseudo_header_after_regular_rejected",
+                        xqc_test_h3_pseudo_header_after_regular_rejected)
         || !CU_add_test(pSuite, "xqc_test_stable", xqc_test_stable)
         || !CU_add_test(pSuite, "xqc_test_dtable", xqc_test_dtable)
         || !CU_add_test(pSuite, "test_2d_hash_table", test_2d_hash_table)

--- a/tests/unittest/xqc_h3_test.c
+++ b/tests/unittest/xqc_h3_test.c
@@ -2659,3 +2659,70 @@ xqc_test_h3_uppercase_field_name_stream_rejected()
 
     xqc_h3_msgerr_teardown(h3s, h3c, conn);
 }
+
+
+/*
+ * RFC 9114 Section 4.3 requires pseudo-header fields to precede regular
+ * fields. These field sections contain the same otherwise valid request
+ * fields and differ only in the position of :authority relative to x: v.
+ */
+void
+xqc_test_h3_pseudo_header_order_accepted()
+{
+    const unsigned char pseudo_before_regular[] = {
+        0x01, 0x0a, 0x00, 0x00, 0xd1, 0xd7,
+        0xc1, 0xc0, 0x21, 0x78, 0x01, 0x76
+    };
+    xqc_connection_t *conn = NULL;
+    xqc_h3_conn_t *h3c = NULL;
+    xqc_h3_stream_t *h3s = xqc_h3_msgerr_setup(&conn, &h3c);
+    CU_ASSERT_FATAL(h3s != NULL);
+
+    unsigned char buf[sizeof(pseudo_before_regular)];
+    xqc_memcpy(buf, pseudo_before_regular, sizeof(buf));
+
+    xqc_int_t ret = xqc_h3_stream_process_in(h3s, buf, sizeof(buf),
+                                             XQC_TRUE);
+
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    CU_ASSERT_EQUAL(xqc_h3_stream_get_err(h3s), 0);
+    CU_ASSERT_EQUAL(h3s->stream->stream_err, 0);
+    CU_ASSERT_EQUAL(conn->conn_err, 0);
+    CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) == 0);
+    CU_ASSERT_EQUAL(h3s->h3r->current_header, 1);
+    CU_ASSERT(h3s->h3r->read_flag & XQC_REQ_NOTIFY_READ_HEADER);
+
+    xqc_h3_msgerr_teardown(h3s, h3c, conn);
+}
+
+
+void
+xqc_test_h3_pseudo_header_after_regular_rejected()
+{
+    const unsigned char pseudo_after_regular[] = {
+        0x01, 0x0a, 0x00, 0x00, 0xd1, 0xd7,
+        0xc1, 0x21, 0x78, 0x01, 0x76, 0xc0
+    };
+    xqc_connection_t *conn = NULL;
+    xqc_h3_conn_t *h3c = NULL;
+    xqc_h3_stream_t *h3s = xqc_h3_msgerr_setup(&conn, &h3c);
+    CU_ASSERT_FATAL(h3s != NULL);
+
+    unsigned char buf[sizeof(pseudo_after_regular)];
+    xqc_memcpy(buf, pseudo_after_regular, sizeof(buf));
+
+    xqc_int_t ret = xqc_h3_stream_process_in(h3s, buf, sizeof(buf),
+                                             XQC_TRUE);
+
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    CU_ASSERT_EQUAL(xqc_h3_stream_get_err(h3s), H3_MESSAGE_ERROR);
+    CU_ASSERT_EQUAL(h3s->stream->stream_err, H3_MESSAGE_ERROR);
+    CU_ASSERT(h3s->stream->stream_state_send
+              >= XQC_SEND_STREAM_ST_RESET_SENT);
+    CU_ASSERT_EQUAL(conn->conn_err, 0);
+    CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) == 0);
+    CU_ASSERT_EQUAL(h3s->h3r->current_header, 0);
+    CU_ASSERT_EQUAL(h3s->h3r->read_flag, 0);
+
+    xqc_h3_msgerr_teardown(h3s, h3c, conn);
+}

--- a/tests/unittest/xqc_h3_test.h
+++ b/tests/unittest/xqc_h3_test.h
@@ -58,4 +58,8 @@ void xqc_test_h3_field_name_uppercase_rejection();
 void xqc_test_h3_lowercase_field_name_stream_accepted();
 void xqc_test_h3_uppercase_field_name_stream_rejected();
 
+/* RFC 9114 §4.3 pseudo-header field ordering */
+void xqc_test_h3_pseudo_header_order_accepted();
+void xqc_test_h3_pseudo_header_after_regular_rejected();
+
 #endif //XQUIC_XQC_H3_TEST_H


### PR DESCRIPTION
### Mechanism

Reject a decoded pseudo-header field that follows a regular field at the
HTTP/3 receive boundary, before the header section is exposed to the
application. The existing malformed-header path resets only the affected
stream with `H3_MESSAGE_ERROR`.

- RFC or draft: RFC 9114 Sections 4.3 and 4.1.2

Fixes: #752

### Validation Cases

- 1019 — accepts a response whose pseudo-header precedes a regular field
- 1020 — rejects the malformed stream and then reuses the connection

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Complete
- CI: Pending
