### PR TITLE
[=] Fix #738: Preserve congestion threshold semantics across cwnd clamping

### DIFF
--- a/src/congestion_control/xqc_cubic.c
+++ b/src/congestion_control/xqc_cubic.c
@@ -177,10 +177,11 @@ xqc_cubic_on_lost(void *cong_ctl, xqc_usec_t lost_sent_time)
     }
 
     /* Multiplicative Decrease */
-    cubic->cwnd = cubic->cwnd * XQC_CUBIC_BETA / XQC_CUBIC_BETA_SCALE;
-    cubic->cwnd = xqc_max(cubic->cwnd, cubic->min_cwnd);
+    /* RFC 8312 Section 4.5 calculates ssthresh before the cwnd floor. */
+    cubic->ssthresh =
+        cubic->cwnd * XQC_CUBIC_BETA / XQC_CUBIC_BETA_SCALE;
+    cubic->cwnd = xqc_max(cubic->ssthresh, cubic->min_cwnd);
     cubic->tcp_cwnd = cubic->cwnd;
-    cubic->ssthresh = cubic->cwnd;
 }
 
 

--- a/src/congestion_control/xqc_new_reno.c
+++ b/src/congestion_control/xqc_new_reno.c
@@ -101,9 +101,11 @@ xqc_reno_on_lost(void *cong_ctl, xqc_usec_t lost_sent_time)
     if (!xqc_reno_was_pkt_sent_in_recovery(cong_ctl, lost_sent_time)) {
         reno->reno_recovery_start_time = xqc_monotonic_timestamp();
         reno->reno_in_recovery = XQC_TRUE;
-        reno->reno_congestion_window *= XQC_kLossReductionFactor;
-        reno->reno_congestion_window = xqc_max(reno->reno_congestion_window, XQC_kMinimumWindow);
-        reno->reno_ssthresh = reno->reno_congestion_window;
+        /* RFC 9002 Appendix B.6 preserves the pre-clamp reduction. */
+        reno->reno_ssthresh =
+            reno->reno_congestion_window * XQC_kLossReductionFactor;
+        reno->reno_congestion_window =
+            xqc_max(reno->reno_ssthresh, XQC_kMinimumWindow);
     }
 }
 

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -135,6 +135,10 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite, "xqc_test_flow_ctl_normal_no_clamp", xqc_test_flow_ctl_normal_no_clamp)
         || !CU_add_test(pSuite, "xqc_test_recv_record", xqc_test_recv_record)
         || !CU_add_test(pSuite, "xqc_test_reno", xqc_test_reno)
+        || !CU_add_test(pSuite, "xqc_test_reno_loss_ssthresh",
+                        xqc_test_reno_loss_ssthresh)
+        || !CU_add_test(pSuite, "xqc_test_reno_loss_ssthresh_min_clamp",
+                        xqc_test_reno_loss_ssthresh_min_clamp)
         || !CU_add_test(pSuite, "xqc_test_reno_init_cwnd", xqc_test_reno_init_cwnd)
         || !CU_add_test(pSuite, "xqc_test_reno_init_cwnd_override", xqc_test_reno_init_cwnd_override)
         || !CU_add_test(pSuite, "xqc_test_reno_recovery_exit",
@@ -142,6 +146,10 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite, "xqc_test_reno_reordered_ack",
                         xqc_test_reno_reordered_ack)
         || !CU_add_test(pSuite, "xqc_test_cubic", xqc_test_cubic)
+        || !CU_add_test(pSuite, "xqc_test_cubic_loss_ssthresh",
+                        xqc_test_cubic_loss_ssthresh)
+        || !CU_add_test(pSuite, "xqc_test_cubic_loss_ssthresh_min_clamp",
+                        xqc_test_cubic_loss_ssthresh_min_clamp)
         || !CU_add_test(pSuite, "xqc_test_cubic_init_cwnd", xqc_test_cubic_init_cwnd)
         || !CU_add_test(pSuite, "xqc_test_bbr_init_cwnd",
                         xqc_test_bbr_init_cwnd)

--- a/tests/unittest/xqc_cubic_test.c
+++ b/tests/unittest/xqc_cubic_test.c
@@ -18,7 +18,10 @@
  */
 #define XQC_CUBIC_TEST_MSS              XQC_MSS
 #define XQC_CUBIC_TEST_DEFAULT_INIT_WIN (10 * XQC_CUBIC_TEST_MSS)
+#define XQC_CUBIC_TEST_MIN_WIN          (4 * XQC_CUBIC_TEST_MSS)
 #define XQC_CUBIC_TEST_MAX_INIT_WIN     (100 * XQC_CUBIC_TEST_MSS)
+#define XQC_CUBIC_TEST_BETA             718
+#define XQC_CUBIC_TEST_BETA_SCALE       1024
 
 void
 print_cubic(xqc_cubic_t *cubic)
@@ -69,6 +72,42 @@ xqc_test_cubic()
     xqc_cubic_cb.xqc_cong_ctl_reset_cwnd(&cubic);
     print_cubic(&cubic);
 
+}
+
+void
+xqc_test_cubic_loss_ssthresh()
+{
+    xqc_cubic_t     cubic;
+    xqc_cc_params_t params = {0};
+    uint64_t        expected_ssthresh;
+
+    xqc_cubic_cb.xqc_cong_ctl_init(&cubic, NULL, params);
+    expected_ssthresh = cubic.cwnd * XQC_CUBIC_TEST_BETA
+                        / XQC_CUBIC_TEST_BETA_SCALE;
+    xqc_cubic_cb.xqc_cong_ctl_on_lost(&cubic, 1);
+
+    CU_ASSERT_EQUAL(cubic.ssthresh, expected_ssthresh);
+    CU_ASSERT_EQUAL(cubic.cwnd, expected_ssthresh);
+    CU_ASSERT_EQUAL(cubic.tcp_cwnd, expected_ssthresh);
+}
+
+void
+xqc_test_cubic_loss_ssthresh_min_clamp()
+{
+    xqc_cubic_t     cubic;
+    xqc_cc_params_t params = {0};
+    uint64_t        expected_ssthresh;
+
+    xqc_cubic_cb.xqc_cong_ctl_init(&cubic, NULL, params);
+    cubic.cwnd = 5 * XQC_CUBIC_TEST_MSS;
+    expected_ssthresh = cubic.cwnd * XQC_CUBIC_TEST_BETA
+                        / XQC_CUBIC_TEST_BETA_SCALE;
+    xqc_cubic_cb.xqc_cong_ctl_on_lost(&cubic, 1);
+
+    CU_ASSERT_EQUAL(cubic.ssthresh, expected_ssthresh);
+    CU_ASSERT_EQUAL(cubic.cwnd, XQC_CUBIC_TEST_MIN_WIN);
+    CU_ASSERT_EQUAL(cubic.tcp_cwnd, XQC_CUBIC_TEST_MIN_WIN);
+    CU_ASSERT_TRUE(cubic.cwnd > cubic.ssthresh);
 }
 
 /*

--- a/tests/unittest/xqc_cubic_test.h
+++ b/tests/unittest/xqc_cubic_test.h
@@ -6,6 +6,8 @@
 #define _XQC_CUBIC_TEST_H_INCLUDED_
 
 void xqc_test_cubic ();
+void xqc_test_cubic_loss_ssthresh ();
+void xqc_test_cubic_loss_ssthresh_min_clamp ();
 void xqc_test_cubic_init_cwnd ();
 
 #endif /* _XQC_CUBIC_TEST_H_INCLUDED_ */

--- a/tests/unittest/xqc_reno_test.c
+++ b/tests/unittest/xqc_reno_test.c
@@ -19,6 +19,7 @@
  * commit.
  */
 #define XQC_RENO_TEST_MSS               XQC_MSS
+#define XQC_RENO_TEST_MIN_WIN           (2 * XQC_RENO_TEST_MSS)
 #define XQC_RENO_TEST_MIN_INIT_WIN_PKTS 4
 #define XQC_RENO_TEST_MAX_INIT_WIN_PKTS 100
 
@@ -72,6 +73,44 @@ xqc_test_reno()
     xqc_reno_cb.xqc_cong_ctl_reset_cwnd(&reno);
     print_reno(&reno);
 
+}
+
+void
+xqc_test_reno_loss_ssthresh()
+{
+#ifndef XQC_ENABLE_RENO
+    return;
+#endif
+    xqc_new_reno_t  reno;
+    xqc_cc_params_t params = {0};
+    uint32_t        expected_ssthresh;
+
+    xqc_reno_cb.xqc_cong_ctl_init(&reno, NULL, params);
+    expected_ssthresh = reno.reno_congestion_window / 2;
+    xqc_reno_cb.xqc_cong_ctl_on_lost(&reno, 1);
+
+    CU_ASSERT_EQUAL(reno.reno_ssthresh, expected_ssthresh);
+    CU_ASSERT_EQUAL(reno.reno_congestion_window, expected_ssthresh);
+}
+
+void
+xqc_test_reno_loss_ssthresh_min_clamp()
+{
+#ifndef XQC_ENABLE_RENO
+    return;
+#endif
+    xqc_new_reno_t  reno;
+    xqc_cc_params_t params = {0};
+    uint32_t        expected_ssthresh;
+
+    xqc_reno_cb.xqc_cong_ctl_init(&reno, NULL, params);
+    reno.reno_congestion_window = 3 * XQC_RENO_TEST_MSS;
+    expected_ssthresh = reno.reno_congestion_window / 2;
+    xqc_reno_cb.xqc_cong_ctl_on_lost(&reno, 1);
+
+    CU_ASSERT_EQUAL(reno.reno_ssthresh, expected_ssthresh);
+    CU_ASSERT_EQUAL(reno.reno_congestion_window, XQC_RENO_TEST_MIN_WIN);
+    CU_ASSERT_TRUE(reno.reno_congestion_window > reno.reno_ssthresh);
 }
 
 /*

--- a/tests/unittest/xqc_reno_test.h
+++ b/tests/unittest/xqc_reno_test.h
@@ -6,6 +6,8 @@
 #define _XQC_RENO_TEST_H_INCLUDED_
 
 void xqc_test_reno ();
+void xqc_test_reno_loss_ssthresh ();
+void xqc_test_reno_loss_ssthresh_min_clamp ();
 void xqc_test_reno_init_cwnd ();
 void xqc_test_reno_init_cwnd_override ();
 void xqc_test_reno_recovery_exit ();


### PR DESCRIPTION
### Mechanism

- RFC or draft: RFC 9002 Appendix B.6 and RFC 9438 Section 4.6
- Preserve the multiplicative-decrease result as `ssthresh`, while applying
  the controller's minimum-window floor only to the current `cwnd`. This keeps
  the threshold state distinct from the operational congestion-window limit.
- Under the current Reno and CUBIC transitions, the two assignment orders are
  behavior-equivalent for sending: post-loss `cwnd` is unchanged and the
  strict `cwnd < ssthresh` slow-start check is false in either state. The
  change makes the internal state invariant explicit for future consumers.

Fixes: #738

### Validation Cases

- `native` — Reno and CUBIC transfers succeed with pacing enabled and disabled.

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Complete
- CI: Pending — required checks
