### PR TITLE
[~]: Complete self-hosted routing for Ubuntu CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,7 +192,7 @@ jobs:
 
     name: Test BabaSSL on Ubuntu 24.04 with GCC 13
 
-    runs-on: ubuntu-24.04
+    runs-on: self-hosted
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
### Mechanism

Complete the Ubuntu CI migration by routing the remaining BabaSSL job to the
repository's self-hosted runner pool. The primary Ubuntu job is already
self-hosted on the current base, so both Ubuntu jobs will use self-hosted
runners after this change while the macOS job keeps its existing hosted
runner.

- RFC or draft: `Not applicable`

### Validation Cases

- Not applicable — this is a workflow-only runner-routing change.

### CONTRIBUTING.md

- Overall: `Pending`
- Local regression: `Complete`
- CI: `Pending`
