### PR TITLE
[~] Fix #740: Reset CUBIC recovery after persistent congestion

### DIFF
--- a/src/congestion_control/xqc_cubic.c
+++ b/src/congestion_control/xqc_cubic.c
@@ -233,6 +233,8 @@ xqc_cubic_reset_cwnd(void *cong_ctl)
     cubic->cwnd = cubic->min_cwnd;
     cubic->tcp_cwnd = cubic->min_cwnd;
     cubic->last_max_cwnd = cubic->min_cwnd;
+    /* RFC 9002 Appendix B.8 resets recovery after persistent congestion. */
+    cubic->congestion_recovery_start_time = 0;
 }
 
 int32_t

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -143,6 +143,10 @@ main(int argc, char *argv[])
                         xqc_test_reno_reordered_ack)
         || !CU_add_test(pSuite, "xqc_test_cubic", xqc_test_cubic)
         || !CU_add_test(pSuite, "xqc_test_cubic_init_cwnd", xqc_test_cubic_init_cwnd)
+        || !CU_add_test(pSuite, "xqc_test_cubic_persistent_congestion_reset",
+                        xqc_test_cubic_persistent_congestion_reset)
+        || !CU_add_test(pSuite, "xqc_test_cubic_reordered_ack_in_recovery",
+                        xqc_test_cubic_reordered_ack_in_recovery)
         || !CU_add_test(pSuite, "xqc_test_bbr_init_cwnd",
                         xqc_test_bbr_init_cwnd)
         || !CU_add_test(pSuite, "xqc_test_bbr_init_cwnd_override",

--- a/tests/unittest/xqc_cubic_test.c
+++ b/tests/unittest/xqc_cubic_test.c
@@ -128,3 +128,63 @@ xqc_test_cubic_init_cwnd()
     CU_ASSERT_EQUAL(cubic.init_cwnd, XQC_CUBIC_TEST_MAX_INIT_WIN);
     CU_ASSERT_EQUAL(cubic.cwnd, XQC_CUBIC_TEST_MAX_INIT_WIN);
 }
+
+
+void
+xqc_test_cubic_persistent_congestion_reset()
+{
+    xqc_cubic_t       cubic;
+    xqc_cc_params_t   params;
+    xqc_packet_out_t  po;
+    xqc_usec_t        lost_sent_time;
+    xqc_usec_t        recovery_start;
+    uint64_t          cwnd;
+
+    memset(&params, 0, sizeof(params));
+    memset(&po, 0, sizeof(po));
+    xqc_cubic_cb.xqc_cong_ctl_init(&cubic, NULL, params);
+
+    lost_sent_time = xqc_monotonic_timestamp() + 1;
+    xqc_cubic_cb.xqc_cong_ctl_on_lost(&cubic, lost_sent_time);
+    CU_ASSERT_FATAL(cubic.congestion_recovery_start_time != 0);
+
+    recovery_start = cubic.congestion_recovery_start_time;
+    xqc_cubic_cb.xqc_cong_ctl_reset_cwnd(&cubic);
+
+    CU_ASSERT_EQUAL(cubic.congestion_recovery_start_time, 0);
+    CU_ASSERT_EQUAL(cubic.cwnd, cubic.min_cwnd);
+
+    cwnd = cubic.cwnd;
+    po.po_sent_time = recovery_start;
+    po.po_used_size = 1000;
+    xqc_cubic_cb.xqc_cong_ctl_on_ack(&cubic, &po, recovery_start + 1);
+
+    CU_ASSERT(cubic.cwnd > cwnd);
+}
+
+
+void
+xqc_test_cubic_reordered_ack_in_recovery()
+{
+    xqc_cubic_t       cubic;
+    xqc_cc_params_t   params;
+    xqc_packet_out_t  po;
+    xqc_usec_t        lost_sent_time;
+    uint64_t          cwnd;
+
+    memset(&params, 0, sizeof(params));
+    memset(&po, 0, sizeof(po));
+    xqc_cubic_cb.xqc_cong_ctl_init(&cubic, NULL, params);
+
+    lost_sent_time = xqc_monotonic_timestamp() + 1;
+    xqc_cubic_cb.xqc_cong_ctl_on_lost(&cubic, lost_sent_time);
+    CU_ASSERT_FATAL(cubic.congestion_recovery_start_time != 0);
+
+    cwnd = cubic.cwnd;
+    po.po_sent_time = cubic.congestion_recovery_start_time;
+    po.po_used_size = 1000;
+    xqc_cubic_cb.xqc_cong_ctl_on_ack(
+        &cubic, &po, cubic.congestion_recovery_start_time + 1);
+
+    CU_ASSERT_EQUAL(cubic.cwnd, cwnd);
+}

--- a/tests/unittest/xqc_cubic_test.h
+++ b/tests/unittest/xqc_cubic_test.h
@@ -7,5 +7,7 @@
 
 void xqc_test_cubic ();
 void xqc_test_cubic_init_cwnd ();
+void xqc_test_cubic_persistent_congestion_reset ();
+void xqc_test_cubic_reordered_ack_in_recovery ();
 
 #endif /* _XQC_CUBIC_TEST_H_INCLUDED_ */


### PR DESCRIPTION
### Mechanism

Clear CUBIC's recovery-start timestamp when persistent congestion collapses
the congestion window, so ACK processing does not retain the superseded
recovery epoch.

- RFC or draft: RFC 9002 Appendix B.8

Fixes: #740

### Validation Cases

- Not run — no independently targetable persistent-congestion client/server case exists.

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Incomplete — targeted persistent-congestion client/server coverage is unavailable.
- CI: Failed — retry passed macOS, BabaSSL, all 246 unit tests, both new CUBIC tests, and every congestion case; ordinary Ubuntu failed only the unrelated existing `tls.handshake/key_update_0RTT` case.
