### PR TITLE
[~] Fix #244: Bound default connection receive window

### DIFF
--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -553,9 +553,11 @@ xqc_conn_init_trans_settings(xqc_connection_t *conn)
             ls->max_data = xqc_min(XQC_MAX_RECV_WINDOW, ls->max_data);
 
         } else {
-            /* max_data is the sum of stream_data on all uni and bidi streams */
-            ls->max_data = ls->max_streams_bidi * ls->max_stream_data_bidi_local
-                + ls->max_streams_uni * ls->max_stream_data_uni;
+            /*
+             * RFC 9000 Section 4.1: connection flow control limits the
+             * aggregate receive buffer independently of per-stream limits.
+             */
+            ls->max_data = XQC_MAX_RECV_WINDOW;
         }
     }
 

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -82,6 +82,10 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite, "xqc_test_get_random", xqc_test_get_random)
         || !CU_add_test(pSuite, "xqc_test_engine_create", xqc_test_engine_create)
         || !CU_add_test(pSuite, "xqc_test_conn_create", xqc_test_conn_create)
+        || !CU_add_test(pSuite, "xqc_test_conn_default_recv_window",
+                        xqc_test_conn_default_recv_window)
+        || !CU_add_test(pSuite, "xqc_test_conn_recv_window_with_many_streams",
+                        xqc_test_conn_recv_window_with_many_streams)
         || !CU_add_test(pSuite, "xqc_test_datagram_transport_param_65536",
                         xqc_test_datagram_transport_param_65536)
         || !CU_add_test(pSuite,

--- a/tests/unittest/xqc_conn_test.c
+++ b/tests/unittest/xqc_conn_test.c
@@ -155,6 +155,64 @@ xqc_test_conn_create()
 
 
 void
+xqc_test_conn_default_recv_window(void)
+{
+    xqc_connection_t *conn;
+    xqc_transport_params_t params;
+
+    conn = test_engine_connect();
+    CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+
+    xqc_init_transport_params(&params);
+    CU_ASSERT_EQUAL(xqc_conn_get_local_transport_params(conn, &params),
+                    XQC_OK);
+    CU_ASSERT_EQUAL(params.initial_max_data, XQC_MAX_RECV_WINDOW);
+    CU_ASSERT_EQUAL(conn->conn_flow_ctl.fc_max_data_can_recv,
+                    XQC_MAX_RECV_WINDOW);
+    CU_ASSERT_EQUAL(conn->conn_flow_ctl.fc_recv_windows_size,
+                    XQC_MAX_RECV_WINDOW);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
+void
+xqc_test_conn_recv_window_with_many_streams(void)
+{
+    xqc_conn_settings_t conn_settings = {0};
+    xqc_conn_ssl_config_t conn_ssl_config = {0};
+    xqc_transport_params_t params;
+    xqc_engine_t *engine;
+    xqc_connection_t *conn;
+    const xqc_cid_t *cid;
+
+    engine = test_create_engine();
+    CU_ASSERT_PTR_NOT_NULL_FATAL(engine);
+
+    conn_settings.proto_version = XQC_VERSION_V1;
+    conn_settings.max_streams_bidi = 4096;
+    conn_settings.max_streams_uni = 4096;
+    cid = xqc_connect(engine, &conn_settings, NULL, 0, "", 0,
+                      &conn_ssl_config, NULL, 0, "transport", NULL);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(cid);
+
+    conn = xqc_engine_conns_hash_find(engine, cid, 's');
+    CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+    CU_ASSERT_EQUAL(conn->local_settings.max_streams_bidi, 4096);
+    CU_ASSERT_EQUAL(conn->local_settings.max_streams_uni, 4096);
+    CU_ASSERT_EQUAL(conn->local_settings.max_data, XQC_MAX_RECV_WINDOW);
+    CU_ASSERT_EQUAL(conn->conn_flow_ctl.fc_max_data_can_recv,
+                    XQC_MAX_RECV_WINDOW);
+    xqc_init_transport_params(&params);
+    CU_ASSERT_EQUAL(xqc_conn_get_local_transport_params(conn, &params),
+                    XQC_OK);
+    CU_ASSERT_EQUAL(params.initial_max_data, XQC_MAX_RECV_WINDOW);
+
+    xqc_engine_destroy(engine);
+}
+
+
+void
 xqc_test_datagram_transport_param_65536(void)
 {
     xqc_connection_t *conn = test_engine_connect();

--- a/tests/unittest/xqc_conn_test.h
+++ b/tests/unittest/xqc_conn_test.h
@@ -6,6 +6,8 @@
 #define XQC_CONN_TEST_H
 
 void xqc_test_conn_create();
+void xqc_test_conn_default_recv_window(void);
+void xqc_test_conn_recv_window_with_many_streams(void);
 void xqc_test_datagram_transport_param_65536(void);
 void xqc_test_datagram_transport_param_varint_max(void);
 void xqc_test_conn_idle_timeout();


### PR DESCRIPTION
### Mechanism

Default connection receive credit is capped at `XQC_MAX_RECV_WINDOW` instead
of summing every advertised stream's individual allowance. This restores
connection flow control as an aggregate unread-data bound while leaving
per-stream, interoperability-mode, and explicit receive-rate behavior
unchanged.

- RFC or draft: [RFC 9000 Section 4.1](https://www.rfc-editor.org/rfc/rfc9000.html#section-4.1)

Fixes: #244

### Validation Cases

- Not executed — the local transport endpoint runner requires interactive sudo.
- Gap — no existing client-to-server case stalls application reads to exercise the aggregate bound.

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Incomplete — complete unit suite passed; transport endpoint execution requires interactive sudo.
- CI: Pending
