### PR TITLE
[~] Fix #742: Reject DATA before initial HTTP/3 HEADERS

### DIFF
--- a/case_test/http3/core.sh
+++ b/case_test/http3/core.sh
@@ -779,6 +779,36 @@ else
 fi
 }
 
+case_http3_core_h3_data_before_headers_rejected()
+{
+case_test_stop_server
+clear_log
+rm -f test_session xqc_token tp_localhost h3_request_frame_server.log
+case_test_start_server ${SERVER_BIN} -l d -e -x 1021 \
+    > h3_request_frame_server.log
+sleep 1
+echo -e "HTTP/3 DATA before HEADERS gets H3_FRAME_UNEXPECTED ...\c"
+${CLIENT_BIN} -s 1024 -l d -t 1 -E -x 1021 > stdlog
+for wait_idx in 1 2 3 4 5 6 7 8 9 10; do
+    server_err=`grep "data-before-headers|conn_err:261|" \
+        h3_request_frame_server.log`
+    [ -n "$server_err" ] && break
+    sleep 0.2
+done
+sent=`grep "\[h3-request-frame-test\]|type:0x0|ret:0|" stdlog`
+wire_err=`grep "err:0x105" slog`
+client_err=`grep -E "(conn errno:261|conn_err:261)" stdlog`
+application_type=`grep "conn_err_type:2" stdlog`
+if [ -n "$sent" ] && [ -n "$server_err" ] && [ -n "$wire_err" ] \
+    && [ -n "$client_err" ] && [ -n "$application_type" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "h3_data_before_headers_rejected" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "h3_data_before_headers_rejected" "fail"
+fi
+}
+
 case_http3_core_h3_client_push_promise_rejected()
 {
 
@@ -1308,6 +1338,8 @@ case_test_case "h3_reserved_uni_stream_survives" --id native --mode self-reporti
 case_test_case "h3_client_push_stream_creation_error" --id native --mode self-reporting --run case_http3_core_h3_client_push_stream_creation_error
 case_test_case "h3_reserved_request_frame_accepted" --id native --mode self-reporting --run case_http3_core_h3_reserved_request_frame_accepted
 case_test_case "h3_h2_reserved_request_frame_rejected" --id 1015 --mode self-reporting --run case_http3_core_h3_h2_reserved_request_frame_rejected
+case_test_case "h3_data_before_headers_rejected" --id 1021 \
+    --mode self-reporting --run case_http3_core_h3_data_before_headers_rejected
 case_test_case "h3_client_push_promise_rejected" --id native --mode self-reporting --run case_http3_core_h3_client_push_promise_rejected
 case_test_case "h3_max_push_id_increase_accepted" --id native --mode self-reporting --run case_http3_core_h3_max_push_id_increase_accepted
 case_test_case "h3_max_push_id_decrease_rejected" --id native --mode self-reporting --run case_http3_core_h3_max_push_id_decrease_rejected

--- a/harness/spec/validation.md
+++ b/harness/spec/validation.md
@@ -102,7 +102,7 @@ its case is retired so later changes cannot reuse it.
 | `[705, 799]` | QUIC Transport core | `705-723` |
 | `[800, 899]` | Recovery and congestion control | `800` |
 | `[900, 999]` | QUIC-TLS | `902-903` |
-| `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1020` |
+| `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1021` |
 | `[1100, 1149]` | QPACK | None |
 | `[1150, 1199]` | HTTP priority | None |
 | `[1200, 1299]` | QUIC DATAGRAM | `1201-1202` |

--- a/src/http3/xqc_h3_request.c
+++ b/src/http3/xqc_h3_request.c
@@ -815,7 +815,7 @@ xqc_h3_request_on_recv_header(xqc_h3_request_t *h3r)
     xqc_http_headers_t *headers;
     uint64_t fields_size;
 
-    if (h3r->current_header == 1) {
+    if (h3r->completed_header_count == 1) {
         /* notify data before trailer headers*/
         ret = xqc_h3_request_on_recv_body(h3r);
         if (ret != XQC_OK) {
@@ -825,13 +825,13 @@ xqc_h3_request_on_recv_header(xqc_h3_request_t *h3r)
     }
 
     /* header section and trailer section are all processed */
-    if (h3r->current_header >= XQC_H3_REQUEST_MAX_HEADERS_CNT) {
+    if (h3r->completed_header_count >= XQC_H3_REQUEST_MAX_HEADERS_CNT) {
         xqc_log(h3r->h3_stream->log, XQC_LOG_WARN, "|headers count exceed 2|"
                 "stream_id:%ui|", h3r->h3_stream->stream_id);
         return -XQC_H3_INVALID_HEADER;
     }
 
-    headers = &h3r->h3_header[h3r->current_header];
+    headers = &h3r->h3_header[h3r->completed_header_count];
 
     xqc_h3_request_header_end(h3r);
 
@@ -910,12 +910,12 @@ xqc_h3_request_on_recv_header(xqc_h3_request_t *h3r)
     }
 
     /* set read flag */
-    h3r->read_flag |= hdr_type_2_flag[h3r->current_header];
+    h3r->read_flag |= hdr_type_2_flag[h3r->completed_header_count];
 
     h3r->header_recvd += headers->total_len;
 
     /* prepare to process next header */
-    h3r->current_header++;
+    h3r->completed_header_count++;
 
     /* header notify callback */
     if (h3r->request_if->h3_request_read_notify) {
@@ -1009,12 +1009,12 @@ xqc_h3_stream_id(xqc_h3_request_t *h3_request)
 xqc_http_headers_t *
 xqc_h3_request_get_writing_headers(xqc_h3_request_t *h3r)
 {
-    if (h3r->current_header >= XQC_H3_REQUEST_MAX_HEADERS_CNT) {
+    if (h3r->completed_header_count >= XQC_H3_REQUEST_MAX_HEADERS_CNT) {
         return NULL;
     }
 
     xqc_h3_request_header_begin(h3r);
-    return &h3r->h3_header[h3r->current_header];
+    return &h3r->h3_header[h3r->completed_header_count];
 }
 
 #define XQC_H3_REQUEST_RECORD_TIME(a)       \

--- a/src/http3/xqc_h3_request.h
+++ b/src/http3/xqc_h3_request.h
@@ -31,8 +31,8 @@ typedef struct xqc_h3_request_s {
     size_t                          header_recvd;
     /* received header buf */
     xqc_http_headers_t              h3_header[XQC_H3_REQUEST_MAX_HEADERS_CNT];
-    /* total received headers frame count */
-    xqc_h3_header_type_t            current_header;
+    /* number of fully processed HEADERS frames */
+    uint8_t                         completed_header_count;
 
     /* received body buf list and statistic information */
     xqc_list_head_t                 body_buf;

--- a/src/http3/xqc_h3_stream.c
+++ b/src/http3/xqc_h3_stream.c
@@ -1502,6 +1502,20 @@ xqc_h3_stream_process_bidi_type_unknown(xqc_h3_stream_t *h3s,
                             -XQC_H3_REQUEST_FRAME_UNEXPECTED);
             return -XQC_H3_REQUEST_FRAME_UNEXPECTED;
         }
+
+        /*
+         * RFC 9114 Section 4.1: the unknown-type dispatcher consumes a
+         * complete zero-length first frame before request-stream processing.
+         * Reject DATA here so that form cannot bypass the sequence check.
+         */
+        if (pctx->frame.type == XQC_H3_FRM_DATA) {
+            xqc_log(h3s->log, XQC_LOG_ERROR,
+                    "|DATA before initial HEADERS on unknown bidi stream|");
+            xqc_h3_frm_reset_pctx(pctx);
+            XQC_H3_CONN_ERR(h3s->h3c, H3_FRAME_UNEXPECTED,
+                            -XQC_H3_REQUEST_FRAME_UNEXPECTED);
+            return -XQC_H3_REQUEST_FRAME_UNEXPECTED;
+        }
         
         if (pctx->frame.type != XQC_H3_EXT_FRM_BIDI_STREAM_TYPE) {
             /* the first frame is not BIDI_STREAM_TYPE */

--- a/src/http3/xqc_h3_stream.c
+++ b/src/http3/xqc_h3_stream.c
@@ -1091,6 +1091,20 @@ xqc_h3_stream_process_request(xqc_h3_stream_t *h3s, unsigned char *data, size_t 
                 break;
 
             case XQC_H3_FRM_DATA:
+                /*
+                 * RFC 9114 Section 4.1: DATA before the initial HEADERS
+                 * frame is an invalid frame sequence.
+                 */
+                if (h3s->h3r->current_header == XQC_H3_REQUEST_HEADER) {
+                    xqc_log(h3s->log, XQC_LOG_ERROR,
+                            "|DATA before initial HEADERS|stream_id:%ui|",
+                            h3s->stream_id);
+                    xqc_h3_frm_reset_pctx(pctx);
+                    XQC_H3_CONN_ERR(h3s->h3c, H3_FRAME_UNEXPECTED,
+                                    -XQC_H3_REQUEST_FRAME_UNEXPECTED);
+                    return -XQC_H3_REQUEST_FRAME_UNEXPECTED;
+                }
+
                 len = xqc_min(pctx->frame.len - pctx->frame.consumed_len, data_len - processed);
                 buf = xqc_var_buf_create(len);
                 if (buf == NULL) {

--- a/src/http3/xqc_h3_stream.c
+++ b/src/http3/xqc_h3_stream.c
@@ -1005,7 +1005,7 @@ xqc_h3_stream_process_request(xqc_h3_stream_t *h3s, unsigned char *data, size_t 
                 hdrs = xqc_h3_request_get_writing_headers(h3s->h3r);
                 if (NULL == hdrs) {
                     xqc_log(h3s->log, XQC_LOG_ERROR, "|get writing header error|");
-                    /* NULL here means current_header has reached
+                    /* NULL here means completed_header_count has reached
                      * XQC_H3_REQUEST_MAX_HEADERS_CNT (=2): our internal
                      * capacity for stored header blocks is exhausted.
                      * This is an implementation-side limit, not malformed
@@ -1095,7 +1095,7 @@ xqc_h3_stream_process_request(xqc_h3_stream_t *h3s, unsigned char *data, size_t 
                  * RFC 9114 Section 4.1: DATA before the initial HEADERS
                  * frame is an invalid frame sequence.
                  */
-                if (h3s->h3r->current_header == XQC_H3_REQUEST_HEADER) {
+                if (h3s->h3r->completed_header_count == 0) {
                     xqc_log(h3s->log, XQC_LOG_ERROR,
                             "|DATA before initial HEADERS|stream_id:%ui|",
                             h3s->stream_id);

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -93,6 +93,7 @@ printf_null(const char *format, ...)
 #define XQC_TEST_CASE_H3_GOAWAY_INCREASE 1018
 #define XQC_TEST_CASE_H3_PSEUDO_HEADER_ORDER_VALID 1019
 #define XQC_TEST_CASE_H3_PSEUDO_HEADER_ORDER_INVALID 1020
+#define XQC_TEST_CASE_H3_DATA_BEFORE_HEADERS 1021
 #define XQC_TEST_CASE_AEAD_CONFIDENTIALITY_BELOW_LIMIT 902
 #define XQC_TEST_CASE_AEAD_CONFIDENTIALITY_AT_LIMIT 903
 #define XQC_TEST_CASE_DATAGRAM_1RTT_ALLOWED 1201
@@ -311,7 +312,7 @@ uint64_t g_last_sock_op_time;
  * 718/719 for MAX_STREAM_DATA stream direction validation
  * 722/723 for RESET_STREAM final-size validation
  * 902/903 for AEAD confidentiality-limit validation
- * 1000-1020 for HTTP/3 protocol validation
+ * 1000-1021 for HTTP/3 protocol validation
  */
 int g_test_case;
 int g_ipv6;
@@ -3063,7 +3064,8 @@ xqc_client_request_send(xqc_h3_request_t *h3_request, user_stream_t *user_stream
     if (!user_stream->h3_test_frame_queued
         && (g_test_case == XQC_TEST_CASE_H3_RESERVED_REQUEST_FRAME
             || g_test_case == XQC_TEST_CASE_H3_CLIENT_PUSH_PROMISE
-            || g_test_case == XQC_TEST_CASE_H3_H2_RESERVED_REQUEST_FRAME))
+            || g_test_case == XQC_TEST_CASE_H3_H2_RESERVED_REQUEST_FRAME
+            || g_test_case == XQC_TEST_CASE_H3_DATA_BEFORE_HEADERS))
     {
         uint64_t frame_type = XQC_H3_FRM_RESERVED_PRIORITY;
         if (g_test_case == XQC_TEST_CASE_H3_CLIENT_PUSH_PROMISE) {
@@ -3071,6 +3073,9 @@ xqc_client_request_send(xqc_h3_request_t *h3_request, user_stream_t *user_stream
 
         } else if (g_test_case == XQC_TEST_CASE_H3_RESERVED_REQUEST_FRAME) {
             frame_type = 0x21;
+
+        } else if (g_test_case == XQC_TEST_CASE_H3_DATA_BEFORE_HEADERS) {
+            frame_type = XQC_H3_FRM_DATA;
         }
         ret = xqc_client_send_test_request_frame(h3_request, frame_type);
         if (ret != XQC_OK) {
@@ -3081,7 +3086,8 @@ xqc_client_request_send(xqc_h3_request_t *h3_request, user_stream_t *user_stream
 
     if (g_test_case == XQC_TEST_CASE_H3_RESERVED_REQUEST_FRAME
         || g_test_case == XQC_TEST_CASE_H3_CLIENT_PUSH_PROMISE
-        || g_test_case == XQC_TEST_CASE_H3_H2_RESERVED_REQUEST_FRAME)
+        || g_test_case == XQC_TEST_CASE_H3_H2_RESERVED_REQUEST_FRAME
+        || g_test_case == XQC_TEST_CASE_H3_DATA_BEFORE_HEADERS)
     {
         return XQC_OK;
     }

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -74,6 +74,7 @@ printf_null(const char *format, ...)
 #define XQC_TEST_CASE_H3_H2_RESERVED_CONTROL_FRAME 1016
 #define XQC_TEST_CASE_H3_PSEUDO_HEADER_ORDER_VALID 1019
 #define XQC_TEST_CASE_H3_PSEUDO_HEADER_ORDER_INVALID 1020
+#define XQC_TEST_CASE_H3_DATA_BEFORE_HEADERS 1021
 #define XQC_TEST_CASE_AEAD_CONFIDENTIALITY_BELOW_LIMIT 902
 #define XQC_TEST_CASE_AEAD_CONFIDENTIALITY_AT_LIMIT 903
 #define XQC_TEST_CASE_CRYPTO_PREVIOUS_LEVEL_BOUNDARY 720
@@ -1092,10 +1093,18 @@ xqc_server_h3_conn_close_notify(xqc_h3_conn_t *h3_conn, const xqc_cid_t *cid, vo
            stats.send_count, stats.lost_count, stats.tlp_count, stats.recv_count, stats.srtt, stats.early_data_flag, stats.conn_err, stats.ack_info, stats.conn_info, stats.alpn);
 
     if (g_test_case == XQC_TEST_CASE_H3_RESERVED_REQUEST_FRAME
-        || g_test_case == XQC_TEST_CASE_H3_H2_RESERVED_REQUEST_FRAME)
+        || g_test_case == XQC_TEST_CASE_H3_H2_RESERVED_REQUEST_FRAME
+        || g_test_case == XQC_TEST_CASE_H3_DATA_BEFORE_HEADERS)
     {
-        const char *kind = g_test_case == XQC_TEST_CASE_H3_RESERVED_REQUEST_FRAME
-                           ? "reserved-frame" : "http2-reserved";
+        const char *kind = "data-before-headers";
+        if (g_test_case == XQC_TEST_CASE_H3_RESERVED_REQUEST_FRAME) {
+            kind = "reserved-frame";
+
+        } else if (g_test_case
+                   == XQC_TEST_CASE_H3_H2_RESERVED_REQUEST_FRAME)
+        {
+            kind = "http2-reserved";
+        }
         printf("[h3-request-frame-test]|%s|conn_err:%d|\n", kind,
                stats.conn_err);
         fflush(stdout);

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -350,6 +350,12 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite, "xqc_test_h3_missing_settings", xqc_test_h3_missing_settings)
         || !CU_add_test(pSuite, "xqc_test_h3_request_frame_unexpected", xqc_test_h3_request_frame_unexpected)
         || !CU_add_test(pSuite,
+                        "xqc_test_h3_data_after_headers_accepted",
+                        xqc_test_h3_data_after_headers_accepted)
+        || !CU_add_test(pSuite,
+                        "xqc_test_h3_data_before_headers_rejected",
+                        xqc_test_h3_data_before_headers_rejected)
+        || !CU_add_test(pSuite,
                         "xqc_test_h3_server_reserved_request_frame_accepted",
                         xqc_test_h3_server_reserved_request_frame_accepted)
         || !CU_add_test(pSuite,

--- a/tests/unittest/xqc_h3_test.c
+++ b/tests/unittest/xqc_h3_test.c
@@ -2273,6 +2273,33 @@ xqc_test_h3_data_before_headers_rejected()
     CU_ASSERT(h3s->pctx.frame_pctx.state == XQC_H3_FRM_STATE_TYPE);
 
     xqc_h3_msgerr_teardown(h3s, h3c, conn);
+
+    /*
+     * A peer-created bidi stream is initially type-unknown when extensions
+     * are enabled. Exercise a complete zero-length DATA frame, which the
+     * unknown-type dispatcher consumes before request-stream processing.
+     */
+    conn = NULL;
+    h3c = NULL;
+    h3s = xqc_h3_msgerr_setup(&conn, &h3c);
+    CU_ASSERT_FATAL(h3s != NULL);
+    xqc_h3_request_destroy(h3s->h3r);
+    h3s->h3r = NULL;
+    h3s->type = XQC_H3_STREAM_TYPE_UNKNOWN;
+    h3c->flags |= XQC_H3_CONN_FLAG_EXT_ENABLED;
+
+    unsigned char empty_data[] = { XQC_H3_FRM_DATA, 0x00 };
+    processed = xqc_h3_stream_process_in(h3s, empty_data,
+            sizeof(empty_data), XQC_FALSE);
+
+    CU_ASSERT(processed == -XQC_H3_EPROC_REQUEST);
+    CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err) == H3_FRAME_UNEXPECTED);
+    CU_ASSERT(XQC_CONN_ERR_IS_APPLICATION(conn->conn_err));
+    CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
+    CU_ASSERT(h3s->h3r == NULL);
+    CU_ASSERT(h3s->pctx.frame_pctx.state == XQC_H3_FRM_STATE_TYPE);
+
+    xqc_h3_msgerr_teardown(h3s, h3c, conn);
 }
 
 

--- a/tests/unittest/xqc_h3_test.c
+++ b/tests/unittest/xqc_h3_test.c
@@ -960,7 +960,7 @@ xqc_test_h3_recv_header_field_section_size()
        total_len + count*32 > limit. Pre-fix this would have been accepted. */
     hdr->count     = 1;
     hdr->total_len = 80;
-    h3r->current_header = 0;
+    h3r->completed_header_count = 0;
     h3r->read_flag      = 0;
     ret = xqc_h3_request_on_recv_header(h3r);
     CU_ASSERT_EQUAL(ret, -XQC_H3_INVALID_HEADER);
@@ -968,7 +968,7 @@ xqc_test_h3_recv_header_field_section_size()
     /* exact-equal-to-limit must be accepted (check is strictly greater) */
     hdr->count     = 2;
     hdr->total_len = 36;
-    h3r->current_header = 0;
+    h3r->completed_header_count = 0;
     h3r->read_flag      = 0;
     ret = xqc_h3_request_on_recv_header(h3r);
     CU_ASSERT_EQUAL(ret, XQC_OK);
@@ -976,7 +976,7 @@ xqc_test_h3_recv_header_field_section_size()
     /* one byte over the limit must be rejected */
     hdr->count     = 2;
     hdr->total_len = 37;
-    h3r->current_header = 0;
+    h3r->completed_header_count = 0;
     h3r->read_flag      = 0;
     ret = xqc_h3_request_on_recv_header(h3r);
     CU_ASSERT_EQUAL(ret, -XQC_H3_INVALID_HEADER);
@@ -984,7 +984,7 @@ xqc_test_h3_recv_header_field_section_size()
     /* zero-field headers under the limit are accepted */
     hdr->count     = 0;
     hdr->total_len = 50;
-    h3r->current_header = 0;
+    h3r->completed_header_count = 0;
     h3r->read_flag      = 0;
     ret = xqc_h3_request_on_recv_header(h3r);
     CU_ASSERT_EQUAL(ret, XQC_OK);
@@ -1078,7 +1078,7 @@ xqc_h3_msgerr_setup(xqc_connection_t **out_conn, xqc_h3_conn_t **out_h3c)
         return NULL;
     }
 
-    /* eagerly create the request so tests can manipulate current_header
+    /* eagerly create the request so tests can manipulate completed_header_count
      * before feeding bytes through process_in. */
     h3s->h3r = xqc_h3_request_create_inner(h3c, h3s, NULL);
     if (h3s->h3r == NULL) {
@@ -1213,7 +1213,7 @@ xqc_test_h3_headers_capacity_uses_internal_error()
 
     /*
      * Simulate two prior HEADERS sections (request + trailer) by
-     * jumping current_header to the cap. A third HEADERS frame then
+     * jumping completed_header_count to the cap. A third HEADERS frame then
      * makes xqc_h3_request_get_writing_headers return NULL inside
      * xqc_h3_stream_process_request (xqc_h3_stream.c:920), which is
      * an implementation-side capacity exhaustion. Post-fix this must
@@ -1222,7 +1222,7 @@ xqc_test_h3_headers_capacity_uses_internal_error()
      * first-write-wins so the outer process_in mapping at line 1521
      * does not overwrite it.
      */
-    h3s->h3r->current_header = XQC_H3_REQUEST_MAX_HEADERS_CNT;
+    h3s->h3r->completed_header_count = XQC_H3_REQUEST_MAX_HEADERS_CNT;
 
     CU_ASSERT(conn->conn_err == 0);
 
@@ -1268,7 +1268,7 @@ xqc_test_h3_valid_headers_smoke()
     CU_ASSERT(h3s->stream->stream_state_send
               < XQC_SEND_STREAM_ST_RESET_SENT);
     /* the HEADERS frame should have advanced the request to 1 section */
-    CU_ASSERT(h3s->h3r->current_header == 1);
+    CU_ASSERT(h3s->h3r->completed_header_count == 1);
 
     xqc_h3_msgerr_teardown(h3s, h3c, conn);
 }
@@ -2236,7 +2236,7 @@ xqc_test_h3_data_after_headers_accepted()
     ssize_t processed = xqc_h3_stream_process_request(h3s, headers,
             sizeof(headers), XQC_FALSE);
     CU_ASSERT(processed == (ssize_t)sizeof(headers));
-    CU_ASSERT(h3s->h3r->current_header == XQC_H3_REQUEST_TRAILER);
+    CU_ASSERT(h3s->h3r->completed_header_count == 1);
 
     processed = xqc_h3_stream_process_request(h3s, data, sizeof(data),
             XQC_FALSE);
@@ -2267,7 +2267,7 @@ xqc_test_h3_data_before_headers_rejected()
     CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err) == H3_FRAME_UNEXPECTED);
     CU_ASSERT(XQC_CONN_ERR_IS_APPLICATION(conn->conn_err));
     CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
-    CU_ASSERT(h3s->h3r->current_header == XQC_H3_REQUEST_HEADER);
+    CU_ASSERT(h3s->h3r->completed_header_count == 0);
     CU_ASSERT(h3s->h3r->body_buf_count == 0);
     CU_ASSERT(xqc_list_empty(&h3s->h3r->body_buf));
     CU_ASSERT(h3s->pctx.frame_pctx.state == XQC_H3_FRM_STATE_TYPE);
@@ -2641,7 +2641,7 @@ xqc_test_h3_field_name_uppercase_rejection()
     hdr->total_len = 12;
     hdr->capacity  = 1;
 
-    h3r->current_header = 0;
+    h3r->completed_header_count = 0;
     h3r->read_flag      = 0;
     xqc_int_t ret = xqc_h3_request_on_recv_header(h3r);
     CU_ASSERT_EQUAL(ret, -XQC_H3_EMALFORMED_HEADER);
@@ -2650,7 +2650,7 @@ xqc_test_h3_field_name_uppercase_rejection()
     fake_hdrs[0].name.iov_base = (void *)"x-good-name";
     fake_hdrs[0].name.iov_len  = 11;
     hdr->total_len = 13;
-    h3r->current_header = 0;
+    h3r->completed_header_count = 0;
     h3r->read_flag      = 0;
     ret = xqc_h3_request_on_recv_header(h3r);
     CU_ASSERT_EQUAL(ret, XQC_OK);
@@ -2762,7 +2762,7 @@ xqc_test_h3_pseudo_header_order_accepted()
     CU_ASSERT_EQUAL(h3s->stream->stream_err, 0);
     CU_ASSERT_EQUAL(conn->conn_err, 0);
     CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) == 0);
-    CU_ASSERT_EQUAL(h3s->h3r->current_header, 1);
+    CU_ASSERT_EQUAL(h3s->h3r->completed_header_count, 1);
     CU_ASSERT(h3s->h3r->read_flag & XQC_REQ_NOTIFY_READ_HEADER);
 
     xqc_h3_msgerr_teardown(h3s, h3c, conn);
@@ -2794,7 +2794,7 @@ xqc_test_h3_pseudo_header_after_regular_rejected()
               >= XQC_SEND_STREAM_ST_RESET_SENT);
     CU_ASSERT_EQUAL(conn->conn_err, 0);
     CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) == 0);
-    CU_ASSERT_EQUAL(h3s->h3r->current_header, 0);
+    CU_ASSERT_EQUAL(h3s->h3r->completed_header_count, 0);
     CU_ASSERT_EQUAL(h3s->h3r->read_flag, 0);
 
     xqc_h3_msgerr_teardown(h3s, h3c, conn);

--- a/tests/unittest/xqc_h3_test.c
+++ b/tests/unittest/xqc_h3_test.c
@@ -2184,17 +2184,8 @@ xqc_test_h3_request_frame_unexpected()
     CU_ASSERT(XQC_H3_FRM_MAX_PUSH_ID == 0x0D);
 
 
-    /*
-     * ===== Negative cases: request-stream frames MUST NOT be rejected =====
-     *
-     * DATA and HEADERS are valid on request streams. Verify the fix
-     * does not accidentally widen the rejection to legitimate frames.
-     */
-
-    /* Case 5: DATA (0x00) on request stream -- must be accepted */
-    xqc_test_h3_request_frame_unexpected_one(XQC_H3_FRM_DATA, XQC_FALSE);
-
-    /* Case 6: HEADERS (0x01) on request stream -- must be accepted */
+    /* HEADERS is valid on request streams. DATA validity depends on the
+     * HTTP message sequence and is covered by dedicated tests below. */
     xqc_test_h3_request_frame_unexpected_one(XQC_H3_FRM_HEADERS, XQC_FALSE);
 
 
@@ -2227,6 +2218,61 @@ xqc_test_h3_request_frame_unexpected()
      */
     CU_ASSERT(XQC_H3_REQUEST_FRAME_UNEXPECTED == 835);
     CU_ASSERT(XQC_H3_REQUEST_FRAME_UNEXPECTED >= XQC_H3_EMALLOC);
+}
+
+
+void
+xqc_test_h3_data_after_headers_accepted()
+{
+    xqc_connection_t *conn = NULL;
+    xqc_h3_conn_t *h3c = NULL;
+    xqc_h3_stream_t *h3s = xqc_h3_msgerr_setup(&conn, &h3c);
+    CU_ASSERT_FATAL(h3s != NULL);
+
+    unsigned char headers[sizeof(xqc_h3_msgerr_valid_headers)];
+    xqc_memcpy(headers, xqc_h3_msgerr_valid_headers, sizeof(headers));
+    unsigned char data[] = { XQC_H3_FRM_DATA, 0x01, 0x2a };
+
+    ssize_t processed = xqc_h3_stream_process_request(h3s, headers,
+            sizeof(headers), XQC_FALSE);
+    CU_ASSERT(processed == (ssize_t)sizeof(headers));
+    CU_ASSERT(h3s->h3r->current_header == XQC_H3_REQUEST_TRAILER);
+
+    processed = xqc_h3_stream_process_request(h3s, data, sizeof(data),
+            XQC_FALSE);
+    CU_ASSERT(processed == (ssize_t)sizeof(data));
+    CU_ASSERT(conn->conn_err == 0);
+    CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) == 0);
+    CU_ASSERT(h3s->h3r->body_buf_count == 1);
+    CU_ASSERT(!xqc_list_empty(&h3s->h3r->body_buf));
+
+    xqc_h3_msgerr_teardown(h3s, h3c, conn);
+}
+
+
+void
+xqc_test_h3_data_before_headers_rejected()
+{
+    xqc_connection_t *conn = NULL;
+    xqc_h3_conn_t *h3c = NULL;
+    xqc_h3_stream_t *h3s = xqc_h3_msgerr_setup(&conn, &h3c);
+    CU_ASSERT_FATAL(h3s != NULL);
+
+    /* RFC 9114 Section 4.1 requires H3_FRAME_UNEXPECTED for this sequence. */
+    unsigned char data[] = { XQC_H3_FRM_DATA, 0x01, 0x2a };
+    ssize_t processed = xqc_h3_stream_process_request(h3s, data,
+            sizeof(data), XQC_FALSE);
+
+    CU_ASSERT(processed == -XQC_H3_REQUEST_FRAME_UNEXPECTED);
+    CU_ASSERT(XQC_CONN_ERR_CODE(conn->conn_err) == H3_FRAME_UNEXPECTED);
+    CU_ASSERT(XQC_CONN_ERR_IS_APPLICATION(conn->conn_err));
+    CU_ASSERT((conn->conn_flag & XQC_CONN_FLAG_ERROR) != 0);
+    CU_ASSERT(h3s->h3r->current_header == XQC_H3_REQUEST_HEADER);
+    CU_ASSERT(h3s->h3r->body_buf_count == 0);
+    CU_ASSERT(xqc_list_empty(&h3s->h3r->body_buf));
+    CU_ASSERT(h3s->pctx.frame_pctx.state == XQC_H3_FRM_STATE_TYPE);
+
+    xqc_h3_msgerr_teardown(h3s, h3c, conn);
 }
 
 

--- a/tests/unittest/xqc_h3_test.h
+++ b/tests/unittest/xqc_h3_test.h
@@ -39,6 +39,10 @@ void xqc_test_h3_missing_settings();
 /* issue #609: RFC 9114 §7.2 control-only frames on request stream */
 void xqc_test_h3_request_frame_unexpected();
 
+/* issue #742: RFC 9114 §4.1 request-stream frame sequence */
+void xqc_test_h3_data_after_headers_accepted();
+void xqc_test_h3_data_before_headers_rejected();
+
 /* issue #849: RFC 9114 §7.2.5 PUSH_PROMISE sender role */
 void xqc_test_h3_server_reserved_request_frame_accepted();
 void xqc_test_h3_server_push_promise_rejected();


### PR DESCRIPTION
### Mechanism

Track fully processed HEADERS frames with an explicit numeric counter. Reject
DATA while the completed count is zero with `H3_FRAME_UNEXPECTED`, before
buffering body data. This also covers a zero-length first DATA frame consumed
by the unknown-stream dispatcher, while DATA following a completed initial
HEADERS remains accepted.

- RFC or draft: RFC 9114 Section 4.1

Fixes: #742

### Validation Cases

- Pending — client-to-server case `1021` has not been rerun for the current
  head.

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Incomplete — case `1021` pending
- CI: Pending
