### PR TITLE
[~] Fix #518: Prevent HQ request loops after delayed FIN

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -305,24 +305,29 @@ jobs:
     - name: Check Test Result
       run: |
         log_file=xquic_test_ubuntu_24_babassl.log
-        unit_total=$(awk '/  Test: / {count++} END {print count + 0}' \
-          "$log_file")
-        unit_passed=$(awk '/  Test: .*passed/ {count++} END {print count + 0}' \
-          "$log_file")
-        unit_failed=$(awk '/  Test: .*FAILED/ {count++} END {print count + 0}' \
-          "$log_file")
+        unit_summary=$(awk '
+          $1 == "tests" && NF == 6 && $2 ~ /^[0-9]+$/ \
+            && $3 ~ /^[0-9]+$/ && $4 ~ /^[0-9]+$/ && $5 ~ /^[0-9]+$/ {
+            summary = $2 " " $3 " " $4 " " $5
+          }
+          END {print summary}
+        ' "$log_file")
+        read -r unit_total unit_ran unit_passed unit_failed \
+          <<< "${unit_summary:-0 0 0 1}"
         case_result=1
         if [ -f xquic_case_status_ubuntu_24_babassl ]; then
           case_result=`cat xquic_case_status_ubuntu_24_babassl`
         fi
 
-        echo "unit test total:$unit_total passed:$unit_passed failed:$unit_failed"
+        echo "unit test total:$unit_total ran:$unit_ran" \
+          "passed:$unit_passed failed:$unit_failed"
         echo "case test result:$case_result"
         if [ -f xquic_case_test_ubuntu_24_babassl.log ]; then
           cat xquic_case_test_ubuntu_24_babassl.log | grep -E '^\[case-test:[^]]+\] .+ >>>>>>>> pass:' || true
         fi
 
         if [ "$unit_total" -gt 0 ] \
+          && [ "$unit_ran" -eq "$unit_total" ] \
           && [ "$unit_passed" -eq "$unit_total" ] \
           && [ "$unit_failed" -eq 0 ] \
           && [ "$case_result" -eq 0 ]; then

--- a/case_test/demo/hq.sh
+++ b/case_test/demo/hq.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "${ROOT_DIR}/case_test/lib/common.sh"
+
+case_test_group "demo.hq"
+
+hq_request_transfer()
+{
+    local id="$1"
+    local name="$2"
+    local initial_fin="$3"
+    local build_dir
+    local status=0
+
+    build_dir="$(case_test_build_dir "${ROOT_DIR}")"
+    rm -f test_session tp_localhost xqc_token
+    clear_log
+
+    # Serve the request bytes to reuse test_client's complete echo comparison.
+    printf 'GET /hq-resource\r\n' > hq-resource
+    case_test_start_server \
+        "${CASE_TEST_SERVER_BIN:-${build_dir}/demo/demo_server}" \
+        -p "${CASE_TEST_PORT:-8443}" -D "${CASE_TEST_WORK_DIR}" \
+        -l d -L slog > /dev/null 2>&1
+
+    ${CLIENT_BIN} -T 1 -1 -r hq-resource -E -n 2 -t 1 -F 5 \
+        -l d -x "${id}" > stdlog 2>&1 || status=1
+
+    case_test_wait_for_log slog \
+        'xqc_destroy_stream.*stream_id:4|' || status=1
+    kill -0 "${CASE_TEST_SERVER_PID}" 2> /dev/null || status=1
+    case_test_stop_server
+    case_test_snapshot_case_logs "${name}"
+
+    [[ "${status}" -eq 0 ]] || return 1
+    [[ "$(grep -c '>>>>>>>> pass:1' stdlog)" -eq 2 ]] || return 1
+    ! grep -q '>>>>>>>> pass:0\|forced conn_close' stdlog || return 1
+    grep -q 'alpn:hq-interop' stdlog || return 1
+    grep -q 'conn_err:0,' stdlog || return 1
+
+    local stream_id
+    for stream_id in 0 4; do
+        grep -q "data_length:18|fin:${initial_fin}|stream_id:${stream_id}|" \
+            slog || return 1
+        if [[ "${initial_fin}" -eq 0 ]]; then
+            grep -q "offset:18|data_length:0|fin:1|stream_id:${stream_id}|" \
+                slog || return 1
+            grep -q "stream_id:${stream_id}|fin_after_response:0|" \
+                stdlog || return 1
+        fi
+    done
+}
+
+hq_request_fin()
+{
+    hq_request_transfer 1702 hq_request_fin 1
+}
+
+hq_request_delayed_fin()
+{
+    hq_request_transfer 1703 hq_request_delayed_fin 0
+}
+
+case_test_case "hq_request_fin" --id 1702 --run hq_request_fin --timeout 12
+case_test_case "hq_request_delayed_fin" --id 1703 \
+    --run hq_request_delayed_fin --timeout 12
+
+if case_test_is_discovery; then
+    case_test_run
+    exit 0
+fi
+
+case_test_enter_work_dir
+case_test_run

--- a/case_test/manifest.yml
+++ b/case_test/manifest.yml
@@ -2,6 +2,16 @@
 version: 1
 max_parallel_jobs: 11
 groups:
+- id: demo.hq
+  module: demo
+  submodule: hq
+  source_paths:
+  - demo/xqc_hq*
+  - demo/demo_client.c
+  - demo/demo_server.c
+  runner: case_test/demo/hq.sh
+  execution: implemented
+  port_offset: 120
 - id: transport.core
   module: transport
   source_paths:

--- a/demo/xqc_hq.h
+++ b/demo/xqc_hq.h
@@ -132,6 +132,11 @@ void xqc_hq_request_set_user_data(xqc_hq_request_t *hqr, void *user_data);
 ssize_t
 xqc_hq_request_send_req(xqc_hq_request_t *hqr, const char *resource);
 
+/*
+ * Return copied resource bytes, excluding the terminating NUL. Partial reads
+ * resume at the previous offset; fin is set only when the last bytes are
+ * delivered. Later reads consume transport input without repeating the path.
+ */
 ssize_t
 xqc_hq_request_recv_req(xqc_hq_request_t *hqr, char *res_buf, size_t buf_sz, uint8_t *fin);
 

--- a/demo/xqc_hq_request.c
+++ b/demo/xqc_hq_request.c
@@ -57,6 +57,7 @@ typedef struct xqc_hq_request_s {
      */
     uint8_t                    *resource_buf;
     size_t                      resource_buf_sz;
+    size_t                      resource_len;
     size_t                      resource_read_offset;
     uint8_t                     fin;
 } xqc_hq_request_s;
@@ -244,7 +245,7 @@ xqc_hq_parse_req(xqc_hq_request_t *hqr, char *res, size_t sz, uint8_t *fin)
     snprintf(fmt, sizeof(fmt), "%%%zus %%%zus", method_cap, res_cap);
 
     int ret = sscanf((char *)hqr->req_recv_buf, fmt, method, res);
-    if (ret <= 0) {
+    if (ret != 2) {
         PRINT_LOG("|parse hq request failed: %s", hqr->req_recv_buf);
         return -XQC_EPROTO;
     }
@@ -284,7 +285,7 @@ xqc_hq_request_recv_req(xqc_hq_request_t *hqr, char *res_buf, size_t buf_sz, uin
 
         } else if (read < 0) {
             PRINT_LOG("|xqc_stream_recv error %zd|", read);
-            return 0;
+            return read;
         }
 
         hqr->recv_cnt += read;
@@ -311,31 +312,38 @@ xqc_hq_request_recv_req(xqc_hq_request_t *hqr, char *res_buf, size_t buf_sz, uin
         hqr->resource_buf_sz = XQC_HQ_REQUEST_RESOURCE_MAX_LEN;
     }
 
-    uint8_t req_fin = 0;
-    read = xqc_hq_parse_req(hqr, hqr->resource_buf, XQC_HQ_REQUEST_RESOURCE_MAX_LEN, &req_fin);
-    if (read <= 0) {
-        if (!hqr->fin) {
-            /* return until all request bytes are received in the current request */
-            return XQC_OK;
-        } else {
-            return -XQC_EPROTO;
+    if (hqr->resource_len == 0) {
+        uint8_t req_fin = 0;
+        read = xqc_hq_parse_req(hqr, hqr->resource_buf,
+                               hqr->resource_buf_sz, &req_fin);
+        if (read <= 0) {
+            return hqr->fin ? -XQC_EPROTO : XQC_OK;
         }
+
+        if (!hqr->fin && !req_fin) {
+            return XQC_OK;
+        }
+
+        hqr->resource_len = read;
     }
 
-    /* return until all request bytes are received in the current request */
-    if (!hqr->fin && !req_fin) {
+    /*
+     * RFC 9000 Section 19.8 permits FIN in a later, empty STREAM frame.
+     * Consume it above without delivering a CRLF-completed request again.
+     */
+    if (hqr->resource_read_offset == hqr->resource_len) {
         return XQC_OK;
     }
 
-    if (buf_sz < hqr->resource_read_offset) {
+    if (buf_sz <= 1) {
         return -XQC_ENOBUF;
     }
 
-    if (hqr->resource_read_offset < strlen(hqr->resource_buf)) {
-        read = (ssize_t)strncpy(res_buf, hqr->resource_buf, buf_sz);
-        hqr->resource_read_offset += read;
-        *fin = (hqr->fin || req_fin);
-    }
+    read = xqc_min(hqr->resource_len - hqr->resource_read_offset, buf_sz - 1);
+    memcpy(res_buf, hqr->resource_buf + hqr->resource_read_offset, read);
+    res_buf[read] = '\0';
+    hqr->resource_read_offset += read;
+    *fin = hqr->resource_read_offset == hqr->resource_len;
 
     return read;
 }

--- a/harness/spec/harness-manifest.yml
+++ b/harness/spec/harness-manifest.yml
@@ -64,6 +64,15 @@ test_routing:
   case_manifest: case_test/manifest.yml
 
 modules:
+  demo:
+    paths:
+      - demo/*
+    read:
+      - harness/spec/architecture.md
+      - case_test/README.md
+    validation:
+      level: targeted
+
   api:
     paths:
       - include/xquic/*

--- a/harness/spec/validation.md
+++ b/harness/spec/validation.md
@@ -45,10 +45,10 @@ The required minimum is:
 - endpoint-visible abnormal-path coverage.
 
 When `scripts/case_test.sh` cases are added, the paired cases must use
-distinct `case_print_result` names and exercise the real `tests/test_client` to
-`tests/test_server` path. Their assertions must prove the expected
-endpoint-visible result. For an error path, prove the specific rejection,
-connection error, close, or recovery behavior rather than accepting any
+distinct `case_print_result` names and exercise a real client-to-server path
+using the existing `tests/` or `demo/` executables. Their assertions must prove
+the expected endpoint-visible result. For an error path, prove the specific
+rejection, connection error, close, or recovery behavior rather than accepting any
 failure. Until targeted case execution exists, record missing or unrun
 client-to-server coverage as a gap instead of running the full suite by
 default.
@@ -110,7 +110,7 @@ its case is retired so later changes cannot reuse it.
 | `[1400, 1499]` | MoQT | None |
 | `[1500, 1599]` | LOC and MSF application protocols | None |
 | `[1600, 1699]` | FEC and experimental transport extensions | None |
-| `[1700, 1799]` | Common runtime, public API, and test harness | None |
+| `[1700, 1799]` | Common runtime, public API, and test harness | `1702-1703` |
 
 Apply these allocation rules before running a new case:
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -99,6 +99,8 @@ if(HAVE_CUNIT)
         ${UNIT_TEST_DIR}/xqc_tls_test.c
         ${UNIT_TEST_DIR}/xqc_crypto_test.c
         ${UNIT_TEST_DIR}/xqc_h3_test.c
+        ${UNIT_TEST_DIR}/xqc_hq_test.c
+        ${CMAKE_SOURCE_DIR}/demo/xqc_hq_request.c
         ${UNIT_TEST_DIR}/xqc_stable_test.c
         ${UNIT_TEST_DIR}/xqc_dtable_test.c
         ${UNIT_TEST_DIR}/utils/xqc_2d_hash_table_test.c

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -104,6 +104,10 @@ printf_null(const char *format, ...)
 #define XQC_TEST_CASE_RESET_FINAL_SIZE_TOO_SMALL 723
 #define XQC_TEST_CASE_CLOSE_SEND_ONLY_STREAM 724
 #define XQC_TEST_CASE_CLOSE_RECV_ONLY_STREAM 725
+#define XQC_TEST_CASE_HQ_REQUEST_FIN 1702
+#define XQC_TEST_CASE_HQ_REQUEST_DELAYED_FIN 1703
+
+static xqc_bool_t xqc_client_is_hq_case(void);
 
 typedef struct user_conn_s user_conn_t;
 
@@ -2660,6 +2664,13 @@ xqc_client_h3_conn_update_cid_notify(xqc_h3_conn_t *conn, const xqc_cid_t *retir
 
 }
 
+static xqc_bool_t
+xqc_client_is_hq_case(void)
+{
+    return g_test_case == XQC_TEST_CASE_HQ_REQUEST_FIN
+           || g_test_case == XQC_TEST_CASE_HQ_REQUEST_DELAYED_FIN;
+}
+
 int
 xqc_client_stream_send(xqc_stream_t *stream, void *user_data)
 {
@@ -2712,7 +2723,9 @@ xqc_client_stream_send(xqc_stream_t *stream, void *user_data)
     }
 
     int fin = 1;
-    if (g_test_case == 4) { /* test fin_only */
+    if (g_test_case == 4
+        || g_test_case == XQC_TEST_CASE_HQ_REQUEST_DELAYED_FIN)
+    {
         fin = 0;
     }
 
@@ -2867,6 +2880,18 @@ xqc_client_stream_read_notify(xqc_stream_t *stream, void *user_data)
     }
 
     if (fin) {
+        if (g_test_case == XQC_TEST_CASE_HQ_REQUEST_DELAYED_FIN
+            && !user_stream->recv_fin)
+        {
+            /* RFC 9000, Section 19.8: FIN may follow the request bytes. */
+            ssize_t ret = xqc_stream_send(stream, NULL, 0, 1);
+            printf("[hq-request]|stream_id:%"PRIu64
+                   "|fin_after_response:%zd|\n", xqc_stream_id(stream), ret);
+            if (ret < 0) {
+                return -1;
+            }
+        }
+
         user_stream->recv_fin = 1;
         xqc_usec_t now_us = xqc_now();
         printf("\033[33m>>>>>>>> request time cost:%"PRIu64" us, speed:%"PRIu64" Kbit/s \n"
@@ -2907,6 +2932,7 @@ xqc_client_stream_close_notify(xqc_stream_t *stream, void *user_data)
 {
     DEBUG;
     user_stream_t *user_stream = (user_stream_t*)user_data;
+    user_conn_t *user_conn = user_stream->user_conn;
     if (g_echo_check) {
         int pass = 0;
         printf("user_stream->recv_fin:%d, user_stream->send_body_len:%zu, user_stream->recv_body_len:%zd\n",
@@ -2932,6 +2958,29 @@ xqc_client_stream_close_notify(xqc_stream_t *stream, void *user_data)
     free(user_stream->send_body);
     free(user_stream->recv_body);
     free(user_stream);
+
+    if (xqc_client_is_hq_case() && stream->stream_err == 0
+        && stream->stream_conn->conn_state < XQC_CONN_STATE_CLOSING)
+    {
+        if (g_req_cnt >= g_req_max) {
+            return xqc_conn_close(user_conn->ctx->engine, &user_conn->cid);
+        }
+
+        user_stream = calloc(1, sizeof(*user_stream));
+        if (user_stream == NULL) {
+            return -1;
+        }
+        user_stream->user_conn = user_conn;
+        user_stream->stream = xqc_stream_create(user_conn->ctx->engine,
+                                              &user_conn->cid, NULL,
+                                              user_stream);
+        if (user_stream->stream == NULL) {
+            free(user_stream);
+            return -1;
+        }
+        g_req_cnt++;
+        return xqc_client_stream_send(user_stream->stream, user_stream);
+    }
     return 0;
 }
 
@@ -5895,7 +5944,10 @@ int main(int argc, char *argv[]) {
             xqc_client_stream_create_notify;
     }
 
-    xqc_engine_register_alpn(ctx.engine, XQC_ALPN_TRANSPORT, 9, &ap_cbs, NULL);
+    const char *transport_alpn = xqc_client_is_hq_case()
+                                ? "hq-interop" : XQC_ALPN_TRANSPORT;
+    xqc_engine_register_alpn(ctx.engine, transport_alpn,
+                             strlen(transport_alpn), &ap_cbs, NULL);
     /* test alpn negotiation failure */
     xqc_engine_register_alpn(ctx.engine, XQC_ALPN_TRANSPORT_TEST, 14, &ap_cbs, NULL);
 
@@ -6075,7 +6127,7 @@ int main(int argc, char *argv[]) {
         } else {
             cid = xqc_connect(ctx.engine, &conn_settings, user_conn->token, user_conn->token_len,
                             server_addr, g_no_crypt, &conn_ssl_config, user_conn->peer_addr, 
-                            user_conn->peer_addrlen, XQC_ALPN_TRANSPORT, user_conn);
+                            user_conn->peer_addrlen, transport_alpn, user_conn);
         }
     }
 

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -24,6 +24,7 @@
 #include "xqc_tls_test.h"
 #include "xqc_crypto_test.h"
 #include "xqc_h3_test.h"
+#include "xqc_hq_test.h"
 #include "xqc_stable_test.h"
 #include "xqc_dtable_test.h"
 #include "utils/xqc_2d_hash_table_test.h"
@@ -75,6 +76,20 @@ main(int argc, char *argv[])
     }     
 
     if (!CU_add_test(pSuite, "xqc_cid_test", xqc_test_cid)
+        || !CU_add_test(pSuite, "xqc_test_hq_request_fin",
+                        xqc_test_hq_request_fin)
+        || !CU_add_test(pSuite, "xqc_test_hq_request_transport_fin",
+                        xqc_test_hq_request_transport_fin)
+        || !CU_add_test(pSuite, "xqc_test_hq_request_delayed_fin",
+                        xqc_test_hq_request_delayed_fin)
+        || !CU_add_test(pSuite, "xqc_test_hq_request_fragmented",
+                        xqc_test_hq_request_fragmented)
+        || !CU_add_test(pSuite, "xqc_test_hq_request_small_buffer",
+                        xqc_test_hq_request_small_buffer)
+        || !CU_add_test(pSuite, "xqc_test_hq_request_no_buffer",
+                        xqc_test_hq_request_no_buffer)
+        || !CU_add_test(pSuite, "xqc_test_hq_request_recv_reset",
+                        xqc_test_hq_request_recv_reset)
         || !CU_add_test(pSuite, "xqc_test_cid_active_limit", xqc_test_cid_active_limit)
         || !CU_add_test(pSuite, "xqc_test_cid_handshake_exclusion", xqc_test_cid_handshake_exclusion)
         || !CU_add_test(pSuite, "xqc_test_cid_mark_original_idempotent", xqc_test_cid_mark_original_idempotent)

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -76,20 +76,10 @@ main(int argc, char *argv[])
     }     
 
     if (!CU_add_test(pSuite, "xqc_cid_test", xqc_test_cid)
-        || !CU_add_test(pSuite, "xqc_test_hq_request_fin",
-                        xqc_test_hq_request_fin)
-        || !CU_add_test(pSuite, "xqc_test_hq_request_transport_fin",
-                        xqc_test_hq_request_transport_fin)
-        || !CU_add_test(pSuite, "xqc_test_hq_request_delayed_fin",
-                        xqc_test_hq_request_delayed_fin)
-        || !CU_add_test(pSuite, "xqc_test_hq_request_fragmented",
-                        xqc_test_hq_request_fragmented)
-        || !CU_add_test(pSuite, "xqc_test_hq_request_small_buffer",
-                        xqc_test_hq_request_small_buffer)
-        || !CU_add_test(pSuite, "xqc_test_hq_request_no_buffer",
-                        xqc_test_hq_request_no_buffer)
-        || !CU_add_test(pSuite, "xqc_test_hq_request_recv_reset",
-                        xqc_test_hq_request_recv_reset)
+        || !CU_add_test(pSuite, "xqc_test_hq_request_recv",
+                        xqc_test_hq_request_recv)
+        || !CU_add_test(pSuite, "xqc_test_hq_request_recv_errors",
+                        xqc_test_hq_request_recv_errors)
         || !CU_add_test(pSuite, "xqc_test_cid_active_limit", xqc_test_cid_active_limit)
         || !CU_add_test(pSuite, "xqc_test_cid_handshake_exclusion", xqc_test_cid_handshake_exclusion)
         || !CU_add_test(pSuite, "xqc_test_cid_mark_original_idempotent", xqc_test_cid_mark_original_idempotent)

--- a/tests/unittest/xqc_hq_test.c
+++ b/tests/unittest/xqc_hq_test.c
@@ -1,0 +1,419 @@
+/**
+ * @copyright Copyright (c) 2026, Alibaba Group Holding Limited
+ */
+
+#include <CUnit/CUnit.h>
+#include "xqc_hq_test.h"
+#include "xqc_common_test.h"
+#include "demo/xqc_hq_conn.h"
+#include "demo/xqc_hq_request.h"
+#include "src/transport/xqc_conn.h"
+#include "src/transport/xqc_frame.h"
+#include "src/transport/xqc_stream.h"
+
+
+typedef struct {
+    xqc_engine_t      *engine;
+    xqc_connection_t  *conn;
+    xqc_stream_t      *stream;
+    xqc_hq_conn_t      hqc;
+    xqc_hq_request_t  *hqr;
+    size_t             input_offset;
+    size_t             read_calls;
+    size_t             copied_bytes;
+    size_t             completions;
+} xqc_test_hq_ctx_t;
+
+static int xqc_test_hq_init(xqc_test_hq_ctx_t *ctx);
+static void xqc_test_hq_destroy(xqc_test_hq_ctx_t *ctx);
+static int xqc_test_hq_input(xqc_test_hq_ctx_t *ctx, const char *data,
+    size_t len, uint8_t fin);
+static int xqc_test_hq_read_notify(xqc_hq_request_t *hqr, void *user_data);
+
+
+static int
+xqc_test_hq_init(xqc_test_hq_ctx_t *ctx)
+{
+    memset(ctx, 0, sizeof(*ctx));
+    ctx->engine = test_create_engine();
+    if (ctx->engine == NULL) {
+        return XQC_ERROR;
+    }
+
+    const xqc_cid_t *cid = test_cid_connect(ctx->engine);
+    if (cid != NULL) {
+        ctx->conn = xqc_engine_conns_hash_find(ctx->engine, cid, 's');
+    }
+    if (ctx->conn == NULL) {
+        xqc_test_hq_destroy(ctx);
+        return XQC_ERROR;
+    }
+
+    ctx->hqc.conn = ctx->conn;
+    ctx->hqc.hqr_cbs.req_read_notify = xqc_test_hq_read_notify;
+    xqc_conn_set_alp_user_data(ctx->conn, &ctx->hqc);
+    ctx->conn->app_proto_cbs.stream_cbs = hq_stream_callbacks;
+    ctx->stream = xqc_stream_create_with_direction(ctx->conn,
+                                                   XQC_STREAM_BIDI, NULL);
+    if (ctx->stream == NULL || ctx->stream->user_data == NULL) {
+        xqc_test_hq_destroy(ctx);
+        return XQC_ERROR;
+    }
+
+    ctx->hqr = ctx->stream->user_data;
+    xqc_hq_request_set_user_data(ctx->hqr, ctx);
+    return XQC_OK;
+}
+
+
+static void
+xqc_test_hq_destroy(xqc_test_hq_ctx_t *ctx)
+{
+    if (ctx->engine != NULL) {
+        /* The stream close callback owns the HQ request. */
+        xqc_engine_destroy(ctx->engine);
+        ctx->engine = NULL;
+        ctx->conn = NULL;
+    }
+}
+
+
+static int
+xqc_test_hq_input(xqc_test_hq_ctx_t *ctx, const char *data, size_t len,
+    uint8_t fin)
+{
+    xqc_stream_frame_t *frame = xqc_calloc(1, sizeof(*frame));
+    if (frame == NULL) {
+        return -XQC_EMALLOC;
+    }
+
+    frame->data = xqc_malloc(len + 1);
+    if (frame->data == NULL) {
+        xqc_free(frame);
+        return -XQC_EMALLOC;
+    }
+
+    memcpy(frame->data, data, len);
+    frame->data_length = len;
+    frame->data_offset = ctx->input_offset;
+    frame->fin = fin;
+    int ret = xqc_insert_stream_frame(ctx->conn, ctx->stream, frame);
+    if (ret != XQC_OK) {
+        xqc_destroy_stream_frame(frame);
+        return ret;
+    }
+
+    ctx->input_offset += len;
+    if (fin) {
+        ctx->stream->stream_data_in.stream_determined = 1;
+        ctx->stream->stream_data_in.stream_length = ctx->input_offset;
+        ctx->stream->stream_state_recv = XQC_RECV_STREAM_ST_DATA_RECVD;
+    }
+
+    return XQC_OK;
+}
+
+
+static int
+xqc_test_hq_read_notify(xqc_hq_request_t *hqr, void *user_data)
+{
+    xqc_test_hq_ctx_t *ctx = user_data;
+    char buf[64];
+    uint8_t fin;
+    ssize_t read;
+
+    /* Bound the application's read loop so a regression cannot hang CUnit. */
+    for (size_t i = 0; i < 8; i++) {
+        read = xqc_hq_request_recv_req(hqr, buf, sizeof(buf), &fin);
+        ctx->read_calls++;
+        if (read < 0) {
+            return (int)read;
+        }
+        if (read > 0 && read < sizeof(buf)) {
+            ctx->copied_bytes += read;
+        }
+        if (fin) {
+            ctx->completions++;
+        }
+        if (read == 0 || fin) {
+            return XQC_OK;
+        }
+    }
+
+    return -XQC_EFATAL;
+}
+
+
+void
+xqc_test_hq_request_fin(void)
+{
+    xqc_test_hq_ctx_t ctx;
+    char buf[32];
+    uint8_t fin = 0;
+    const char request[] = "GET /same-fin\r\n";
+    int ret = xqc_test_hq_init(&ctx);
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    if (ret != XQC_OK) {
+        return;
+    }
+
+    CU_ASSERT_EQUAL(xqc_test_hq_input(&ctx, request, sizeof(request) - 1, 1),
+                    XQC_OK);
+    memset(buf, '!', sizeof(buf));
+    ssize_t read = xqc_hq_request_recv_req(ctx.hqr, buf, sizeof(buf), &fin);
+    CU_ASSERT_EQUAL(read, strlen("/same-fin"));
+    CU_ASSERT_EQUAL(fin, 1);
+    CU_ASSERT_STRING_EQUAL(buf, "/same-fin");
+    CU_ASSERT_EQUAL(ctx.stream->stream_state_recv,
+                    XQC_RECV_STREAM_ST_DATA_READ);
+
+    fin = 1;
+    read = xqc_hq_request_recv_req(ctx.hqr, buf, sizeof(buf), &fin);
+    CU_ASSERT_EQUAL(read, 0);
+    CU_ASSERT_EQUAL(fin, 0);
+    xqc_test_hq_destroy(&ctx);
+}
+
+
+void
+xqc_test_hq_request_delayed_fin(void)
+{
+    xqc_test_hq_ctx_t ctx;
+    const char request[] = "GET /delayed-fin\r\n";
+    int ret = xqc_test_hq_init(&ctx);
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    if (ret != XQC_OK) {
+        return;
+    }
+
+    /* RFC 9000 Section 19.8 permits FIN in a later, empty STREAM frame. */
+    CU_ASSERT_EQUAL(xqc_test_hq_input(&ctx, request, sizeof(request) - 1, 0),
+                    XQC_OK);
+    ret = hq_stream_callbacks.stream_read_notify(ctx.stream, ctx.hqr);
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    CU_ASSERT_EQUAL(ctx.read_calls, 1);
+    CU_ASSERT_EQUAL(ctx.copied_bytes, strlen("/delayed-fin"));
+    CU_ASSERT_EQUAL(ctx.completions, 1);
+    CU_ASSERT_EQUAL(ctx.stream->stream_stats.peer_fin_read_time, 0);
+
+    /* An EAGAIN before FIN must not deliver the resource a second time. */
+    ret = hq_stream_callbacks.stream_read_notify(ctx.stream, ctx.hqr);
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    CU_ASSERT_EQUAL(ctx.read_calls, 2);
+    CU_ASSERT_EQUAL(ctx.completions, 1);
+
+    CU_ASSERT_EQUAL(xqc_test_hq_input(&ctx, "", 0, 1), XQC_OK);
+    ret = hq_stream_callbacks.stream_read_notify(ctx.stream, ctx.hqr);
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    CU_ASSERT_EQUAL(ctx.read_calls, 3);
+    CU_ASSERT_EQUAL(ctx.copied_bytes, strlen("/delayed-fin"));
+    CU_ASSERT_EQUAL(ctx.completions, 1);
+    CU_ASSERT_EQUAL(ctx.stream->stream_state_recv,
+                    XQC_RECV_STREAM_ST_DATA_READ);
+    CU_ASSERT(ctx.stream->stream_stats.peer_fin_read_time != 0);
+
+    ret = hq_stream_callbacks.stream_read_notify(ctx.stream, ctx.hqr);
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    CU_ASSERT_EQUAL(ctx.read_calls, 4);
+    CU_ASSERT_EQUAL(ctx.completions, 1);
+    xqc_test_hq_destroy(&ctx);
+
+    ret = xqc_test_hq_init(&ctx);
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    if (ret != XQC_OK) {
+        return;
+    }
+
+    CU_ASSERT_EQUAL(xqc_test_hq_input(&ctx, request, sizeof(request) - 1, 0),
+                    XQC_OK);
+    ret = hq_stream_callbacks.stream_read_notify(ctx.stream, ctx.hqr);
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    CU_ASSERT_EQUAL(xqc_test_hq_input(&ctx, "tail", 4, 1), XQC_OK);
+    ret = hq_stream_callbacks.stream_read_notify(ctx.stream, ctx.hqr);
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    CU_ASSERT_EQUAL(ctx.read_calls, 2);
+    CU_ASSERT_EQUAL(ctx.copied_bytes, strlen("/delayed-fin"));
+    CU_ASSERT_EQUAL(ctx.completions, 1);
+    CU_ASSERT_EQUAL(ctx.stream->stream_data_in.next_read_offset,
+                    sizeof(request) - 1 + 4);
+    CU_ASSERT_EQUAL(ctx.stream->stream_state_recv,
+                    XQC_RECV_STREAM_ST_DATA_READ);
+    xqc_test_hq_destroy(&ctx);
+}
+
+
+void
+xqc_test_hq_request_fragmented(void)
+{
+    xqc_test_hq_ctx_t ctx;
+    const char *parts[] = {"G", "ET /frag", "mented\r", "\n"};
+    char buf[32];
+    uint8_t fin;
+    int ret = xqc_test_hq_init(&ctx);
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    if (ret != XQC_OK) {
+        return;
+    }
+
+    /* RFC 9000 Section 2.2: frame boundaries do not delimit stream data. */
+    for (size_t i = 0; i < sizeof(parts) / sizeof(parts[0]); i++) {
+        CU_ASSERT_EQUAL(xqc_test_hq_input(&ctx, parts[i], strlen(parts[i]), 0),
+                        XQC_OK);
+        memset(buf, '!', sizeof(buf));
+        fin = 1;
+        ssize_t read = xqc_hq_request_recv_req(ctx.hqr, buf, sizeof(buf), &fin);
+        if (i < 3) {
+            CU_ASSERT_EQUAL(read, 0);
+            CU_ASSERT_EQUAL(fin, 0);
+
+        } else {
+            CU_ASSERT_EQUAL(read, strlen("/fragmented"));
+            CU_ASSERT_EQUAL(fin, 1);
+            CU_ASSERT_STRING_EQUAL(buf, "/fragmented");
+        }
+    }
+
+    xqc_test_hq_destroy(&ctx);
+
+    ret = xqc_test_hq_init(&ctx);
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    if (ret != XQC_OK) {
+        return;
+    }
+
+    CU_ASSERT_EQUAL(xqc_test_hq_input(&ctx, "GET", 3, 1), XQC_OK);
+    fin = 1;
+    ssize_t read = xqc_hq_request_recv_req(ctx.hqr, buf, sizeof(buf), &fin);
+    CU_ASSERT_EQUAL(read, -XQC_EPROTO);
+    CU_ASSERT_EQUAL(fin, 0);
+    xqc_test_hq_destroy(&ctx);
+}
+
+
+void
+xqc_test_hq_request_small_buffer(void)
+{
+    xqc_test_hq_ctx_t ctx;
+    const char request[] = "GET /abcdefg\r\n";
+    const char *parts[] = {"/ab", "cde", "fg"};
+    char buf[5];
+    uint8_t fin;
+    int ret = xqc_test_hq_init(&ctx);
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    if (ret != XQC_OK) {
+        return;
+    }
+
+    CU_ASSERT_EQUAL(xqc_test_hq_input(&ctx, request, sizeof(request) - 1, 0),
+                    XQC_OK);
+    for (size_t i = 0; i < sizeof(parts) / sizeof(parts[0]); i++) {
+        memset(buf, '!', sizeof(buf));
+        fin = 1;
+        ssize_t read = xqc_hq_request_recv_req(ctx.hqr, buf, 4, &fin);
+        CU_ASSERT_EQUAL(read, strlen(parts[i]));
+        CU_ASSERT_EQUAL(fin, i == 2);
+        CU_ASSERT_EQUAL(memcmp(buf, parts[i], strlen(parts[i])), 0);
+        CU_ASSERT_EQUAL(buf[strlen(parts[i])], '\0');
+        CU_ASSERT_EQUAL(buf[4], '!');
+    }
+
+    CU_ASSERT_EQUAL(xqc_test_hq_input(&ctx, "", 0, 1), XQC_OK);
+    ssize_t read = xqc_hq_request_recv_req(ctx.hqr, buf, sizeof(buf), &fin);
+    CU_ASSERT_EQUAL(read, 0);
+    CU_ASSERT_EQUAL(fin, 0);
+    CU_ASSERT_EQUAL(ctx.stream->stream_state_recv,
+                    XQC_RECV_STREAM_ST_DATA_READ);
+    xqc_test_hq_destroy(&ctx);
+}
+
+
+void
+xqc_test_hq_request_no_buffer(void)
+{
+    xqc_test_hq_ctx_t ctx;
+    const char request[] = "GET /retry-buffer\r\n";
+    char buf[32];
+    uint8_t fin;
+    int ret = xqc_test_hq_init(&ctx);
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    if (ret != XQC_OK) {
+        return;
+    }
+
+    CU_ASSERT_EQUAL(xqc_test_hq_input(&ctx, request, sizeof(request) - 1, 1),
+                    XQC_OK);
+    for (size_t capacity = 0; capacity <= 1; capacity++) {
+        memset(buf, '!', sizeof(buf));
+        fin = 1;
+        ssize_t read = xqc_hq_request_recv_req(ctx.hqr, buf, capacity, &fin);
+        CU_ASSERT_EQUAL(read, -XQC_ENOBUF);
+        CU_ASSERT_EQUAL(fin, 0);
+        CU_ASSERT_EQUAL(buf[capacity], '!');
+    }
+
+    ssize_t read = xqc_hq_request_recv_req(ctx.hqr, buf, sizeof(buf), &fin);
+    CU_ASSERT_EQUAL(read, strlen("/retry-buffer"));
+    CU_ASSERT_EQUAL(fin, 1);
+    CU_ASSERT_EQUAL(memcmp(buf, "/retry-buffer", sizeof("/retry-buffer")), 0);
+    xqc_test_hq_destroy(&ctx);
+}
+
+
+void
+xqc_test_hq_request_recv_reset(void)
+{
+    const char request[] = "GET /reset\r\n";
+    char buf[32];
+    uint8_t fin;
+
+    for (int stage = 0; stage <= 2; stage++) {
+        xqc_test_hq_ctx_t ctx;
+        int ret = xqc_test_hq_init(&ctx);
+        CU_ASSERT_EQUAL(ret, XQC_OK);
+        if (ret != XQC_OK) {
+            return;
+        }
+
+        if (stage > 0) {
+            CU_ASSERT_EQUAL(xqc_test_hq_input(&ctx, request,
+                                             sizeof(request) - 1, 0), XQC_OK);
+            size_t capacity = stage == 1 ? 4 : sizeof(buf);
+            ssize_t read = xqc_hq_request_recv_req(ctx.hqr, buf, capacity,
+                                                   &fin);
+            CU_ASSERT_EQUAL(read, stage == 1 ? 3 : strlen("/reset"));
+            CU_ASSERT_EQUAL(fin, stage == 2);
+        }
+
+        ctx.stream->stream_state_recv = XQC_RECV_STREAM_ST_RESET_RECVD;
+        fin = 1;
+        ssize_t read = xqc_hq_request_recv_req(ctx.hqr, buf, sizeof(buf), &fin);
+        CU_ASSERT_EQUAL(read, -XQC_ESTREAM_RESET);
+        CU_ASSERT_EQUAL(fin, 0);
+        CU_ASSERT_EQUAL(ctx.stream->stream_state_recv,
+                        XQC_RECV_STREAM_ST_RESET_READ);
+        xqc_test_hq_destroy(&ctx);
+    }
+}
+
+
+void
+xqc_test_hq_request_transport_fin(void)
+{
+    xqc_test_hq_ctx_t ctx;
+    const char request[] = "GET /transport-fin";
+    char buf[32];
+    uint8_t fin = 0;
+    int ret = xqc_test_hq_init(&ctx);
+    CU_ASSERT_EQUAL(ret, XQC_OK);
+    if (ret != XQC_OK) {
+        return;
+    }
+
+    CU_ASSERT_EQUAL(xqc_test_hq_input(&ctx, request, sizeof(request) - 1, 1),
+                    XQC_OK);
+    ssize_t read = xqc_hq_request_recv_req(ctx.hqr, buf, sizeof(buf), &fin);
+    CU_ASSERT_EQUAL(read, strlen("/transport-fin"));
+    CU_ASSERT_EQUAL(fin, 1);
+    CU_ASSERT_STRING_EQUAL(buf, "/transport-fin");
+    xqc_test_hq_destroy(&ctx);
+}

--- a/tests/unittest/xqc_hq_test.c
+++ b/tests/unittest/xqc_hq_test.c
@@ -11,409 +11,156 @@
 #include "src/transport/xqc_frame.h"
 #include "src/transport/xqc_stream.h"
 
-
-typedef struct {
-    xqc_engine_t      *engine;
-    xqc_connection_t  *conn;
-    xqc_stream_t      *stream;
-    xqc_hq_conn_t      hqc;
-    xqc_hq_request_t  *hqr;
-    size_t             input_offset;
-    size_t             read_calls;
-    size_t             copied_bytes;
-    size_t             completions;
-} xqc_test_hq_ctx_t;
-
-static int xqc_test_hq_init(xqc_test_hq_ctx_t *ctx);
-static void xqc_test_hq_destroy(xqc_test_hq_ctx_t *ctx);
-static int xqc_test_hq_input(xqc_test_hq_ctx_t *ctx, const char *data,
-    size_t len, uint8_t fin);
-static int xqc_test_hq_read_notify(xqc_hq_request_t *hqr, void *user_data);
+static xqc_stream_t *xqc_test_hq_stream(xqc_hq_conn_t *hqc);
+static int xqc_test_hq_input(xqc_stream_t *stream, const char *data,
+    uint8_t fin);
 
 
-static int
-xqc_test_hq_init(xqc_test_hq_ctx_t *ctx)
+static xqc_stream_t *
+xqc_test_hq_stream(xqc_hq_conn_t *hqc)
 {
-    memset(ctx, 0, sizeof(*ctx));
-    ctx->engine = test_create_engine();
-    if (ctx->engine == NULL) {
-        return XQC_ERROR;
+    xqc_connection_t *conn = test_engine_connect();
+    if (conn == NULL) {
+        return NULL;
     }
 
-    const xqc_cid_t *cid = test_cid_connect(ctx->engine);
-    if (cid != NULL) {
-        ctx->conn = xqc_engine_conns_hash_find(ctx->engine, cid, 's');
-    }
-    if (ctx->conn == NULL) {
-        xqc_test_hq_destroy(ctx);
-        return XQC_ERROR;
-    }
-
-    ctx->hqc.conn = ctx->conn;
-    ctx->hqc.hqr_cbs.req_read_notify = xqc_test_hq_read_notify;
-    xqc_conn_set_alp_user_data(ctx->conn, &ctx->hqc);
-    ctx->conn->app_proto_cbs.stream_cbs = hq_stream_callbacks;
-    ctx->stream = xqc_stream_create_with_direction(ctx->conn,
-                                                   XQC_STREAM_BIDI, NULL);
-    if (ctx->stream == NULL || ctx->stream->user_data == NULL) {
-        xqc_test_hq_destroy(ctx);
-        return XQC_ERROR;
+    hqc->conn = conn;
+    xqc_conn_set_alp_user_data(conn, hqc);
+    conn->app_proto_cbs.stream_cbs = hq_stream_callbacks;
+    xqc_stream_t *stream = xqc_stream_create_with_direction(conn,
+                                                           XQC_STREAM_BIDI,
+                                                           NULL);
+    if (stream == NULL || stream->user_data == NULL) {
+        xqc_engine_destroy(conn->engine);
+        return NULL;
     }
 
-    ctx->hqr = ctx->stream->user_data;
-    xqc_hq_request_set_user_data(ctx->hqr, ctx);
-    return XQC_OK;
-}
-
-
-static void
-xqc_test_hq_destroy(xqc_test_hq_ctx_t *ctx)
-{
-    if (ctx->engine != NULL) {
-        /* The stream close callback owns the HQ request. */
-        xqc_engine_destroy(ctx->engine);
-        ctx->engine = NULL;
-        ctx->conn = NULL;
-    }
+    return stream;
 }
 
 
 static int
-xqc_test_hq_input(xqc_test_hq_ctx_t *ctx, const char *data, size_t len,
-    uint8_t fin)
+xqc_test_hq_input(xqc_stream_t *stream, const char *data, uint8_t fin)
 {
+    size_t len = strlen(data);
     xqc_stream_frame_t *frame = xqc_calloc(1, sizeof(*frame));
     if (frame == NULL) {
         return -XQC_EMALLOC;
     }
-
     frame->data = xqc_malloc(len + 1);
     if (frame->data == NULL) {
         xqc_free(frame);
         return -XQC_EMALLOC;
     }
 
-    memcpy(frame->data, data, len);
+    memcpy(frame->data, data, len + 1);
     frame->data_length = len;
-    frame->data_offset = ctx->input_offset;
+    frame->data_offset = stream->stream_data_in.merged_offset_end;
     frame->fin = fin;
-    int ret = xqc_insert_stream_frame(ctx->conn, ctx->stream, frame);
+    int ret = xqc_insert_stream_frame(stream->stream_conn, stream, frame);
     if (ret != XQC_OK) {
         xqc_destroy_stream_frame(frame);
-        return ret;
-    }
 
-    ctx->input_offset += len;
-    if (fin) {
-        ctx->stream->stream_data_in.stream_determined = 1;
-        ctx->stream->stream_data_in.stream_length = ctx->input_offset;
-        ctx->stream->stream_state_recv = XQC_RECV_STREAM_ST_DATA_RECVD;
+    } else if (fin) {
+        stream->stream_data_in.stream_determined = 1;
+        stream->stream_data_in.stream_length = frame->data_offset + len;
+        stream->stream_state_recv = XQC_RECV_STREAM_ST_DATA_RECVD;
     }
-
-    return XQC_OK;
+    return ret;
 }
 
 
-static int
-xqc_test_hq_read_notify(xqc_hq_request_t *hqr, void *user_data)
+void
+xqc_test_hq_request_recv(void)
 {
-    xqc_test_hq_ctx_t *ctx = user_data;
-    char buf[64];
+    const char *requests[] = {"GET /path\r\n", "GET /path", "ET /path\r\n"};
+    char buf[16];
+    uint8_t fin;
+
+    for (size_t i = 0; i < 3; i++) {
+        xqc_hq_conn_t hqc = {0};
+        xqc_stream_t *stream = xqc_test_hq_stream(&hqc);
+        CU_ASSERT_PTR_NOT_NULL_FATAL(stream);
+        xqc_hq_request_t *hqr = stream->user_data;
+
+        if (i == 2) {
+            /* RFC 9000 Section 2.2: frame boundaries do not delimit data. */
+            CU_ASSERT_EQUAL(xqc_test_hq_input(stream, "G", 0), XQC_OK);
+            fin = 1;
+            CU_ASSERT_EQUAL(xqc_hq_request_recv_req(hqr, buf, sizeof(buf),
+                                                   &fin), 0);
+            CU_ASSERT_EQUAL(fin, 0);
+        }
+        CU_ASSERT_EQUAL(xqc_test_hq_input(stream, requests[i], i != 2), XQC_OK);
+        memset(buf, '!', sizeof(buf));
+        ssize_t read = xqc_hq_request_recv_req(hqr, buf, sizeof(buf), &fin);
+        CU_ASSERT_EQUAL(read, strlen("/path"));
+        CU_ASSERT_EQUAL(memcmp(buf, "/path", sizeof("/path")), 0);
+        CU_ASSERT_EQUAL(fin, 1);
+
+        fin = 1;
+        read = xqc_hq_request_recv_req(hqr, buf, sizeof(buf), &fin);
+        CU_ASSERT_EQUAL(read, 0);
+        CU_ASSERT_EQUAL(fin, 0);
+        if (i == 2) {
+            CU_ASSERT_EQUAL(xqc_test_hq_input(stream, "", 1), XQC_OK);
+            fin = 1;
+            read = xqc_hq_request_recv_req(hqr, buf, sizeof(buf), &fin);
+            CU_ASSERT_EQUAL(read, 0);
+            CU_ASSERT_EQUAL(fin, 0);
+            CU_ASSERT_EQUAL(stream->stream_state_recv,
+                            XQC_RECV_STREAM_ST_DATA_READ);
+        }
+        xqc_engine_destroy(stream->stream_conn->engine);
+    }
+}
+
+
+void
+xqc_test_hq_request_recv_errors(void)
+{
+    xqc_hq_conn_t hqc = {0};
+    xqc_stream_t *stream = xqc_test_hq_stream(&hqc);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(stream);
+    xqc_hq_request_t *hqr = stream->user_data;
+    char buf[8];
     uint8_t fin;
     ssize_t read;
 
-    /* Bound the application's read loop so a regression cannot hang CUnit. */
-    for (size_t i = 0; i < 8; i++) {
-        read = xqc_hq_request_recv_req(hqr, buf, sizeof(buf), &fin);
-        ctx->read_calls++;
-        if (read < 0) {
-            return (int)read;
-        }
-        if (read > 0 && read < sizeof(buf)) {
-            ctx->copied_bytes += read;
-        }
-        if (fin) {
-            ctx->completions++;
-        }
-        if (read == 0 || fin) {
-            return XQC_OK;
-        }
-    }
-
-    return -XQC_EFATAL;
-}
-
-
-void
-xqc_test_hq_request_fin(void)
-{
-    xqc_test_hq_ctx_t ctx;
-    char buf[32];
-    uint8_t fin = 0;
-    const char request[] = "GET /same-fin\r\n";
-    int ret = xqc_test_hq_init(&ctx);
-    CU_ASSERT_EQUAL(ret, XQC_OK);
-    if (ret != XQC_OK) {
-        return;
-    }
-
-    CU_ASSERT_EQUAL(xqc_test_hq_input(&ctx, request, sizeof(request) - 1, 1),
-                    XQC_OK);
-    memset(buf, '!', sizeof(buf));
-    ssize_t read = xqc_hq_request_recv_req(ctx.hqr, buf, sizeof(buf), &fin);
-    CU_ASSERT_EQUAL(read, strlen("/same-fin"));
-    CU_ASSERT_EQUAL(fin, 1);
-    CU_ASSERT_STRING_EQUAL(buf, "/same-fin");
-    CU_ASSERT_EQUAL(ctx.stream->stream_state_recv,
-                    XQC_RECV_STREAM_ST_DATA_READ);
-
-    fin = 1;
-    read = xqc_hq_request_recv_req(ctx.hqr, buf, sizeof(buf), &fin);
-    CU_ASSERT_EQUAL(read, 0);
-    CU_ASSERT_EQUAL(fin, 0);
-    xqc_test_hq_destroy(&ctx);
-}
-
-
-void
-xqc_test_hq_request_delayed_fin(void)
-{
-    xqc_test_hq_ctx_t ctx;
-    const char request[] = "GET /delayed-fin\r\n";
-    int ret = xqc_test_hq_init(&ctx);
-    CU_ASSERT_EQUAL(ret, XQC_OK);
-    if (ret != XQC_OK) {
-        return;
-    }
-
-    /* RFC 9000 Section 19.8 permits FIN in a later, empty STREAM frame. */
-    CU_ASSERT_EQUAL(xqc_test_hq_input(&ctx, request, sizeof(request) - 1, 0),
-                    XQC_OK);
-    ret = hq_stream_callbacks.stream_read_notify(ctx.stream, ctx.hqr);
-    CU_ASSERT_EQUAL(ret, XQC_OK);
-    CU_ASSERT_EQUAL(ctx.read_calls, 1);
-    CU_ASSERT_EQUAL(ctx.copied_bytes, strlen("/delayed-fin"));
-    CU_ASSERT_EQUAL(ctx.completions, 1);
-    CU_ASSERT_EQUAL(ctx.stream->stream_stats.peer_fin_read_time, 0);
-
-    /* An EAGAIN before FIN must not deliver the resource a second time. */
-    ret = hq_stream_callbacks.stream_read_notify(ctx.stream, ctx.hqr);
-    CU_ASSERT_EQUAL(ret, XQC_OK);
-    CU_ASSERT_EQUAL(ctx.read_calls, 2);
-    CU_ASSERT_EQUAL(ctx.completions, 1);
-
-    CU_ASSERT_EQUAL(xqc_test_hq_input(&ctx, "", 0, 1), XQC_OK);
-    ret = hq_stream_callbacks.stream_read_notify(ctx.stream, ctx.hqr);
-    CU_ASSERT_EQUAL(ret, XQC_OK);
-    CU_ASSERT_EQUAL(ctx.read_calls, 3);
-    CU_ASSERT_EQUAL(ctx.copied_bytes, strlen("/delayed-fin"));
-    CU_ASSERT_EQUAL(ctx.completions, 1);
-    CU_ASSERT_EQUAL(ctx.stream->stream_state_recv,
-                    XQC_RECV_STREAM_ST_DATA_READ);
-    CU_ASSERT(ctx.stream->stream_stats.peer_fin_read_time != 0);
-
-    ret = hq_stream_callbacks.stream_read_notify(ctx.stream, ctx.hqr);
-    CU_ASSERT_EQUAL(ret, XQC_OK);
-    CU_ASSERT_EQUAL(ctx.read_calls, 4);
-    CU_ASSERT_EQUAL(ctx.completions, 1);
-    xqc_test_hq_destroy(&ctx);
-
-    ret = xqc_test_hq_init(&ctx);
-    CU_ASSERT_EQUAL(ret, XQC_OK);
-    if (ret != XQC_OK) {
-        return;
-    }
-
-    CU_ASSERT_EQUAL(xqc_test_hq_input(&ctx, request, sizeof(request) - 1, 0),
-                    XQC_OK);
-    ret = hq_stream_callbacks.stream_read_notify(ctx.stream, ctx.hqr);
-    CU_ASSERT_EQUAL(ret, XQC_OK);
-    CU_ASSERT_EQUAL(xqc_test_hq_input(&ctx, "tail", 4, 1), XQC_OK);
-    ret = hq_stream_callbacks.stream_read_notify(ctx.stream, ctx.hqr);
-    CU_ASSERT_EQUAL(ret, XQC_OK);
-    CU_ASSERT_EQUAL(ctx.read_calls, 2);
-    CU_ASSERT_EQUAL(ctx.copied_bytes, strlen("/delayed-fin"));
-    CU_ASSERT_EQUAL(ctx.completions, 1);
-    CU_ASSERT_EQUAL(ctx.stream->stream_data_in.next_read_offset,
-                    sizeof(request) - 1 + 4);
-    CU_ASSERT_EQUAL(ctx.stream->stream_state_recv,
-                    XQC_RECV_STREAM_ST_DATA_READ);
-    xqc_test_hq_destroy(&ctx);
-}
-
-
-void
-xqc_test_hq_request_fragmented(void)
-{
-    xqc_test_hq_ctx_t ctx;
-    const char *parts[] = {"G", "ET /frag", "mented\r", "\n"};
-    char buf[32];
-    uint8_t fin;
-    int ret = xqc_test_hq_init(&ctx);
-    CU_ASSERT_EQUAL(ret, XQC_OK);
-    if (ret != XQC_OK) {
-        return;
-    }
-
-    /* RFC 9000 Section 2.2: frame boundaries do not delimit stream data. */
-    for (size_t i = 0; i < sizeof(parts) / sizeof(parts[0]); i++) {
-        CU_ASSERT_EQUAL(xqc_test_hq_input(&ctx, parts[i], strlen(parts[i]), 0),
-                        XQC_OK);
-        memset(buf, '!', sizeof(buf));
-        fin = 1;
-        ssize_t read = xqc_hq_request_recv_req(ctx.hqr, buf, sizeof(buf), &fin);
-        if (i < 3) {
-            CU_ASSERT_EQUAL(read, 0);
-            CU_ASSERT_EQUAL(fin, 0);
-
-        } else {
-            CU_ASSERT_EQUAL(read, strlen("/fragmented"));
-            CU_ASSERT_EQUAL(fin, 1);
-            CU_ASSERT_STRING_EQUAL(buf, "/fragmented");
-        }
-    }
-
-    xqc_test_hq_destroy(&ctx);
-
-    ret = xqc_test_hq_init(&ctx);
-    CU_ASSERT_EQUAL(ret, XQC_OK);
-    if (ret != XQC_OK) {
-        return;
-    }
-
-    CU_ASSERT_EQUAL(xqc_test_hq_input(&ctx, "GET", 3, 1), XQC_OK);
-    fin = 1;
-    ssize_t read = xqc_hq_request_recv_req(ctx.hqr, buf, sizeof(buf), &fin);
-    CU_ASSERT_EQUAL(read, -XQC_EPROTO);
-    CU_ASSERT_EQUAL(fin, 0);
-    xqc_test_hq_destroy(&ctx);
-}
-
-
-void
-xqc_test_hq_request_small_buffer(void)
-{
-    xqc_test_hq_ctx_t ctx;
-    const char request[] = "GET /abcdefg\r\n";
-    const char *parts[] = {"/ab", "cde", "fg"};
-    char buf[5];
-    uint8_t fin;
-    int ret = xqc_test_hq_init(&ctx);
-    CU_ASSERT_EQUAL(ret, XQC_OK);
-    if (ret != XQC_OK) {
-        return;
-    }
-
-    CU_ASSERT_EQUAL(xqc_test_hq_input(&ctx, request, sizeof(request) - 1, 0),
-                    XQC_OK);
-    for (size_t i = 0; i < sizeof(parts) / sizeof(parts[0]); i++) {
-        memset(buf, '!', sizeof(buf));
-        fin = 1;
-        ssize_t read = xqc_hq_request_recv_req(ctx.hqr, buf, 4, &fin);
-        CU_ASSERT_EQUAL(read, strlen(parts[i]));
-        CU_ASSERT_EQUAL(fin, i == 2);
-        CU_ASSERT_EQUAL(memcmp(buf, parts[i], strlen(parts[i])), 0);
-        CU_ASSERT_EQUAL(buf[strlen(parts[i])], '\0');
-        CU_ASSERT_EQUAL(buf[4], '!');
-    }
-
-    CU_ASSERT_EQUAL(xqc_test_hq_input(&ctx, "", 0, 1), XQC_OK);
-    ssize_t read = xqc_hq_request_recv_req(ctx.hqr, buf, sizeof(buf), &fin);
-    CU_ASSERT_EQUAL(read, 0);
-    CU_ASSERT_EQUAL(fin, 0);
-    CU_ASSERT_EQUAL(ctx.stream->stream_state_recv,
-                    XQC_RECV_STREAM_ST_DATA_READ);
-    xqc_test_hq_destroy(&ctx);
-}
-
-
-void
-xqc_test_hq_request_no_buffer(void)
-{
-    xqc_test_hq_ctx_t ctx;
-    const char request[] = "GET /retry-buffer\r\n";
-    char buf[32];
-    uint8_t fin;
-    int ret = xqc_test_hq_init(&ctx);
-    CU_ASSERT_EQUAL(ret, XQC_OK);
-    if (ret != XQC_OK) {
-        return;
-    }
-
-    CU_ASSERT_EQUAL(xqc_test_hq_input(&ctx, request, sizeof(request) - 1, 1),
-                    XQC_OK);
+    CU_ASSERT_EQUAL(xqc_test_hq_input(stream, "GET /abcdef\r\n", 0), XQC_OK);
     for (size_t capacity = 0; capacity <= 1; capacity++) {
         memset(buf, '!', sizeof(buf));
         fin = 1;
-        ssize_t read = xqc_hq_request_recv_req(ctx.hqr, buf, capacity, &fin);
+        read = xqc_hq_request_recv_req(hqr, buf, capacity, &fin);
         CU_ASSERT_EQUAL(read, -XQC_ENOBUF);
         CU_ASSERT_EQUAL(fin, 0);
         CU_ASSERT_EQUAL(buf[capacity], '!');
     }
 
-    ssize_t read = xqc_hq_request_recv_req(ctx.hqr, buf, sizeof(buf), &fin);
-    CU_ASSERT_EQUAL(read, strlen("/retry-buffer"));
-    CU_ASSERT_EQUAL(fin, 1);
-    CU_ASSERT_EQUAL(memcmp(buf, "/retry-buffer", sizeof("/retry-buffer")), 0);
-    xqc_test_hq_destroy(&ctx);
-}
-
-
-void
-xqc_test_hq_request_recv_reset(void)
-{
-    const char request[] = "GET /reset\r\n";
-    char buf[32];
-    uint8_t fin;
-
-    for (int stage = 0; stage <= 2; stage++) {
-        xqc_test_hq_ctx_t ctx;
-        int ret = xqc_test_hq_init(&ctx);
-        CU_ASSERT_EQUAL(ret, XQC_OK);
-        if (ret != XQC_OK) {
-            return;
-        }
-
-        if (stage > 0) {
-            CU_ASSERT_EQUAL(xqc_test_hq_input(&ctx, request,
-                                             sizeof(request) - 1, 0), XQC_OK);
-            size_t capacity = stage == 1 ? 4 : sizeof(buf);
-            ssize_t read = xqc_hq_request_recv_req(ctx.hqr, buf, capacity,
-                                                   &fin);
-            CU_ASSERT_EQUAL(read, stage == 1 ? 3 : strlen("/reset"));
-            CU_ASSERT_EQUAL(fin, stage == 2);
-        }
-
-        ctx.stream->stream_state_recv = XQC_RECV_STREAM_ST_RESET_RECVD;
+    const char *parts[] = {"/ab", "cde", "f"};
+    for (size_t i = 0; i < 3; i++) {
+        memset(buf, '!', sizeof(buf));
         fin = 1;
-        ssize_t read = xqc_hq_request_recv_req(ctx.hqr, buf, sizeof(buf), &fin);
-        CU_ASSERT_EQUAL(read, -XQC_ESTREAM_RESET);
-        CU_ASSERT_EQUAL(fin, 0);
-        CU_ASSERT_EQUAL(ctx.stream->stream_state_recv,
-                        XQC_RECV_STREAM_ST_RESET_READ);
-        xqc_test_hq_destroy(&ctx);
-    }
-}
-
-
-void
-xqc_test_hq_request_transport_fin(void)
-{
-    xqc_test_hq_ctx_t ctx;
-    const char request[] = "GET /transport-fin";
-    char buf[32];
-    uint8_t fin = 0;
-    int ret = xqc_test_hq_init(&ctx);
-    CU_ASSERT_EQUAL(ret, XQC_OK);
-    if (ret != XQC_OK) {
-        return;
+        read = xqc_hq_request_recv_req(hqr, buf, 4, &fin);
+        CU_ASSERT_EQUAL(read, strlen(parts[i]));
+        CU_ASSERT_EQUAL(memcmp(buf, parts[i], strlen(parts[i]) + 1), 0);
+        CU_ASSERT_EQUAL(buf[4], '!');
+        CU_ASSERT_EQUAL(fin, i == 2);
     }
 
-    CU_ASSERT_EQUAL(xqc_test_hq_input(&ctx, request, sizeof(request) - 1, 1),
-                    XQC_OK);
-    ssize_t read = xqc_hq_request_recv_req(ctx.hqr, buf, sizeof(buf), &fin);
-    CU_ASSERT_EQUAL(read, strlen("/transport-fin"));
-    CU_ASSERT_EQUAL(fin, 1);
-    CU_ASSERT_STRING_EQUAL(buf, "/transport-fin");
-    xqc_test_hq_destroy(&ctx);
+    stream->stream_state_recv = XQC_RECV_STREAM_ST_RESET_RECVD;
+    fin = 1;
+    read = xqc_hq_request_recv_req(hqr, buf, sizeof(buf), &fin);
+    CU_ASSERT_EQUAL(read, -XQC_ESTREAM_RESET);
+    CU_ASSERT_EQUAL(fin, 0);
+    xqc_engine_destroy(stream->stream_conn->engine);
+
+    stream = xqc_test_hq_stream(&hqc);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(stream);
+    CU_ASSERT_EQUAL(xqc_test_hq_input(stream, "GET", 1), XQC_OK);
+    fin = 1;
+    read = xqc_hq_request_recv_req(stream->user_data, buf, sizeof(buf), &fin);
+    CU_ASSERT_EQUAL(read, -XQC_EPROTO);
+    CU_ASSERT_EQUAL(fin, 0);
+    xqc_engine_destroy(stream->stream_conn->engine);
 }

--- a/tests/unittest/xqc_hq_test.h
+++ b/tests/unittest/xqc_hq_test.h
@@ -5,12 +5,7 @@
 #ifndef XQC_HQ_TEST_H
 #define XQC_HQ_TEST_H
 
-void xqc_test_hq_request_fin(void);
-void xqc_test_hq_request_transport_fin(void);
-void xqc_test_hq_request_delayed_fin(void);
-void xqc_test_hq_request_fragmented(void);
-void xqc_test_hq_request_small_buffer(void);
-void xqc_test_hq_request_no_buffer(void);
-void xqc_test_hq_request_recv_reset(void);
+void xqc_test_hq_request_recv(void);
+void xqc_test_hq_request_recv_errors(void);
 
 #endif

--- a/tests/unittest/xqc_hq_test.h
+++ b/tests/unittest/xqc_hq_test.h
@@ -1,0 +1,16 @@
+/**
+ * @copyright Copyright (c) 2026, Alibaba Group Holding Limited
+ */
+
+#ifndef XQC_HQ_TEST_H
+#define XQC_HQ_TEST_H
+
+void xqc_test_hq_request_fin(void);
+void xqc_test_hq_request_transport_fin(void);
+void xqc_test_hq_request_delayed_fin(void);
+void xqc_test_hq_request_fragmented(void);
+void xqc_test_hq_request_small_buffer(void);
+void xqc_test_hq_request_no_buffer(void);
+void xqc_test_hq_request_recv_reset(void);
+
+#endif


### PR DESCRIPTION
### Mechanism

Return the actual copied HQ resource bytes and deliver the completed request only once. A CRLF-terminated request followed by a separate QUIC FIN previously corrupted read offsets and kept the server read callback looping over an already delivered path. Preserve CRLF completion while consuming a later FIN without replaying the request.

Regression coverage uses the existing CUnit and endpoint frameworks. CI reads the CUnit summary so diagnostic output cannot undercount passed tests.

- RFC: [9000 §2.2](https://www.rfc-editor.org/rfc/rfc9000.html#section-2.2) and [§19.8](https://www.rfc-editor.org/rfc/rfc9000.html#section-19.8).
- Reproduced from the [kwik multiplexing failure](https://interop.seemann.io/logs/quic/2026-09-09T18:34/xquic_kwik/multiplexing/). A fresh public Docker matrix run remains pending.

Fixes: #518

### Validation Cases

- 1702 — HQ request with inline FIN completes two transfers on one connection.
- 1703 — HQ request with FIN sent after its response completes a subsequent transfer on the same connection.

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Complete
- CI: Pending — Build on Ubuntu; Test BabaSSL on Ubuntu 24.04 with GCC 13.
