### PR TITLE
[~] Fix #283: Prevent RESET_STREAM after data acknowledgment

### DIFF
--- a/case_test/transport/stream.sh
+++ b/case_test/transport/stream.sh
@@ -223,7 +223,8 @@ clear_log
 echo -e "Reset stream when receiving...\c"
 ${CLIENT_BIN} -s 1024000 -l d -t 1 -E -x 21 > stdlog
 result=`grep "xqc_send_queue_drop_stream_frame_packets" slog`
-flag=`grep "send_state:5|recv_state:5" clog`
+# RFC 9000 Section 3.3 keeps the terminal send side in Data Recvd.
+flag=`grep "send_state:3|recv_state:5" clog`
 errlog=`grep_err_log|grep -v stream`
 if [ -n "$flag" ] && [ -z "$errlog" ] && [ -n "$result" ]; then
     echo ">>>>>>>> pass:1"
@@ -244,7 +245,8 @@ clear_log
 echo -e "Send header after reset stream...\c"
 ${CLIENT_BIN} -s 1024000 -l d -t 1 -E -x 28 > stdlog
 result=`grep "xqc_conn_destroy.*err:0x0" clog`
-flag=`grep "send_state:5|recv_state:5" clog`
+# RFC 9000 Section 3.3 keeps the terminal send side in Data Recvd.
+flag=`grep "send_state:3|recv_state:5" clog`
 errlog=`grep_err_log|grep -v stream`
 if [ -n "$flag" ] && [ -z "$errlog" ] && [ -n "$result" ]; then
     echo ">>>>>>>> pass:1"

--- a/case_test/transport/stream.sh
+++ b/case_test/transport/stream.sh
@@ -222,11 +222,11 @@ grep_err_log|grep -v stream
 clear_log
 echo -e "Reset stream when receiving...\c"
 ${CLIENT_BIN} -s 1024000 -l d -t 1 -E -x 21 > stdlog
-result=`grep "xqc_send_queue_drop_stream_frame_packets" slog`
+reset=`grep "xqc_write_reset_stream_to_packet" clog`
 # RFC 9000 Section 3.3 keeps the terminal send side in Data Recvd.
 flag=`grep "send_state:3|recv_state:5" clog`
 errlog=`grep_err_log|grep -v stream`
-if [ -n "$flag" ] && [ -z "$errlog" ] && [ -n "$result" ]; then
+if [ -n "$flag" ] && [ -z "$errlog" ] && [ -z "$reset" ]; then
     echo ">>>>>>>> pass:1"
     case_print_result "reset_stream_when_receiving" "pass"
 else
@@ -234,6 +234,7 @@ else
     case_print_result "reset_stream_when_receiving" "fail"
     echo "$flag"
     echo "$errlog"
+    echo "$reset"
 fi
 
 }

--- a/case_test/transport/stream.sh
+++ b/case_test/transport/stream.sh
@@ -840,6 +840,39 @@ fi
 
 }
 
+
+case_transport_stream_close_after_data_recvd()
+{
+
+case_test_stop_server
+clear_log
+rm -f test_session xqc_token tp_localhost
+case_test_start_server ${SERVER_BIN} -l d -e -x 726 > /dev/null
+sleep 1
+echo -e "close_after_data_recvd ...\c"
+${CLIENT_BIN} -s 1024 -l d -t 1 -E -T 1 -x 726 > stdlog
+sleep 1
+client_sent=`grep \
+    "\[stream-close-data-recvd-test\]|case:726|stream_id:2|send_ret:1|" \
+    stdlog`
+client_closed=`grep \
+    "\[stream-close-data-recvd-test\]|case:726|stream_id:2|"\
+"state_before:3|close_ret:0|state_after:3|" stdlog`
+server_reset=`grep \
+    "xqc_parse_reset_stream_frame|type:3|stream_id:2|" slog`
+client_close_code=`grep "xqc_parse_conn_close_frame|type:18|err_code:5|" clog`
+if [ -n "$client_sent" ] && [ -n "$client_closed" ] \
+    && [ -z "$server_reset" ] && [ -z "$client_close_code" ]; then
+    echo ">>>>>>>> pass:1"
+    case_print_result "close_after_data_recvd" "pass"
+else
+    echo ">>>>>>>> pass:0"
+    case_print_result "close_after_data_recvd" "fail"
+fi
+
+}
+
+
 case_test_case "server_inited_stream" --id native --mode self-reporting --run case_transport_stream_server_inited_stream
 case_test_case "stream_send_pure_fin" --id native --mode self-reporting --run case_transport_stream_stream_send_pure_fin
 case_test_case "stream_read_notify_fail" --id native --mode self-reporting --run case_transport_stream_stream_read_notify_fail
@@ -884,6 +917,8 @@ case_test_case "close_send_only_stream" --id 724 \
     --mode self-reporting --run case_transport_stream_close_send_only_stream
 case_test_case "close_recv_only_stream" --id 725 \
     --mode self-reporting --run case_transport_stream_close_recv_only_stream
+case_test_case "close_after_data_recvd" --id 726 \
+    --mode self-reporting --run case_transport_stream_close_after_data_recvd
 
 if case_test_is_discovery; then
     case_test_run

--- a/harness/spec/validation.md
+++ b/harness/spec/validation.md
@@ -99,7 +99,7 @@ its case is retired so later changes cannot reuse it.
 
 | Range | New-case namespace | Allocated IDs |
 |-------|--------------------|---------------|
-| `[705, 799]` | QUIC Transport core | `705-725` |
+| `[705, 799]` | QUIC Transport core | `705-726` |
 | `[800, 899]` | Recovery and congestion control | `800` |
 | `[900, 999]` | QUIC-TLS | `902-903` |
 | `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1021` |

--- a/src/transport/xqc_packet_out.c
+++ b/src/transport/xqc_packet_out.c
@@ -869,6 +869,15 @@ xqc_write_reset_stream_to_packet(xqc_connection_t *conn, xqc_stream_t *stream,
     int support_0rtt = xqc_conn_is_ready_to_send_early_data(conn);
     xqc_bool_t buff_reset = XQC_FALSE;
 
+    /*
+     * RFC 9000 Section 3.3: a sender MUST NOT send RESET_STREAM from the
+     * terminal Data Recvd or Reset Recvd states. Reset Sent retransmission is
+     * handled by the send queue rather than by generating another frame.
+     */
+    if (stream->stream_state_send >= XQC_SEND_STREAM_ST_DATA_RECVD) {
+        return XQC_OK;
+    }
+
     if (!(conn->conn_flag & XQC_CONN_FLAG_CAN_SEND_1RTT)) {
         if ((conn->conn_type == XQC_CONN_TYPE_CLIENT) 
             && (conn->conn_state == XQC_CONN_STATE_CLIENT_INITIAL_SENT) 

--- a/src/transport/xqc_stream.c
+++ b/src/transport/xqc_stream.c
@@ -927,6 +927,8 @@ xqc_stream_close_with_error(xqc_stream_t *stream, uint64_t err_code)
                                                     stream->stream_id);
     xqc_bool_t recv_only = xqc_stream_is_recv_only(conn->conn_type,
                                                     stream->stream_id);
+    xqc_bool_t send_reset;
+    xqc_bool_t send_stop;
     xqc_log(conn->log, XQC_LOG_DEBUG, "|stream_id:%ui|"
             "stream_state_send:%d|stream_state_recv:%d|conn:%p|"
             "conn_state:%s|err_code:%ui|", stream->stream_id,
@@ -935,24 +937,28 @@ xqc_stream_close_with_error(xqc_stream_t *stream, uint64_t err_code)
 
     XQC_STREAM_CLOSE_MSG(stream, "local reset");
 
-    if ((!recv_only
-         && stream->stream_state_send >= XQC_SEND_STREAM_ST_RESET_SENT)
-        || (recv_only
-            && (stream->stream_flag
-                & XQC_STREAM_FLAG_STOP_SENDING_SENT)))
-    {
+    send_reset = !recv_only
+                 && stream->stream_state_send
+                    < XQC_SEND_STREAM_ST_DATA_RECVD;
+    send_stop = !send_only
+                && !(stream->stream_flag
+                     & XQC_STREAM_FLAG_STOP_SENDING_SENT)
+                && (stream->stream_state_recv == XQC_RECV_STREAM_ST_RECV
+                    || stream->stream_state_recv
+                       == XQC_RECV_STREAM_ST_SIZE_KNOWN);
+    if (!send_reset && !send_stop) {
         return XQC_OK;
     }
     if (conn->conn_state >= XQC_CONN_STATE_CLOSING) {
         return XQC_OK;
     }
 
-    xqc_send_queue_drop_stream_frame_packets(conn, stream->stream_id);
     /*
      * RFC 9000 Sections 3.3, 19.4, and 19.5: a stream receiver sends
      * STOP_SENDING, while a stream sender sends RESET_STREAM.
      */
-    if (!recv_only) {
+    if (send_reset) {
+        xqc_send_queue_drop_stream_frame_packets(conn, stream->stream_id);
         ret = xqc_write_reset_stream_to_packet(conn, stream, err_code,
                                                stream->stream_send_offset);
         if (ret < 0) {
@@ -962,12 +968,7 @@ xqc_stream_close_with_error(xqc_stream_t *stream, uint64_t err_code)
         }
     }
 
-    /* A STOP_SENDING frame can be sent for streams in the "Recv" or "Size
-       Known" states */
-    if (!send_only
-        && (stream->stream_state_recv == XQC_RECV_STREAM_ST_RECV
-            || stream->stream_state_recv == XQC_RECV_STREAM_ST_SIZE_KNOWN))
-    {
+    if (send_stop) {
         ret = xqc_write_stop_sending_to_packet(conn, stream, err_code);
         if (ret < 0) {
             xqc_log(conn->log, XQC_LOG_ERROR,

--- a/src/transport/xqc_stream.c
+++ b/src/transport/xqc_stream.c
@@ -935,6 +935,10 @@ xqc_stream_close_with_error(xqc_stream_t *stream, uint64_t err_code)
             stream->stream_state_send, stream->stream_state_recv, conn,
             xqc_conn_state_2_str(conn->conn_state), err_code);
 
+    /* Preserve the local cause even when no close frame remains legal. */
+    if (stream->stream_close_msg == NULL) {
+        stream->stream_err = err_code;
+    }
     XQC_STREAM_CLOSE_MSG(stream, "local reset");
 
     send_reset = !recv_only

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -104,6 +104,7 @@ printf_null(const char *format, ...)
 #define XQC_TEST_CASE_RESET_FINAL_SIZE_TOO_SMALL 723
 #define XQC_TEST_CASE_CLOSE_SEND_ONLY_STREAM 724
 #define XQC_TEST_CASE_CLOSE_RECV_ONLY_STREAM 725
+#define XQC_TEST_CASE_CLOSE_AFTER_DATA_RECVD 726
 #define XQC_TEST_CASE_HQ_REQUEST_FIN 1702
 #define XQC_TEST_CASE_HQ_REQUEST_DELAYED_FIN 1703
 
@@ -125,6 +126,7 @@ static xqc_int_t xqc_client_write_test_datagram_frame(
     xqc_connection_t *conn, xqc_pkt_type_t pkt_type);
 static void xqc_client_send_reset_final_size_frames(xqc_connection_t *conn);
 static void xqc_client_close_send_only_stream(xqc_connection_t *conn);
+static void xqc_client_close_after_data_recvd(int fd, short what, void *arg);
 
 
 #define XQC_TEST_DGRAM_BATCH_SZ 32
@@ -176,6 +178,7 @@ typedef struct user_stream_s {
 
     xqc_h3_ext_bytestream_t *h3_ext_bs;
     struct event            *ev_bytestream_timer;
+    struct event            *ev_stream_close_timer;
 
     int                      snd_times;
     int                      rcv_times;
@@ -318,7 +321,7 @@ uint64_t g_last_sock_op_time;
  * 717 for RESET_STREAM on a peer-initiated unidirectional stream
  * 718/719 for MAX_STREAM_DATA stream direction validation
  * 722/723 for RESET_STREAM final-size validation
- * 724/725 for unidirectional stream close validation
+ * 724-726 for stream close state and direction validation
  * 902/903 for AEAD confidentiality-limit validation
  * 1000-1021 for HTTP/3 protocol validation
  */
@@ -2099,7 +2102,9 @@ xqc_client_conn_handshake_finished(xqc_connection_t *conn, void *user_data, void
         xqc_client_send_reset_final_size_frames(conn);
     }
 
-    if (g_test_case == XQC_TEST_CASE_CLOSE_SEND_ONLY_STREAM) {
+    if (g_test_case == XQC_TEST_CASE_CLOSE_SEND_ONLY_STREAM
+        || g_test_case == XQC_TEST_CASE_CLOSE_AFTER_DATA_RECVD)
+    {
         xqc_client_close_send_only_stream(conn);
     }
 
@@ -2313,10 +2318,38 @@ xqc_client_send_reset_final_size_frames(xqc_connection_t *conn)
 
 
 static void
+xqc_client_close_after_data_recvd(int fd, short what, void *arg)
+{
+    user_stream_t *user_stream = (user_stream_t *) arg;
+    xqc_stream_t *stream = user_stream->stream;
+    xqc_send_stream_state_t state_before;
+    struct timeval tv = {0, 10000};
+    xqc_int_t ret;
+
+    if (stream->stream_state_send != XQC_SEND_STREAM_ST_DATA_RECVD) {
+        event_add(user_stream->ev_stream_close_timer, &tv);
+        return;
+    }
+
+    state_before = stream->stream_state_send;
+    event_free(user_stream->ev_stream_close_timer);
+    user_stream->ev_stream_close_timer = NULL;
+    ret = xqc_stream_close(stream);
+    printf("[stream-close-data-recvd-test]|case:%d|stream_id:%"PRIu64
+           "|state_before:%d|close_ret:%d|state_after:%d|\n",
+           g_test_case, xqc_stream_id(stream), state_before, ret,
+           stream->stream_state_send);
+    fflush(stdout);
+}
+
+
+static void
 xqc_client_close_send_only_stream(xqc_connection_t *conn)
 {
+    const unsigned char payload = 0;
     user_stream_t *user_stream;
     xqc_stream_t *stream;
+    struct timeval tv = {0, 10000};
     xqc_int_t ret;
 
     user_stream = calloc(1, sizeof(*user_stream));
@@ -2336,6 +2369,31 @@ xqc_client_close_send_only_stream(xqc_connection_t *conn)
     }
 
     user_stream->stream = stream;
+
+    if (g_test_case == XQC_TEST_CASE_CLOSE_AFTER_DATA_RECVD) {
+        ret = xqc_stream_send(stream, (unsigned char *) &payload,
+                              sizeof(payload), 1);
+        if (ret != sizeof(payload)) {
+            printf("[stream-close-data-recvd-test]|case:%d|stream_id:%"PRIu64
+                   "|send_ret:%d|\n", g_test_case,
+                   xqc_stream_id(stream), ret);
+            return;
+        }
+
+        user_stream->ev_stream_close_timer = event_new(
+            eb, -1, 0, xqc_client_close_after_data_recvd, user_stream);
+        if (user_stream->ev_stream_close_timer == NULL) {
+            printf("[stream-close-data-recvd-test]|case:%d|timer_failed|\n",
+                   g_test_case);
+            return;
+        }
+        event_add(user_stream->ev_stream_close_timer, &tv);
+        printf("[stream-close-data-recvd-test]|case:%d|stream_id:%"PRIu64
+               "|send_ret:%d|\n", g_test_case, xqc_stream_id(stream), ret);
+        fflush(stdout);
+        return;
+    }
+
     ret = xqc_stream_close(stream);
     printf("[stream-close-direction-test]|case:%d|stream_id:%"PRIu64
            "|close_ret:%d|\n", g_test_case, xqc_stream_id(stream), ret);
@@ -2954,6 +3012,9 @@ xqc_client_stream_close_notify(xqc_stream_t *stream, void *user_data)
     /* test abnormal rate */
     if (g_test_case == 14) {
         printf("\033[33m>>>>>>>> abnormal pass:%d count:%d\033[0m\n", user_stream->abnormal_count == 0 ? 1 : 0, user_stream->abnormal_count);
+    }
+    if (user_stream->ev_stream_close_timer != NULL) {
+        event_free(user_stream->ev_stream_close_timer);
     }
     free(user_stream->send_body);
     free(user_stream->recv_body);

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -81,6 +81,7 @@ printf_null(const char *format, ...)
 #define XQC_TEST_CASE_CRYPTO_PREVIOUS_LEVEL_EXTENSION 721
 #define XQC_TEST_CASE_DATAGRAM_1RTT_ALLOWED 1201
 #define XQC_TEST_CASE_CLOSE_RECV_ONLY_STREAM 725
+#define XQC_TEST_CASE_CLOSE_AFTER_DATA_RECVD 726
 
 extern long xqc_random(void);
 extern xqc_usec_t xqc_now();
@@ -1025,7 +1026,7 @@ xqc_server_stream_read_notify(xqc_stream_t *stream, void *user_data)
     // mpshell
     // printf("xqc_stream_recv read:%zd, offset:%zu, fin:%d\n", read_sum, user_stream->recv_body_len, fin);
 
-    if (fin) {
+    if (fin && g_test_case != XQC_TEST_CASE_CLOSE_AFTER_DATA_RECVD) {
         xqc_server_stream_send(stream, user_data);
     }
     return 0;

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -290,6 +290,11 @@ main(int argc, char *argv[])
                         xqc_test_stream_close_recv_only)
         || !CU_add_test(pSuite, "xqc_test_stream_close_bidirectional",
                         xqc_test_stream_close_bidirectional)
+        || !CU_add_test(pSuite, "xqc_test_stream_close_after_data_recvd",
+                        xqc_test_stream_close_after_data_recvd)
+        || !CU_add_test(
+            pSuite, "xqc_test_stream_close_data_recvd_bidirectional",
+            xqc_test_stream_close_data_recvd_bidirectional)
         || !CU_add_test(pSuite, "xqc_test_reset_stream_final_size_accepted",
                         xqc_test_reset_stream_final_size_accepted)
         || !CU_add_test(pSuite,

--- a/tests/unittest/xqc_process_frame_test.c
+++ b/tests/unittest/xqc_process_frame_test.c
@@ -1821,6 +1821,82 @@ xqc_test_stream_close_bidirectional(void)
 }
 
 
+void
+xqc_test_stream_close_after_data_recvd(void)
+{
+    xqc_connection_t *conn;
+    xqc_stream_t *stream;
+    int reset_before, stop_before;
+    xqc_int_t ret;
+
+    conn = xqc_test_dir_make_conn(XQC_CONN_TYPE_CLIENT);
+    CU_ASSERT_FATAL(conn != NULL);
+    stream = xqc_stream_create_with_direction(conn, XQC_STREAM_UNI, NULL);
+    CU_ASSERT_FATAL(stream != NULL);
+
+    xqc_stream_send_state_update(stream, XQC_SEND_STREAM_ST_DATA_RECVD);
+    reset_before = xqc_test_count_queued_frame(
+        conn, XQC_FRAME_BIT_RESET_STREAM);
+    stop_before = xqc_test_count_queued_frame(
+        conn, XQC_FRAME_BIT_STOP_SENDING);
+
+    ret = xqc_write_reset_stream_to_packet(
+        conn, stream, H3_REQUEST_CANCELLED, stream->stream_send_offset);
+    CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(xqc_test_count_queued_frame(
+                  conn, XQC_FRAME_BIT_RESET_STREAM) == reset_before);
+
+    ret = xqc_stream_close(stream);
+    CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(stream->stream_state_send == XQC_SEND_STREAM_ST_DATA_RECVD);
+    CU_ASSERT(xqc_test_count_queued_frame(
+                  conn, XQC_FRAME_BIT_RESET_STREAM) == reset_before);
+    CU_ASSERT(xqc_test_count_queued_frame(
+                  conn, XQC_FRAME_BIT_STOP_SENDING) == stop_before);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
+void
+xqc_test_stream_close_data_recvd_bidirectional(void)
+{
+    xqc_connection_t *conn;
+    xqc_stream_t *stream;
+    int reset_before, stop_before, stop_after;
+    xqc_int_t ret;
+
+    conn = xqc_test_dir_make_conn(XQC_CONN_TYPE_CLIENT);
+    CU_ASSERT_FATAL(conn != NULL);
+    stream = xqc_stream_create_with_direction(conn, XQC_STREAM_BIDI, NULL);
+    CU_ASSERT_FATAL(stream != NULL);
+
+    xqc_stream_send_state_update(stream, XQC_SEND_STREAM_ST_DATA_RECVD);
+    reset_before = xqc_test_count_queued_frame(
+        conn, XQC_FRAME_BIT_RESET_STREAM);
+    stop_before = xqc_test_count_queued_frame(
+        conn, XQC_FRAME_BIT_STOP_SENDING);
+
+    ret = xqc_stream_close(stream);
+    CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(stream->stream_state_send == XQC_SEND_STREAM_ST_DATA_RECVD);
+    CU_ASSERT(xqc_test_count_queued_frame(
+                  conn, XQC_FRAME_BIT_RESET_STREAM) == reset_before);
+    stop_after = xqc_test_count_queued_frame(
+        conn, XQC_FRAME_BIT_STOP_SENDING);
+    CU_ASSERT(stop_after == stop_before + 1);
+
+    ret = xqc_stream_close(stream);
+    CU_ASSERT(ret == XQC_OK);
+    CU_ASSERT(xqc_test_count_queued_frame(
+                  conn, XQC_FRAME_BIT_RESET_STREAM) == reset_before);
+    CU_ASSERT(xqc_test_count_queued_frame(
+                  conn, XQC_FRAME_BIT_STOP_SENDING) == stop_after);
+
+    xqc_engine_destroy(conn->engine);
+}
+
+
 static xqc_connection_t *
 xqc_test_reset_stream_final_size_setup(xqc_stream_t **stream)
 {

--- a/tests/unittest/xqc_process_frame_test.c
+++ b/tests/unittest/xqc_process_frame_test.c
@@ -1849,6 +1849,7 @@ xqc_test_stream_close_after_data_recvd(void)
     ret = xqc_stream_close(stream);
     CU_ASSERT(ret == XQC_OK);
     CU_ASSERT(stream->stream_state_send == XQC_SEND_STREAM_ST_DATA_RECVD);
+    CU_ASSERT(stream->stream_err == H3_REQUEST_CANCELLED);
     CU_ASSERT(xqc_test_count_queued_frame(
                   conn, XQC_FRAME_BIT_RESET_STREAM) == reset_before);
     CU_ASSERT(xqc_test_count_queued_frame(
@@ -1880,6 +1881,7 @@ xqc_test_stream_close_data_recvd_bidirectional(void)
     ret = xqc_stream_close(stream);
     CU_ASSERT(ret == XQC_OK);
     CU_ASSERT(stream->stream_state_send == XQC_SEND_STREAM_ST_DATA_RECVD);
+    CU_ASSERT(stream->stream_err == H3_REQUEST_CANCELLED);
     CU_ASSERT(xqc_test_count_queued_frame(
                   conn, XQC_FRAME_BIT_RESET_STREAM) == reset_before);
     stop_after = xqc_test_count_queued_frame(

--- a/tests/unittest/xqc_process_frame_test.h
+++ b/tests/unittest/xqc_process_frame_test.h
@@ -92,6 +92,10 @@ void xqc_test_stream_close_recv_only(void);
 
 void xqc_test_stream_close_bidirectional(void);
 
+void xqc_test_stream_close_after_data_recvd(void);
+
+void xqc_test_stream_close_data_recvd_bidirectional(void);
+
 void xqc_test_reset_stream_final_size_accepted(void);
 
 void xqc_test_reset_stream_final_size_too_small(void);


### PR DESCRIPTION
### Mechanism

Closing a stream now evaluates its send and receive directions independently.
The send direction does not generate `RESET_STREAM` after reaching terminal
`Data Recvd`, while an active receive direction can still generate
`STOP_SENDING`. The reset-frame writer also rejects new reset generation from
terminal send states, while retaining the first local close cause for stream
statistics even when no close frame remains legal. This follows RFC 9000 Sections
[3.1](https://www.rfc-editor.org/rfc/rfc9000.html#section-3.1) and
[3.3](https://www.rfc-editor.org/rfc/rfc9000.html#section-3.3).

Fixes: #283

### Validation Cases

- 724 — permits `RESET_STREAM` when a send-only stream is not terminal
- 726 — closes after all stream data is acknowledged without `RESET_STREAM`

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Incomplete — endpoint execution requires CI on this host
- CI: Pending — final-head checks are running
