### PR TITLE
[~] Fix #232: Close unidirectional streams by direction

### DIFF
--- a/case_test/transport/stream.sh
+++ b/case_test/transport/stream.sh
@@ -776,6 +776,70 @@ fi
 
 }
 
+case_transport_stream_close_send_only_stream()
+{
+
+case_test_stop_server
+clear_log
+rm -f test_session xqc_token tp_localhost
+case_test_start_server ${SERVER_BIN} -l d -e -x 724 > /dev/null
+sleep 1
+echo -e "close_send_only_stream ...\c"
+${CLIENT_BIN} -s 1024 -l d -t 1 -E -T 1 -x 724 > stdlog
+sleep 1
+client_closed=`grep \
+    "\[stream-close-direction-test\]|case:724|stream_id:2|close_ret:0|" \
+    stdlog`
+server_reset=`grep \
+    "xqc_parse_reset_stream_frame|type:3|stream_id:2|" slog`
+server_rejected=`grep "STOP_SENDING on recv-only stream|stream_id:2|" slog`
+client_close_code=`grep "xqc_parse_conn_close_frame|type:18|err_code:5|" clog`
+if [ -n "$client_closed" ] && [ -n "$server_reset" ] \
+    && [ -z "$server_rejected" ] && [ -z "$client_close_code" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "close_send_only_stream" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "close_send_only_stream" "fail"
+fi
+
+}
+
+case_transport_stream_close_recv_only_stream()
+{
+
+case_test_stop_server
+clear_log
+rm -f test_session xqc_token tp_localhost
+case_test_start_server ${SERVER_BIN} -l d -e -x 725 > svr_stdlog
+sleep 1
+echo -e "close_recv_only_stream ...\c"
+${CLIENT_BIN} -s 1024 -l d -t 1 -E -T 1 -x 725 > stdlog
+sleep 1
+server_sent=`grep \
+    "\[stream-close-direction-test\]|case:725|stream_id:3|send_ret:1|" \
+    svr_stdlog`
+client_closed=`grep \
+    "\[stream-close-direction-test\]|case:725|stream_id:3|"\
+"first_ret:0|second_ret:0|" stdlog`
+server_stop=`grep \
+    "xqc_parse_stop_sending_frame|type:4|stream_id:3|" slog`
+client_reset=`grep \
+    "xqc_parse_reset_stream_frame|type:3|stream_id:3|" clog`
+server_rejected=`grep "RESET_STREAM on send-only stream|stream_id:3|" slog`
+client_close_code=`grep "xqc_parse_conn_close_frame|type:18|err_code:5|" clog`
+if [ -n "$server_sent" ] && [ -n "$client_closed" ] \
+    && [ -n "$server_stop" ] && [ -n "$client_reset" ] \
+    && [ -z "$server_rejected" ] && [ -z "$client_close_code" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "close_recv_only_stream" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "close_recv_only_stream" "fail"
+fi
+
+}
+
 case_test_case "server_inited_stream" --id native --mode self-reporting --run case_transport_stream_server_inited_stream
 case_test_case "stream_send_pure_fin" --id native --mode self-reporting --run case_transport_stream_stream_send_pure_fin
 case_test_case "stream_read_notify_fail" --id native --mode self-reporting --run case_transport_stream_stream_read_notify_fail
@@ -816,6 +880,10 @@ case_test_case "max_stream_data_on_send_only_stream" --id native \
 case_test_case "max_stream_data_on_recv_only_stream" --id native \
     --mode self-reporting \
     --run case_transport_stream_max_stream_data_on_recv_only_stream
+case_test_case "close_send_only_stream" --id 724 \
+    --mode self-reporting --run case_transport_stream_close_send_only_stream
+case_test_case "close_recv_only_stream" --id 725 \
+    --mode self-reporting --run case_transport_stream_close_recv_only_stream
 
 if case_test_is_discovery; then
     case_test_run

--- a/harness/spec/validation.md
+++ b/harness/spec/validation.md
@@ -99,7 +99,7 @@ its case is retired so later changes cannot reuse it.
 
 | Range | New-case namespace | Allocated IDs |
 |-------|--------------------|---------------|
-| `[705, 799]` | QUIC Transport core | `705-723` |
+| `[705, 799]` | QUIC Transport core | `705-725` |
 | `[800, 899]` | Recovery and congestion control | `800` |
 | `[900, 999]` | QUIC-TLS | `902-903` |
 | `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1021` |

--- a/include/xquic/xquic.h
+++ b/include/xquic/xquic.h
@@ -2062,7 +2062,8 @@ XQC_EXPORT_PUBLIC_API
 xqc_stream_id_t xqc_stream_id(xqc_stream_t *stream);
 
 /**
- * Send RESET_STREAM to peer, stream_close_notify will callback when stream destroyed
+ * Close the applicable stream directions with RESET_STREAM or STOP_SENDING.
+ * stream_close_notify will callback when stream destroyed.
  * @retval XQC_OK for success, others for failure
  */
 XQC_EXPORT_PUBLIC_API

--- a/src/transport/xqc_stream.c
+++ b/src/transport/xqc_stream.c
@@ -923,6 +923,10 @@ xqc_stream_close_with_error(xqc_stream_t *stream, uint64_t err_code)
 {
     xqc_int_t ret;
     xqc_connection_t *conn = stream->stream_conn;
+    xqc_bool_t send_only = xqc_stream_is_send_only(conn->conn_type,
+                                                    stream->stream_id);
+    xqc_bool_t recv_only = xqc_stream_is_recv_only(conn->conn_type,
+                                                    stream->stream_id);
     xqc_log(conn->log, XQC_LOG_DEBUG, "|stream_id:%ui|"
             "stream_state_send:%d|stream_state_recv:%d|conn:%p|"
             "conn_state:%s|err_code:%ui|", stream->stream_id,
@@ -931,7 +935,12 @@ xqc_stream_close_with_error(xqc_stream_t *stream, uint64_t err_code)
 
     XQC_STREAM_CLOSE_MSG(stream, "local reset");
 
-    if (stream->stream_state_send >= XQC_SEND_STREAM_ST_RESET_SENT) {
+    if ((!recv_only
+         && stream->stream_state_send >= XQC_SEND_STREAM_ST_RESET_SENT)
+        || (recv_only
+            && (stream->stream_flag
+                & XQC_STREAM_FLAG_STOP_SENDING_SENT)))
+    {
         return XQC_OK;
     }
     if (conn->conn_state >= XQC_CONN_STATE_CLOSING) {
@@ -939,24 +948,34 @@ xqc_stream_close_with_error(xqc_stream_t *stream, uint64_t err_code)
     }
 
     xqc_send_queue_drop_stream_frame_packets(conn, stream->stream_id);
-    ret = xqc_write_reset_stream_to_packet(conn, stream, err_code,
-                                           stream->stream_send_offset);
-    if (ret < 0) {
-        xqc_log(conn->log, XQC_LOG_ERROR,
-                "|xqc_write_reset_stream_to_packet error|%d|", ret);
-        XQC_CONN_ERR(conn, TRA_INTERNAL_ERROR);
+    /*
+     * RFC 9000 Sections 3.3, 19.4, and 19.5: a stream receiver sends
+     * STOP_SENDING, while a stream sender sends RESET_STREAM.
+     */
+    if (!recv_only) {
+        ret = xqc_write_reset_stream_to_packet(conn, stream, err_code,
+                                               stream->stream_send_offset);
+        if (ret < 0) {
+            xqc_log(conn->log, XQC_LOG_ERROR,
+                    "|xqc_write_reset_stream_to_packet error|%d|", ret);
+            XQC_CONN_ERR(conn, TRA_INTERNAL_ERROR);
+        }
     }
 
     /* A STOP_SENDING frame can be sent for streams in the "Recv" or "Size
        Known" states */
-    if (stream->stream_state_recv == XQC_RECV_STREAM_ST_RECV
-        || stream->stream_state_recv == XQC_RECV_STREAM_ST_SIZE_KNOWN)
+    if (!send_only
+        && (stream->stream_state_recv == XQC_RECV_STREAM_ST_RECV
+            || stream->stream_state_recv == XQC_RECV_STREAM_ST_SIZE_KNOWN))
     {
         ret = xqc_write_stop_sending_to_packet(conn, stream, err_code);
         if (ret < 0) {
             xqc_log(conn->log, XQC_LOG_ERROR,
                     "|xqc_write_stop_sending_to_packet error|%d|", ret);
             XQC_CONN_ERR(conn, TRA_INTERNAL_ERROR);
+
+        } else {
+            stream->stream_flag |= XQC_STREAM_FLAG_STOP_SENDING_SENT;
         }
     }
 

--- a/src/transport/xqc_stream.h
+++ b/src/transport/xqc_stream.h
@@ -39,6 +39,7 @@ typedef enum {
     XQC_STREAM_FLAG_CLOSED          = 1 << 7,
     XQC_STREAM_FLAG_UNEXPECTED      = 1 << 8,
     XQC_STREAM_FLAG_DISCARDED       = 1 << 9,   /* stream create_notify with error, all stream data will be discarded */
+    XQC_STREAM_FLAG_STOP_SENDING_SENT = 1 << 10,
 } xqc_stream_flag_t;
 
 typedef enum {

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -102,6 +102,8 @@ printf_null(const char *format, ...)
 #define XQC_TEST_CASE_RETRY_IGNORE_OLD_INITIAL_DCID 716
 #define XQC_TEST_CASE_RESET_FINAL_SIZE_VALID 722
 #define XQC_TEST_CASE_RESET_FINAL_SIZE_TOO_SMALL 723
+#define XQC_TEST_CASE_CLOSE_SEND_ONLY_STREAM 724
+#define XQC_TEST_CASE_CLOSE_RECV_ONLY_STREAM 725
 
 typedef struct user_conn_s user_conn_t;
 
@@ -118,6 +120,7 @@ static void xqc_client_send_test_single_vint_frame(
 static xqc_int_t xqc_client_write_test_datagram_frame(
     xqc_connection_t *conn, xqc_pkt_type_t pkt_type);
 static void xqc_client_send_reset_final_size_frames(xqc_connection_t *conn);
+static void xqc_client_close_send_only_stream(xqc_connection_t *conn);
 
 
 #define XQC_TEST_DGRAM_BATCH_SZ 32
@@ -311,6 +314,7 @@ uint64_t g_last_sock_op_time;
  * 717 for RESET_STREAM on a peer-initiated unidirectional stream
  * 718/719 for MAX_STREAM_DATA stream direction validation
  * 722/723 for RESET_STREAM final-size validation
+ * 724/725 for unidirectional stream close validation
  * 902/903 for AEAD confidentiality-limit validation
  * 1000-1021 for HTTP/3 protocol validation
  */
@@ -2091,6 +2095,10 @@ xqc_client_conn_handshake_finished(xqc_connection_t *conn, void *user_data, void
         xqc_client_send_reset_final_size_frames(conn);
     }
 
+    if (g_test_case == XQC_TEST_CASE_CLOSE_SEND_ONLY_STREAM) {
+        xqc_client_close_send_only_stream(conn);
+    }
+
     hsk_completed = 1;
 
     user_conn->dgram_mss = xqc_datagram_get_mss(conn);
@@ -2297,6 +2305,37 @@ xqc_client_send_reset_final_size_frames(xqc_connection_t *conn)
     printf("[reset-final-size-test]|case:%d|stream_id:2|offset:5|"
            "data_length:1|final_size:%"PRIu64"|written|\n",
            g_test_case, final_size);
+}
+
+
+static void
+xqc_client_close_send_only_stream(xqc_connection_t *conn)
+{
+    user_stream_t *user_stream;
+    xqc_stream_t *stream;
+    xqc_int_t ret;
+
+    user_stream = calloc(1, sizeof(*user_stream));
+    if (user_stream == NULL) {
+        printf("[stream-close-direction-test]|case:%d|alloc_failed|\n",
+               g_test_case);
+        return;
+    }
+
+    stream = xqc_stream_create_with_direction(conn, XQC_STREAM_UNI,
+                                              user_stream);
+    if (stream == NULL) {
+        printf("[stream-close-direction-test]|case:%d|stream_unavailable|\n",
+               g_test_case);
+        free(user_stream);
+        return;
+    }
+
+    user_stream->stream = stream;
+    ret = xqc_stream_close(stream);
+    printf("[stream-close-direction-test]|case:%d|stream_id:%"PRIu64
+           "|close_ret:%d|\n", g_test_case, xqc_stream_id(stream), ret);
+    fflush(stdout);
 }
 
 
@@ -2712,6 +2751,38 @@ xqc_client_stream_write_notify(xqc_stream_t *stream, void *user_data)
     user_stream_t *user_stream = (user_stream_t *) user_data;
     ret = xqc_client_stream_send(stream, user_stream);
     return ret;
+}
+
+int
+xqc_client_stream_create_notify(xqc_stream_t *stream, void *user_data)
+{
+    user_stream_t *user_stream;
+    xqc_int_t first_ret = XQC_OK;
+    xqc_int_t second_ret = XQC_OK;
+
+    if (g_test_case != XQC_TEST_CASE_CLOSE_RECV_ONLY_STREAM
+        || !xqc_stream_is_recv_only(stream->stream_conn->conn_type,
+                                    xqc_stream_id(stream)))
+    {
+        return XQC_OK;
+    }
+
+    user_stream = calloc(1, sizeof(*user_stream));
+    if (user_stream == NULL) {
+        return XQC_ERROR;
+    }
+
+    user_stream->stream = stream;
+    xqc_stream_set_user_data(stream, user_stream);
+
+    first_ret = xqc_stream_close(stream);
+    second_ret = xqc_stream_close(stream);
+    printf("[stream-close-direction-test]|case:%d|stream_id:%"PRIu64
+           "|first_ret:%d|second_ret:%d|\n", g_test_case,
+           xqc_stream_id(stream), first_ret, second_ret);
+    fflush(stdout);
+
+    return first_ret != XQC_OK ? first_ret : second_ret;
 }
 
 int
@@ -4718,6 +4789,11 @@ static void xqc_client_concurrent_callback(int fd, short what, void *arg){
         }
     };
 
+    if (g_test_case == XQC_TEST_CASE_CLOSE_RECV_ONLY_STREAM) {
+        ap_cbs.stream_cbs.stream_create_notify =
+            xqc_client_stream_create_notify;
+    }
+
     xqc_engine_register_alpn(ctx->engine, XQC_ALPN_TRANSPORT, 9, &ap_cbs, NULL);
 
 
@@ -5813,6 +5889,11 @@ int main(int argc, char *argv[]) {
             .datagram_mss_updated_notify = xqc_client_datagram_mss_updated_callback,
         }
     };
+
+    if (g_test_case == XQC_TEST_CASE_CLOSE_RECV_ONLY_STREAM) {
+        ap_cbs.stream_cbs.stream_create_notify =
+            xqc_client_stream_create_notify;
+    }
 
     xqc_engine_register_alpn(ctx.engine, XQC_ALPN_TRANSPORT, 9, &ap_cbs, NULL);
     /* test alpn negotiation failure */

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -80,6 +80,7 @@ printf_null(const char *format, ...)
 #define XQC_TEST_CASE_CRYPTO_PREVIOUS_LEVEL_BOUNDARY 720
 #define XQC_TEST_CASE_CRYPTO_PREVIOUS_LEVEL_EXTENSION 721
 #define XQC_TEST_CASE_DATAGRAM_1RTT_ALLOWED 1201
+#define XQC_TEST_CASE_CLOSE_RECV_ONLY_STREAM 725
 
 extern long xqc_random(void);
 extern xqc_usec_t xqc_now();
@@ -801,6 +802,10 @@ xqc_server_send_previous_level_crypto(xqc_connection_t *conn,
 void
 xqc_server_conn_handshake_finished(xqc_connection_t *conn, void *user_data, void *conn_proto_data)
 {
+    const unsigned char payload = 0;
+    xqc_stream_t *stream;
+    ssize_t ret;
+
     DEBUG;
     printf("datagram_mss:%zd\n", xqc_datagram_get_mss(conn));
 
@@ -810,6 +815,21 @@ xqc_server_conn_handshake_finished(xqc_connection_t *conn, void *user_data, void
         xqc_server_send_previous_level_crypto(
             conn,
             g_test_case == XQC_TEST_CASE_CRYPTO_PREVIOUS_LEVEL_EXTENSION);
+    }
+
+    if (g_test_case == XQC_TEST_CASE_CLOSE_RECV_ONLY_STREAM) {
+        stream = xqc_stream_create_with_direction(conn, XQC_STREAM_UNI, NULL);
+        if (stream == NULL) {
+            printf("[stream-close-direction-test]|case:%d|"
+                   "stream_unavailable|\n", g_test_case);
+            return;
+        }
+
+        ret = xqc_stream_send(stream, (unsigned char *) &payload,
+                              sizeof(payload), 0);
+        printf("[stream-close-direction-test]|case:%d|stream_id:%"PRIu64
+               "|send_ret:%zd|\n", g_test_case, xqc_stream_id(stream), ret);
+        fflush(stdout);
     }
 }
 

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -279,6 +279,12 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite,
                         "xqc_test_process_reset_stream_on_recv_only_stream",
                         xqc_test_process_reset_stream_on_recv_only_stream)
+        || !CU_add_test(pSuite, "xqc_test_stream_close_send_only",
+                        xqc_test_stream_close_send_only)
+        || !CU_add_test(pSuite, "xqc_test_stream_close_recv_only",
+                        xqc_test_stream_close_recv_only)
+        || !CU_add_test(pSuite, "xqc_test_stream_close_bidirectional",
+                        xqc_test_stream_close_bidirectional)
         || !CU_add_test(pSuite, "xqc_test_reset_stream_final_size_accepted",
                         xqc_test_reset_stream_final_size_accepted)
         || !CU_add_test(pSuite,

--- a/tests/unittest/xqc_process_frame_test.c
+++ b/tests/unittest/xqc_process_frame_test.c
@@ -1675,6 +1675,152 @@ xqc_test_process_reset_stream_on_recv_only_stream(void)
 }
 
 
+static int
+xqc_test_count_frame_in_list(xqc_list_head_t *head,
+    xqc_frame_type_bit_t frame_bit)
+{
+    xqc_list_head_t *pos;
+    xqc_packet_out_t *packet_out;
+    int count = 0;
+
+    xqc_list_for_each(pos, head) {
+        packet_out = xqc_list_entry(pos, xqc_packet_out_t, po_list);
+        if (packet_out->po_frame_types & frame_bit) {
+            count++;
+        }
+    }
+
+    return count;
+}
+
+
+static int
+xqc_test_count_queued_frame(xqc_connection_t *conn,
+    xqc_frame_type_bit_t frame_bit)
+{
+    xqc_send_queue_t *send_queue = conn->conn_send_queue;
+    int count = 0;
+    int i;
+
+    count += xqc_test_count_frame_in_list(&send_queue->sndq_send_packets,
+                                          frame_bit);
+    count += xqc_test_count_frame_in_list(
+        &send_queue->sndq_send_packets_high_pri, frame_bit);
+    count += xqc_test_count_frame_in_list(&send_queue->sndq_lost_packets,
+                                          frame_bit);
+    count += xqc_test_count_frame_in_list(
+        &send_queue->sndq_buff_1rtt_packets, frame_bit);
+    count += xqc_test_count_frame_in_list(&send_queue->sndq_pto_probe_packets,
+                                          frame_bit);
+    for (i = 0; i < XQC_PNS_N; i++) {
+        count += xqc_test_count_frame_in_list(
+            &send_queue->sndq_unacked_packets[i], frame_bit);
+    }
+
+    return count;
+}
+
+
+static void
+xqc_test_stream_close_direction(xqc_conn_type_t conn_type,
+    xqc_bool_t local_initiated, xqc_bool_t expect_reset,
+    xqc_bool_t expect_stop)
+{
+    xqc_connection_t *conn;
+    xqc_stream_t *stream;
+    xqc_stream_id_t stream_id;
+    int reset_before, reset_after;
+    int stop_before, stop_after;
+    xqc_int_t ret;
+
+    conn = xqc_test_dir_make_conn(conn_type);
+    CU_ASSERT_FATAL(conn != NULL);
+
+    if (local_initiated) {
+        stream = xqc_stream_create_with_direction(conn, XQC_STREAM_UNI,
+                                                  NULL);
+
+    } else {
+        stream_id = conn_type == XQC_CONN_TYPE_CLIENT ? 3 : 2;
+        stream = xqc_passive_create_stream(conn, stream_id, NULL);
+    }
+    CU_ASSERT_FATAL(stream != NULL);
+
+    reset_before = xqc_test_count_queued_frame(
+        conn, XQC_FRAME_BIT_RESET_STREAM);
+    stop_before = xqc_test_count_queued_frame(
+        conn, XQC_FRAME_BIT_STOP_SENDING);
+
+    ret = xqc_stream_close(stream);
+    CU_ASSERT(ret == XQC_OK);
+
+    reset_after = xqc_test_count_queued_frame(
+        conn, XQC_FRAME_BIT_RESET_STREAM);
+    stop_after = xqc_test_count_queued_frame(
+        conn, XQC_FRAME_BIT_STOP_SENDING);
+    CU_ASSERT(reset_after - reset_before == expect_reset);
+    CU_ASSERT(stop_after - stop_before == expect_stop);
+
+    ret = xqc_stream_close(stream);
+    CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(xqc_test_count_queued_frame(
+                  conn, XQC_FRAME_BIT_RESET_STREAM) == reset_after);
+    CU_ASSERT(xqc_test_count_queued_frame(
+                  conn, XQC_FRAME_BIT_STOP_SENDING) == stop_after);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
+void
+xqc_test_stream_close_send_only(void)
+{
+    xqc_test_stream_close_direction(XQC_CONN_TYPE_CLIENT, XQC_TRUE,
+                                    XQC_TRUE, XQC_FALSE);
+    xqc_test_stream_close_direction(XQC_CONN_TYPE_SERVER, XQC_TRUE,
+                                    XQC_TRUE, XQC_FALSE);
+}
+
+
+void
+xqc_test_stream_close_recv_only(void)
+{
+    xqc_test_stream_close_direction(XQC_CONN_TYPE_CLIENT, XQC_FALSE,
+                                    XQC_FALSE, XQC_TRUE);
+    xqc_test_stream_close_direction(XQC_CONN_TYPE_SERVER, XQC_FALSE,
+                                    XQC_FALSE, XQC_TRUE);
+}
+
+
+void
+xqc_test_stream_close_bidirectional(void)
+{
+    xqc_connection_t *conn;
+    xqc_stream_t *stream;
+    int reset_before, stop_before;
+    xqc_int_t ret;
+
+    conn = xqc_test_dir_make_conn(XQC_CONN_TYPE_CLIENT);
+    CU_ASSERT_FATAL(conn != NULL);
+    stream = xqc_stream_create_with_direction(conn, XQC_STREAM_BIDI, NULL);
+    CU_ASSERT_FATAL(stream != NULL);
+
+    reset_before = xqc_test_count_queued_frame(
+        conn, XQC_FRAME_BIT_RESET_STREAM);
+    stop_before = xqc_test_count_queued_frame(
+        conn, XQC_FRAME_BIT_STOP_SENDING);
+
+    ret = xqc_stream_close(stream);
+    CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(xqc_test_count_queued_frame(
+                  conn, XQC_FRAME_BIT_RESET_STREAM) == reset_before + 1);
+    CU_ASSERT(xqc_test_count_queued_frame(
+                  conn, XQC_FRAME_BIT_STOP_SENDING) == stop_before + 1);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
 static xqc_connection_t *
 xqc_test_reset_stream_final_size_setup(xqc_stream_t **stream)
 {

--- a/tests/unittest/xqc_process_frame_test.h
+++ b/tests/unittest/xqc_process_frame_test.h
@@ -86,6 +86,12 @@ void xqc_test_process_reset_stream_on_bidirectional_stream(void);
 
 void xqc_test_process_reset_stream_on_recv_only_stream(void);
 
+void xqc_test_stream_close_send_only(void);
+
+void xqc_test_stream_close_recv_only(void);
+
+void xqc_test_stream_close_bidirectional(void);
+
 void xqc_test_reset_stream_final_size_accepted(void);
 
 void xqc_test_reset_stream_final_size_too_small(void);


### PR DESCRIPTION
### Mechanism

- RFC or draft: RFC 9000 Sections 3.3, 19.4, and 19.5

Close each stream direction with its applicable signal: RESET_STREAM for the
send direction and STOP_SENDING for the receive direction. Track a queued
STOP_SENDING so repeated receive-only closes remain idempotent.

Fixes: #232

### Validation Cases

- 724 — Locally initiated unidirectional close emits RESET_STREAM only.
- 725 — Peer-initiated unidirectional close emits STOP_SENDING idempotently.

### CONTRIBUTING.md

- Overall: Passed
- Local regression: Complete
- CI: Complete
