### PR TITLE
[~]: Prevent qlog case log contamination

### DIFF
--- a/case_test/observability/qlog.sh
+++ b/case_test/observability/qlog.sh
@@ -18,10 +18,10 @@ rm -rf tp_localhost test_session xqc_token
 
 
 
+case_test_stop_server
 clear_log
 rm -rf tp_localhost test_session xqc_token
 echo -e "qlog disable ...\c"
-case_test_stop_server
 case_test_start_server ${SERVER_BIN} -l d -e -x 1 --qlog_disable > /dev/null
 sleep 1
 ${CLIENT_BIN} -s 10240 -l d -t 1 -E --qlog_disable > stdlog
@@ -48,9 +48,9 @@ case_observability_qlog_qlog_importance_selected_1()
 {
 
 
+case_test_stop_server
 clear_log
 echo -e "qlog importance selected 1  ...\c"
-case_test_stop_server
 case_test_start_server ${SERVER_BIN} -l d -e -x 1 --qlog_importance s > /dev/null
 sleep 1
 ${CLIENT_BIN} -s 10240 -l d -t 1 -E --qlog_importance s > stdlog
@@ -77,9 +77,9 @@ case_observability_qlog_qlog_importance_selected_2()
 {
 
 
+case_test_stop_server
 clear_log
 echo -e "qlog importance selected 2  ...\c"
-case_test_stop_server
 case_test_start_server ${SERVER_BIN} -l i -e -x 1 --qlog_importance s > /dev/null
 sleep 1
 ${CLIENT_BIN} -s 10240 -l i -t 1 -E --qlog_importance s > stdlog
@@ -106,9 +106,9 @@ case_observability_qlog_qlog_importance_removed()
 {
 
 
+case_test_stop_server
 clear_log
 echo -e "qlog importance removed  ...\c"
-case_test_stop_server
 case_test_start_server ${SERVER_BIN} -l d -e -x 1 --qlog_importance r > /dev/null
 sleep 1
 ${CLIENT_BIN} -s 10240 -l d -t 1 -E --qlog_importance r > stdlog
@@ -140,9 +140,9 @@ case_observability_qlog_qlog_importance_extra()
 {
 
 
+case_test_stop_server
 clear_log
 echo -e "qlog importance extra  ...\c"
-case_test_stop_server
 case_test_start_server ${SERVER_BIN} -l d -e -x 1 --qlog_importance e > /dev/null
 sleep 1
 ${CLIENT_BIN} -s 10240 -l d -t 1 -E --qlog_importance e > stdlog
@@ -174,9 +174,9 @@ case_observability_qlog_qlog_importance_base()
 {
 
 
+case_test_stop_server
 clear_log
 echo -e "qlog importance base  ...\c"
-case_test_stop_server
 case_test_start_server ${SERVER_BIN} -l d -e -x 1 --qlog_importance b > /dev/null
 sleep 1
 ${CLIENT_BIN} -s 10240 -l d -t 1 -E --qlog_importance b > stdlog
@@ -207,12 +207,13 @@ case_observability_qlog_qlog_importance_core()
 {
 
 
+case_test_stop_server
 clear_log
 echo -e "qlog importance core  ...\c"
-case_test_stop_server
 case_test_start_server ${SERVER_BIN} -l d -e -x 1 --qlog_importance c > /dev/null
 sleep 1
-${CLIENT_BIN} -s 10240 -l d -t 1 -E --qlog_importance c > /dev/null
+${CLIENT_BIN} -s 10240 -l d -t 1 -E --qlog_importance c > stdlog
+result=`grep ">>>>>>>> pass:1" stdlog`
 svr_qlog_res1=`grep "\[packet_sent" slog`
 svr_qlog_res2=`grep "\[connection_" slog`
 svr_qlog_res3=`grep "\[datagram" slog`


### PR DESCRIPTION
### Mechanism

Stop each qlog server and wait for teardown before clearing per-case logs, so
shutdown events from the previous case cannot contaminate the next case's
assertions. The core-importance case also captures its own client result
instead of inheriting shell state from an earlier case.

- RFC or draft: `Not applicable` — test lifecycle only; qlog protocol behavior is unchanged.

### Validation Cases

- `Not applicable` — test-runner lifecycle change; no endpoint case IDs were added.

### CONTRIBUTING.md

- Overall: `Pending`
- Local regression: `Complete`
- CI: `Pending` — required pull-request checks.
