### PR TITLE
[~] Fix #730: Detect persistent congestion from lost packet intervals

### DIFF
--- a/case_test/congestion/core.sh
+++ b/case_test/congestion/core.sh
@@ -338,6 +338,89 @@ fi
 
 }
 
+case_congestion_persistent_run()
+{
+    local case_id="$1"
+    local expected_resets="$2"
+    local resets
+    local echoes
+    local server_receives
+
+    case_test_stop_server
+    clear_log
+    rm -f test_session xqc_token tp_localhost
+    case_test_start_server ${SERVER_BIN} -l d -e -x "${case_id}" \
+        > svr_stdlog
+    sleep 1
+    if ! ${CLIENT_BIN} -T 1 -s 1024 -l d -t 1 -E -c cubic \
+        -x "${case_id}" > stdlog 2>&1
+    then
+        return 1
+    fi
+
+    resets=$(grep -c 'persistent_congestion|reset_rtt' clog || true)
+    echoes=$(grep -c '^>>>>>>>> pass:1$' stdlog || true)
+    server_receives=$(grep -c \
+        '\[persistent-congestion-test\]|server_received:1024|' \
+        svr_stdlog || true)
+
+    if [[ "${resets}" -ne "${expected_resets}" \
+        || "${echoes}" -ne 2 || "${server_receives}" -ne 2 ]]
+    then
+        echo "resets=${resets} echoes=${echoes} server_receives=${server_receives}"
+        return 1
+    fi
+
+    grep -q '\[persistent-congestion-test\]|final_acked:1|' stdlog \
+        || return 1
+    grep -q '\[persistent-congestion-test\]|recovery_stream_started:1|' \
+        stdlog || return 1
+    grep -q 'conn_err:0,' stdlog || return 1
+
+    if ! awk -F'|' '
+        /\[persistent-congestion-test\]\|release\|/ {
+            for (i = 1; i <= NF; i++) {
+                split($i, value, ":")
+                if (value[1] == "drops") drops = value[2] + 0
+                if (value[1] == "loss_span") span = value[2] + 0
+                if (value[1] == "duration") duration = value[2] + 0
+                if (value[1] == "pto_count") pto_count = value[2] + 0
+            }
+            valid = drops >= 2 && span > duration && pto_count == 0
+        }
+        END { exit !valid }
+    ' stdlog
+    then
+        return 1
+    fi
+
+    if [[ "${case_id}" -eq 802 ]]; then
+        grep -q '\[persistent-congestion-test\]|middle_acked:1|' stdlog \
+            || return 1
+
+    elif grep -q '\[persistent-congestion-test\]|middle_acked:1|' stdlog; then
+        return 1
+    fi
+}
+
+case_congestion_core_persistent_congestion_loss()
+{
+    if case_congestion_persistent_run 801 1; then
+        case_print_result "persistent_congestion_loss" "pass"
+    else
+        case_print_result "persistent_congestion_loss" "fail"
+    fi
+}
+
+case_congestion_core_persistent_congestion_ack()
+{
+    if case_congestion_persistent_run 802 0; then
+        case_print_result "persistent_congestion_ack" "pass"
+    else
+        case_print_result "persistent_congestion_ack" "fail"
+    fi
+}
+
 case_test_group_setup()
 {
     case_test_start_server ${SERVER_BIN} -l d -e > /dev/null
@@ -361,6 +444,8 @@ case_test_case "3_percent_loss" --id native --mode self-reporting --run case_con
 case_test_case "10_percent_loss" --id native --mode self-reporting --run case_congestion_core__10_percent_loss
 case_test_case "sengmmsg_with_10_percent_loss" --id native --mode self-reporting --run case_congestion_core_sengmmsg_with_10_percent_loss
 case_test_case "max_pkt_out_size" --id native --mode self-reporting --run case_congestion_core_max_pkt_out_size
+case_test_case "persistent_congestion_loss" --id 801 --mode self-reporting --run case_congestion_core_persistent_congestion_loss
+case_test_case "persistent_congestion_ack" --id 802 --mode self-reporting --run case_congestion_core_persistent_congestion_ack
 
 if case_test_is_discovery; then
     case_test_run

--- a/harness/spec/architecture.md
+++ b/harness/spec/architecture.md
@@ -116,3 +116,21 @@ behind the TLS integration layer.
 These boundaries are initially documented rather than mechanically enforced.
 When the same class of violation recurs, promote the invariant into a test,
 lint, or structural check.
+
+## Recovery History
+
+Persistent-congestion detection in `xqc_send_ctl.*` follows
+[RFC 9002 Section 7.6](https://www.rfc-editor.org/rfc/rfc9002.html#section-7.6).
+It compares the sending times of lost ack-eliciting packets after an RTT
+sample, independently of PTO count, and checks for intervening acknowledgments
+across packet number spaces on the sending path. The existing congestion
+callback and RTT-estimator reset handle a qualifying interval.
+
+The detector retains only packet metadata in a lazily allocated per-path
+history, including ACK-only and direct path-probe transmissions that can be
+recycled before their ACK arrives. The history holds at most 256 packets;
+overflow keeps the newest suffix and can delay detection when an older
+endpoint is unavailable. It does not infer loss across missing history.
+Acknowledged prefixes are pruned; path reset, key-space discard and the
+persistent-congestion RTT reset clear the retained interval. Packet generation
+checks prevent a recycled history slot from receiving an older packet's loss.

--- a/harness/spec/architecture.md
+++ b/harness/spec/architecture.md
@@ -132,5 +132,7 @@ recycled before their ACK arrives. The history holds at most 256 packets;
 overflow keeps the newest suffix and can delay detection when an older
 endpoint is unavailable. It does not infer loss across missing history.
 Acknowledged prefixes are pruned; path reset, key-space discard and the
-persistent-congestion RTT reset clear the retained interval. Packet generation
-checks prevent a recycled history slot from receiving an older packet's loss.
+persistent-congestion RTT reset clear the retained interval. A full ACK-range
+array also clears it because the parser may have omitted older acknowledged
+ranges. Packet generation checks prevent a recycled history slot from
+receiving an older packet's loss.

--- a/harness/spec/harness-manifest.yml
+++ b/harness/spec/harness-manifest.yml
@@ -126,6 +126,10 @@ modules:
         validation:
           level: targeted
           hints: [send, loss, pacing]
+          unit:
+            - xqc_test_send_ctl_persistent_congestion_duration_boundary
+            - xqc_test_send_ctl_persistent_congestion_ack_interrupts
+            - xqc_test_send_ctl_persistent_congestion_across_loss_batches
       datagram:
         paths:
           - src/transport/xqc_datagram*

--- a/harness/spec/validation.md
+++ b/harness/spec/validation.md
@@ -100,7 +100,7 @@ its case is retired so later changes cannot reuse it.
 | Range | New-case namespace | Allocated IDs |
 |-------|--------------------|---------------|
 | `[705, 799]` | QUIC Transport core | `705-725` |
-| `[800, 899]` | Recovery and congestion control | `800` |
+| `[800, 899]` | Recovery and congestion control | `800-802` |
 | `[900, 999]` | QUIC-TLS | `902-903` |
 | `[1000, 1099]` | HTTP/3 framing, streams, and settings | `1000-1021` |
 | `[1100, 1149]` | QPACK | None |

--- a/src/transport/xqc_conn.c
+++ b/src/transport/xqc_conn.c
@@ -7080,6 +7080,7 @@ xqc_conn_send_path_challenge(xqc_connection_t *conn, xqc_path_ctx_t *path)
         goto end;
 
     } else {
+        xqc_send_ctl_pc_on_sent(path->path_send_ctl, packet_out);
         xqc_log(conn->log, XQC_LOG_INFO,
                 "|<==|conn:%p|pkt_num:%ui|size:%ud|sent:%z|pkt_type:%s|frame:%s|inflight:%ud|now:%ui|",
                 conn, packet_out->po_pkt.pkt_num, packet_out->po_used_size, sent,

--- a/src/transport/xqc_packet_out.h
+++ b/src/transport/xqc_packet_out.h
@@ -81,6 +81,7 @@ typedef struct xqc_packet_out_s {
     /* Largest Acknowledged in ACK frame, initiated to be 0 */
     xqc_packet_number_t     po_largest_ack;
     xqc_usec_t              po_sent_time;
+    uint64_t                po_pc_seq;
     xqc_frame_type_bit_t    po_frame_types;
 
     /* the stream related to stream frame */

--- a/src/transport/xqc_send_ctl.c
+++ b/src/transport/xqc_send_ctl.c
@@ -83,6 +83,12 @@ xqc_send_ctl_pc_on_ack(xqc_send_ctl_t *send_ctl,
         return;
     }
 
+    /* The parser may have omitted older ranges when this array is full. */
+    if (ack_info->n_ranges >= XQC_MAX_ACK_RANGE_CNT) {
+        pc->count = 0;
+        return;
+    }
+
     unsigned range = ack_info->n_ranges - 1;
     for (uint64_t seq = pc->next - pc->count; seq < pc->next; ++seq) {
         xqc_pc_packet_t *packet = &pc->packets[

--- a/src/transport/xqc_send_ctl.c
+++ b/src/transport/xqc_send_ctl.c
@@ -23,6 +23,120 @@
 #include "src/transport/xqc_reinjection.h"
 #include "src/transport/xqc_transport_params.h"
 
+typedef struct {
+    xqc_packet_number_t  pkt_num;
+    xqc_usec_t           sent_time;
+    xqc_pkt_num_space_t   pns;
+    uint8_t              ack_eliciting;
+    uint8_t              acked;
+    uint8_t              lost;
+} xqc_pc_packet_t;
+
+typedef struct xqc_persistent_congestion_s {
+    uint64_t         next;
+    size_t           count;
+    xqc_pc_packet_t   packets[XQC_PERSISTENT_CONGESTION_MAX_PACKETS];
+} xqc_persistent_congestion_t;
+
+static void xqc_send_ctl_pc_on_ack(xqc_send_ctl_t *send_ctl,
+    const xqc_ack_info_t *ack_info);
+static void xqc_send_ctl_pc_on_lost(xqc_send_ctl_t *send_ctl,
+    const xqc_packet_out_t *po);
+
+
+void
+xqc_send_ctl_pc_on_sent(xqc_send_ctl_t *send_ctl, xqc_packet_out_t *po)
+{
+    po->po_pc_seq = 0;
+    if (send_ctl->ctl_first_rtt_sample_time == 0) {
+        return;
+    }
+
+    if (send_ctl->ctl_pc == NULL) {
+        send_ctl->ctl_pc = xqc_calloc(1, sizeof(*send_ctl->ctl_pc));
+        if (send_ctl->ctl_pc == NULL) {
+            return;
+        }
+        send_ctl->ctl_pc->next = 1;
+    }
+
+    xqc_persistent_congestion_t *pc = send_ctl->ctl_pc;
+    xqc_pc_packet_t *packet = &pc->packets[
+        pc->next % XQC_PERSISTENT_CONGESTION_MAX_PACKETS];
+    memset(packet, 0, sizeof(*packet));
+    packet->pkt_num = po->po_pkt.pkt_num;
+    packet->sent_time = po->po_sent_time;
+    packet->pns = po->po_pkt.pkt_pns;
+    packet->ack_eliciting = XQC_IS_ACK_ELICITING(po->po_frame_types) != 0;
+    po->po_pc_seq = pc->next++;
+    pc->count = xqc_min(pc->count + 1,
+                       XQC_PERSISTENT_CONGESTION_MAX_PACKETS);
+}
+
+
+static void
+xqc_send_ctl_pc_on_ack(xqc_send_ctl_t *send_ctl,
+    const xqc_ack_info_t *ack_info)
+{
+    xqc_persistent_congestion_t *pc = send_ctl->ctl_pc;
+    if (pc == NULL) {
+        return;
+    }
+
+    unsigned range = ack_info->n_ranges - 1;
+    for (uint64_t seq = pc->next - pc->count; seq < pc->next; ++seq) {
+        xqc_pc_packet_t *packet = &pc->packets[
+            seq % XQC_PERSISTENT_CONGESTION_MAX_PACKETS];
+        if (packet->pns != ack_info->pns) {
+            continue;
+        }
+
+        while (range > 0
+               && packet->pkt_num > ack_info->ranges[range].high)
+        {
+            --range;
+        }
+        if (packet->pkt_num >= ack_info->ranges[range].low
+            && packet->pkt_num <= ack_info->ranges[range].high)
+        {
+            packet->acked = 1;
+        }
+    }
+
+    /* Keep unresolved prefixes; later loss detection can still need them. */
+    while (pc->count > 0) {
+        xqc_pc_packet_t *packet = &pc->packets[
+            (pc->next - pc->count) % XQC_PERSISTENT_CONGESTION_MAX_PACKETS];
+        if (!packet->acked) {
+            break;
+        }
+        --pc->count;
+    }
+}
+
+
+static void
+xqc_send_ctl_pc_on_lost(xqc_send_ctl_t *send_ctl,
+    const xqc_packet_out_t *po)
+{
+    xqc_persistent_congestion_t *pc = send_ctl->ctl_pc;
+    if (pc == NULL || po->po_pc_seq == 0
+        || po->po_pc_seq < pc->next - pc->count
+        || po->po_pc_seq >= pc->next)
+    {
+        return;
+    }
+
+    xqc_pc_packet_t *packet = &pc->packets[
+        po->po_pc_seq % XQC_PERSISTENT_CONGESTION_MAX_PACKETS];
+    if (packet->pns == po->po_pkt.pkt_pns
+        && packet->pkt_num == po->po_pkt.pkt_num
+        && packet->sent_time == po->po_sent_time)
+    {
+        packet->lost = 1;
+    }
+}
+
 int 
 xqc_send_ctl_may_remove_unacked_dgram(xqc_connection_t *conn, xqc_packet_out_t *po)
 {
@@ -200,6 +314,8 @@ xqc_send_ctl_destroy(xqc_send_ctl_t *send_ctl)
     }
 
     send_ctl->ctl_bytes_in_flight = 0;
+    xqc_free(send_ctl->ctl_pc);
+    send_ctl->ctl_pc = NULL;
 }
 
 void
@@ -217,6 +333,10 @@ xqc_send_ctl_reset(xqc_send_ctl_t *send_ctl)
     send_ctl->ctl_reordering_time_threshold_shift = XQC_kTimeThresholdShift;
     send_ctl->ctl_ack_sent_cnt = 0;
     send_ctl->ctl_first_rtt_sample_time = 0;
+
+    if (send_ctl->ctl_pc) {
+        send_ctl->ctl_pc->count = 0;
+    }
 
     for (size_t i = 0; i < XQC_PNS_N; i++) {
         send_ctl->ctl_largest_acked[i] = XQC_MAX_UINT64_VALUE;
@@ -583,6 +703,10 @@ xqc_send_ctl_decrease_inflight(xqc_connection_t *conn, xqc_packet_out_t *packet_
 void
 xqc_send_ctl_on_pns_discard(xqc_send_ctl_t *send_ctl, xqc_pkt_num_space_t pns)
 {
+    /* Discarded keys provide no evidence of packet loss (RFC 9002 6.4). */
+    if (send_ctl->ctl_pc) {
+        send_ctl->ctl_pc->count = 0;
+    }
     send_ctl->ctl_time_of_last_sent_ack_eliciting_packet[pns] = 0;
     send_ctl->ctl_loss_time[pns] = 0;
     send_ctl->ctl_pto_count = 0;
@@ -621,6 +745,7 @@ xqc_send_ctl_on_packet_sent(xqc_send_ctl_t *send_ctl, xqc_pn_ctl_t *pn_ctl, xqc_
 {
     xqc_pkt_num_space_t pns = packet_out->po_pkt.pkt_pns;
 
+    xqc_send_ctl_pc_on_sent(send_ctl, packet_out);
     xqc_sample_on_sent(packet_out, send_ctl, now);
 
     xqc_packet_number_t orig_pktnum = packet_out->po_origin ? packet_out->po_origin->po_pkt.pkt_num : 0;
@@ -836,6 +961,9 @@ xqc_send_ctl_on_ack_received(xqc_send_ctl_t *send_ctl, xqc_pn_ctl_t *pn_ctl, xqc
         XQC_CONN_ERR(conn, TRA_PROTOCOL_VIOLATION);
         return -XQC_EPROTO;
     }
+
+    /* ACK-only packets can already have been recycled by the sender. */
+    xqc_send_ctl_pc_on_ack(send_ctl, ack_info);
 
     xqc_packet_number_t largest_acked_ack = xqc_ack_sent_record_on_ack(&pn_ctl->ack_sent_record[pns], ack_info);
     if (largest_acked_ack > pn_ctl->ctl_largest_acked_ack[pns]) {
@@ -1305,6 +1433,8 @@ xqc_send_ctl_detect_lost(xqc_send_ctl_t *send_ctl, xqc_send_queue_t *send_queue,
 		{
             if (po->po_flag & XQC_POF_IN_FLIGHT) {
 
+                xqc_send_ctl_pc_on_lost(send_ctl, po);
+
                 /* reinjection */
                 if (conn->enable_multipath
                     && conn->reinj_callback
@@ -1413,7 +1543,7 @@ xqc_send_ctl_detect_lost(xqc_send_ctl_t *send_ctl, xqc_send_queue_t *send_queue,
 
         /* Collapse congestion window if persistent congestion */
         if (send_ctl->ctl_cong_callback->xqc_cong_ctl_reset_cwnd
-            && xqc_send_ctl_in_persistent_congestion(send_ctl, largest_lost, now))
+            && xqc_send_ctl_in_persistent_congestion(send_ctl))
         {
             /* For loss-based CCs, it means we are gonna slow start again. */
             send_ctl->ctl_max_bytes_in_flight = 0;
@@ -1438,6 +1568,7 @@ xqc_send_ctl_detect_lost(xqc_send_ctl_t *send_ctl, xqc_send_queue_t *send_queue,
             send_ctl->ctl_srtt = send_ctl->ctl_conn->conn_settings.initial_rtt;
             send_ctl->ctl_rttvar = send_ctl->ctl_srtt / 2;
             send_ctl->ctl_first_rtt_sample_time = 0;
+            send_ctl->ctl_pc->count = 0;
 
             /* we reset BBR's cwnd here */
             send_ctl->ctl_cong_callback->xqc_cong_ctl_reset_cwnd(send_ctl->ctl_cong);
@@ -1466,12 +1597,44 @@ xqc_send_ctl_detect_lost(xqc_send_ctl_t *send_ctl, xqc_send_queue_t *send_queue,
  * InPersistentCongestion
  */
 xqc_bool_t
-xqc_send_ctl_in_persistent_congestion(xqc_send_ctl_t *send_ctl, xqc_packet_out_t *largest_lost, xqc_usec_t now)
+xqc_send_ctl_in_persistent_congestion(xqc_send_ctl_t *send_ctl)
 {
-    if (send_ctl->ctl_pto_count >= XQC_CONSECUTIVE_PTO_THRESH) {
-        xqc_usec_t duration = (send_ctl->ctl_srtt + xqc_max(send_ctl->ctl_rttvar << 2, XQC_kGranularity * 1000)
-            + send_ctl->ctl_conn->remote_settings.max_ack_delay * 1000) * XQC_kPersistentCongestionThreshold;
-        if (now - largest_lost->po_sent_time > duration) {
+    xqc_persistent_congestion_t *pc = send_ctl->ctl_pc;
+    if (pc == NULL || send_ctl->ctl_first_rtt_sample_time == 0) {
+        return XQC_FALSE;
+    }
+
+    /* RFC 9002 7.6.1: include max_ack_delay in every packet number space. */
+    xqc_usec_t duration = xqc_send_ctl_calc_pto(send_ctl)
+                          * XQC_kPersistentCongestionThreshold;
+    xqc_usec_t first_sent = 0;
+    xqc_bool_t has_first = XQC_FALSE;
+
+    /*
+     * RFC 9002 7.6.2: only a post-RTT interval of lost ack-eliciting
+     * packets can establish persistent congestion. ACKs in any space
+     * interrupt it. Overflow retains a suffix, never an inferred prefix.
+     */
+    for (uint64_t seq = pc->next - pc->count; seq < pc->next; ++seq) {
+        xqc_pc_packet_t *packet = &pc->packets[
+            seq % XQC_PERSISTENT_CONGESTION_MAX_PACKETS];
+        if (packet->acked
+            || packet->sent_time <= send_ctl->ctl_first_rtt_sample_time
+            || (packet->ack_eliciting && !packet->lost))
+        {
+            has_first = XQC_FALSE;
+            continue;
+        }
+        if (!packet->ack_eliciting || !packet->lost) {
+            continue;
+        }
+        if (!has_first) {
+            first_sent = packet->sent_time;
+            has_first = XQC_TRUE;
+
+        } else if (packet->sent_time > first_sent
+                   && packet->sent_time - first_sent > duration)
+        {
             return XQC_TRUE;
         }
     }

--- a/src/transport/xqc_send_ctl.h
+++ b/src/transport/xqc_send_ctl.h
@@ -18,7 +18,7 @@
 #define XQC_kTimeThresholdShift             3
 #define XQC_kPersistentCongestionThreshold  3
 
-#define XQC_CONSECUTIVE_PTO_THRESH          2
+#define XQC_PERSISTENT_CONGESTION_MAX_PACKETS 256
 /*
  * RFC 9002 Section 6.1.2 recommends a timer granularity of 1 ms.
  */
@@ -76,6 +76,8 @@ typedef struct xqc_pn_ctl_s {
 typedef struct xqc_send_ctl_s {
     xqc_connection_t            *ctl_conn;
     xqc_path_ctx_t              *ctl_path;
+
+    struct xqc_persistent_congestion_s *ctl_pc;
 
     /* largest packet number of the acked packets in packet_out */
     xqc_packet_number_t         ctl_largest_acked[XQC_PNS_N];
@@ -226,6 +228,9 @@ void xqc_send_ctl_decrease_inflight(xqc_connection_t *conn, xqc_packet_out_t *pa
 
 void xqc_send_ctl_on_pns_discard(xqc_send_ctl_t *send_ctl, xqc_pkt_num_space_t pns);
 
+void xqc_send_ctl_pc_on_sent(xqc_send_ctl_t *send_ctl,
+    xqc_packet_out_t *po);
+
 void xqc_send_ctl_on_packet_sent(xqc_send_ctl_t *send_ctl, xqc_pn_ctl_t *pn_ctl, xqc_packet_out_t *packet_out, xqc_usec_t now);
 
 int xqc_send_ctl_on_ack_received (xqc_send_ctl_t *send_ctl, xqc_pn_ctl_t *pn_ctl, xqc_send_queue_t *send_queue, xqc_ack_info_t *const ack_info, xqc_usec_t ack_recv_time, xqc_bool_t ack_on_same_path);
@@ -241,7 +246,7 @@ void xqc_send_ctl_on_spurious_loss_detected(xqc_send_ctl_t *send_ctl,
 
 void xqc_send_ctl_detect_lost(xqc_send_ctl_t *send_ctl, xqc_send_queue_t *send_queue, xqc_pkt_num_space_t pns, xqc_usec_t now);
 
-xqc_bool_t xqc_send_ctl_in_persistent_congestion(xqc_send_ctl_t *send_ctl, xqc_packet_out_t *largest_lost, xqc_usec_t now);
+xqc_bool_t xqc_send_ctl_in_persistent_congestion(xqc_send_ctl_t *send_ctl);
 
 void xqc_send_ctl_congestion_event(xqc_send_ctl_t *send_ctl, xqc_usec_t sent_time);
 

--- a/tests/test_client.c
+++ b/tests/test_client.c
@@ -21,6 +21,7 @@
 #include "src/http3/xqc_h3_request.h"
 #include "src/transport/xqc_conn.h"
 #include "src/transport/xqc_packet_out.h"
+#include "src/transport/xqc_send_ctl.h"
 #include "src/transport/xqc_frame_parser.h"
 #include "src/tls/xqc_crypto.h"
 #include "src/tls/xqc_tls.h"
@@ -104,6 +105,8 @@ printf_null(const char *format, ...)
 #define XQC_TEST_CASE_RESET_FINAL_SIZE_TOO_SMALL 723
 #define XQC_TEST_CASE_CLOSE_SEND_ONLY_STREAM 724
 #define XQC_TEST_CASE_CLOSE_RECV_ONLY_STREAM 725
+#define XQC_TEST_CASE_PERSISTENT_CONGESTION_LOSS 801
+#define XQC_TEST_CASE_PERSISTENT_CONGESTION_ACK 802
 
 typedef struct user_conn_s user_conn_t;
 
@@ -121,6 +124,8 @@ static xqc_int_t xqc_client_write_test_datagram_frame(
     xqc_connection_t *conn, xqc_pkt_type_t pkt_type);
 static void xqc_client_send_reset_final_size_frames(xqc_connection_t *conn);
 static void xqc_client_close_send_only_stream(xqc_connection_t *conn);
+static void xqc_client_congestion_timeout(int fd, short what, void *arg);
+static void xqc_client_start_congestion_test(user_conn_t *user_conn);
 
 
 #define XQC_TEST_DGRAM_BATCH_SZ 32
@@ -178,6 +183,27 @@ typedef struct user_stream_s {
 
 } user_stream_t;
 
+typedef struct {
+    struct event       *timer;
+    xqc_usec_t          start;
+    xqc_usec_t          duration;
+    xqc_usec_t          first_drop;
+    xqc_usec_t          last_drop;
+    xqc_usec_t          middle_sent_time;
+    unsigned            warmup_sent;
+    unsigned            warmup_acked;
+    unsigned            dropped;
+    int                 phase;
+    int                 allow_send;
+    int                 middle_sent;
+    int                 middle_acked;
+    int                 final_acked;
+} xqc_test_congestion_t;
+
+static int g_congestion_warmup_ping = 0;
+static int g_congestion_middle_ping = 1;
+static int g_congestion_final_ping = 2;
+
 typedef struct user_conn_s {
     int                 fd;
     xqc_cid_t           cid;
@@ -217,6 +243,7 @@ typedef struct user_conn_s {
 
     uint64_t            black_hole_start_time;
     int                 tracked_pkt_cnt;
+    xqc_test_congestion_t congestion_test;
 } user_conn_t;
 
 #define XQC_DEMO_INTERFACE_MAX_LEN 64
@@ -1280,6 +1307,25 @@ xqc_client_write_socket_ex(uint64_t path_id,
         return XQC_SOCKET_ERROR;
     }
 
+    if ((g_test_case == XQC_TEST_CASE_PERSISTENT_CONGESTION_LOSS
+         || g_test_case == XQC_TEST_CASE_PERSISTENT_CONGESTION_ACK)
+        && user_conn->congestion_test.phase == 2
+        && !user_conn->congestion_test.allow_send
+        && size > 0 && (buf[0] & 0x80) == 0)
+    {
+        xqc_test_congestion_t *test = &user_conn->congestion_test;
+        xqc_usec_t now = xqc_now();
+
+        if (test->dropped == 0) {
+            test->first_drop = now;
+        }
+        test->last_drop = now;
+        test->dropped++;
+        printf("[persistent-congestion-test]|drop:%u|sent:%"PRIu64"|\n",
+               test->dropped, now);
+        return size;
+    }
+
     /* test stateless reset after handshake completed */
     if (g_test_case == 41) {
         if (hsk_completed && ((buf[0] & 0xC0) == 0x40)) {
@@ -2011,6 +2057,11 @@ xqc_client_conn_close_notify(xqc_connection_t *conn, const xqc_cid_t *cid, void 
         p_ctx = &ctx;
     }
 
+    if (user_conn->congestion_test.timer != NULL) {
+        event_free(user_conn->congestion_test.timer);
+        user_conn->congestion_test.timer = NULL;
+    }
+
     xqc_int_t err = xqc_conn_get_errno(conn);
     printf("conn_err_type:%d\n", (int)xqc_conn_get_err_type(conn));
     printf("should_clear_0rtt_ticket, conn_err:%d, clear_0rtt_ticket:%d\n", err, xqc_conn_should_clear_0rtt_ticket(err));
@@ -2042,6 +2093,23 @@ void
 xqc_client_conn_ping_acked_notify(xqc_connection_t *conn, const xqc_cid_t *cid, void *ping_user_data, void *user_data, void *conn_proto_data)
 {
     DEBUG;
+    user_conn_t *user_conn = user_data;
+    xqc_test_congestion_t *test = &user_conn->congestion_test;
+
+    if (ping_user_data == &g_congestion_warmup_ping) {
+        test->warmup_acked++;
+
+    } else if (ping_user_data == &g_congestion_middle_ping) {
+        test->middle_acked = 1;
+        printf("[persistent-congestion-test]|middle_acked:1|"
+               "sent:%"PRIu64"|received:%"PRIu64"|\n",
+               test->middle_sent_time, xqc_now());
+
+    } else if (ping_user_data == &g_congestion_final_ping) {
+        test->final_acked = 1;
+        printf("[persistent-congestion-test]|final_acked:1|\n");
+    }
+
     if (ping_user_data) {
         printf("====>ping_id:%d\n", *(int *) ping_user_data);
 
@@ -2100,6 +2168,7 @@ xqc_client_conn_handshake_finished(xqc_connection_t *conn, void *user_data, void
     }
 
     hsk_completed = 1;
+    xqc_client_start_congestion_test(user_conn);
 
     user_conn->dgram_mss = xqc_datagram_get_mss(conn);
     if (user_conn->dgram_mss == 0) {
@@ -2739,6 +2808,124 @@ xqc_client_stream_send(xqc_stream_t *stream, void *user_data)
 
     return 0;
 }
+
+static void
+xqc_client_start_congestion_test(user_conn_t *user_conn)
+{
+    struct timeval delay = {0, 20000};
+
+    if (g_test_case != XQC_TEST_CASE_PERSISTENT_CONGESTION_LOSS
+        && g_test_case != XQC_TEST_CASE_PERSISTENT_CONGESTION_ACK)
+    {
+        return;
+    }
+
+    user_conn->congestion_test.timer = event_new(eb, -1, 0,
+        xqc_client_congestion_timeout, user_conn);
+    if (user_conn->congestion_test.timer == NULL) {
+        printf("[persistent-congestion-test]|timer_failed|\n");
+        return;
+    }
+    event_add(user_conn->congestion_test.timer, &delay);
+}
+
+
+static void
+xqc_client_congestion_timeout(int fd, short what, void *arg)
+{
+    user_conn_t *user_conn = arg;
+    xqc_test_congestion_t *test = &user_conn->congestion_test;
+    xqc_send_ctl_t *ctl = user_conn->quic_conn->conn_initial_path->path_send_ctl;
+    xqc_usec_t now = xqc_now();
+    xqc_usec_t delay_us = 20000;
+    struct timeval delay;
+    user_stream_t *stream;
+
+    if (test->phase == 0) {
+        xqc_conn_send_ping(ctx.engine, &user_conn->cid,
+                          &g_congestion_warmup_ping);
+        if (++test->warmup_sent == 8) {
+            test->phase = 1;
+            delay_us = 100000;
+        }
+
+    } else if (test->phase == 1) {
+        if (test->warmup_acked < 4 || ctl->ctl_first_rtt_sample_time == 0) {
+            printf("[persistent-congestion-test]|warmup_failed|\n");
+            return;
+        }
+
+        /* RFC 9002 Section 7.6.1: use the unbacked-off PTO duration. */
+        test->duration = (ctl->ctl_srtt
+            + xqc_max(4 * ctl->ctl_rttvar, XQC_kGranularity * 1000)
+            + user_conn->quic_conn->remote_settings.max_ack_delay * 1000)
+            * XQC_kPersistentCongestionThreshold;
+        test->start = now;
+        test->phase = 2;
+        printf("[persistent-congestion-test]|begin|duration:%"PRIu64
+               "|warmup_acked:%u|\n", test->duration, test->warmup_acked);
+        xqc_conn_send_ping(ctx.engine, &user_conn->cid, NULL);
+        delay_us = xqc_max(test->duration / 24, 1000);
+
+    } else if (test->phase == 2) {
+        if (now - test->start >= 3 * test->duration / 2) {
+            test->phase = 3;
+            printf("[persistent-congestion-test]|release|drops:%u|"
+                   "loss_span:%"PRIu64"|duration:%"PRIu64"|pto_count:%u|\n",
+                   test->dropped, test->last_drop - test->first_drop,
+                   test->duration, ctl->ctl_pto_count);
+            xqc_conn_send_ping(ctx.engine, &user_conn->cid,
+                              &g_congestion_final_ping);
+            delay_us = 100000;
+
+        } else {
+            /* An acknowledged packet splits the RFC 9002 7.6.2 interval. */
+            if (g_test_case == XQC_TEST_CASE_PERSISTENT_CONGESTION_ACK
+                && !test->middle_sent
+                && now - test->start >= 3 * test->duration / 4)
+            {
+                test->middle_sent = 1;
+                test->middle_sent_time = now;
+                test->allow_send = 1;
+                xqc_conn_send_ping(ctx.engine, &user_conn->cid,
+                                  &g_congestion_middle_ping);
+                test->allow_send = 0;
+
+            } else {
+                xqc_conn_send_ping(ctx.engine, &user_conn->cid, NULL);
+            }
+            delay_us = xqc_max(test->duration / 24, 1000);
+        }
+
+    } else if (test->phase == 3) {
+        if (!test->final_acked) {
+            printf("[persistent-congestion-test]|final_ack_missing|\n");
+            return;
+        }
+
+        stream = calloc(1, sizeof(*stream));
+        if (stream == NULL) {
+            return;
+        }
+        stream->user_conn = user_conn;
+        stream->stream = xqc_stream_create(ctx.engine, &user_conn->cid,
+                                          NULL, stream);
+        if (stream->stream == NULL) {
+            free(stream);
+            return;
+        }
+        test->phase = 4;
+        printf("[persistent-congestion-test]|recovery_stream_started:1|\n");
+        xqc_client_stream_send(stream->stream, stream);
+        xqc_engine_main_logic(ctx.engine);
+        return;
+    }
+
+    delay.tv_sec = delay_us / 1000000;
+    delay.tv_usec = delay_us % 1000000;
+    event_add(test->timer, &delay);
+}
+
 
 int
 xqc_client_stream_write_notify(xqc_stream_t *stream, void *user_data)
@@ -5432,6 +5619,14 @@ int main(int argc, char *argv[]) {
         exit(1);
     }
 
+    if ((g_test_case == XQC_TEST_CASE_PERSISTENT_CONGESTION_LOSS
+         || g_test_case == XQC_TEST_CASE_PERSISTENT_CONGESTION_ACK)
+        && (transport != 1 || g_enable_multipath || !g_echo_check))
+    {
+        printf("persistent congestion cases require -T 1 -E and one path\n");
+        exit(1);
+    }
+
     memset(g_header_key, 'k', sizeof(g_header_key));
     memset(g_header_value, 'v', sizeof(g_header_value));
     memset(&ctx, 0, sizeof(ctx));
@@ -6251,6 +6446,9 @@ skip_data:
         event_free(user_conn->ev_socket);
     }
     event_free(user_conn->ev_timeout);
+    if (user_conn->congestion_test.timer != NULL) {
+        event_free(user_conn->congestion_test.timer);
+    }
 
     if (user_conn->dgram_blk) {
         if (user_conn->dgram_blk->data) {

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -81,6 +81,8 @@ printf_null(const char *format, ...)
 #define XQC_TEST_CASE_CRYPTO_PREVIOUS_LEVEL_EXTENSION 721
 #define XQC_TEST_CASE_DATAGRAM_1RTT_ALLOWED 1201
 #define XQC_TEST_CASE_CLOSE_RECV_ONLY_STREAM 725
+#define XQC_TEST_CASE_PERSISTENT_CONGESTION_LOSS 801
+#define XQC_TEST_CASE_PERSISTENT_CONGESTION_ACK 802
 
 extern long xqc_random(void);
 extern xqc_usec_t xqc_now();
@@ -1026,6 +1028,14 @@ xqc_server_stream_read_notify(xqc_stream_t *stream, void *user_data)
     // printf("xqc_stream_recv read:%zd, offset:%zu, fin:%d\n", read_sum, user_stream->recv_body_len, fin);
 
     if (fin) {
+        if (g_test_case == XQC_TEST_CASE_PERSISTENT_CONGESTION_LOSS
+            || g_test_case == XQC_TEST_CASE_PERSISTENT_CONGESTION_ACK)
+        {
+            printf("[persistent-congestion-test]|server_received:%zu|"
+                   "stream:%"PRIu64"|\n", user_stream->recv_body_len,
+                   xqc_stream_id(stream));
+            fflush(stdout);
+        }
         xqc_server_stream_send(stream, user_data);
     }
     return 0;

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -467,6 +467,33 @@ main(int argc, char *argv[])
                         xqc_test_send_ctl_single_loss_does_not_reset_rtt)
         || !CU_add_test(pSuite, "xqc_test_send_ctl_persistent_congestion_no_rtt_sample_early_return",
                         xqc_test_send_ctl_persistent_congestion_no_rtt_sample_early_return)
+        || !CU_add_test(pSuite,
+            "xqc_test_send_ctl_persistent_congestion_duration_boundary",
+            xqc_test_send_ctl_persistent_congestion_duration_boundary)
+        || !CU_add_test(pSuite,
+            "xqc_test_send_ctl_persistent_congestion_prior_rtt_required",
+            xqc_test_send_ctl_persistent_congestion_prior_rtt_required)
+        || !CU_add_test(pSuite,
+            "xqc_test_send_ctl_persistent_congestion_ack_interrupts",
+            xqc_test_send_ctl_persistent_congestion_ack_interrupts)
+        || !CU_add_test(pSuite,
+            "xqc_test_send_ctl_persistent_congestion_ack_eliciting_endpoints",
+            xqc_test_send_ctl_persistent_congestion_ack_eliciting_endpoints)
+        || !CU_add_test(pSuite,
+            "xqc_test_send_ctl_persistent_congestion_across_loss_batches",
+            xqc_test_send_ctl_persistent_congestion_across_loss_batches)
+        || !CU_add_test(pSuite,
+            "xqc_test_send_ctl_persistent_congestion_pending_other_space",
+            xqc_test_send_ctl_persistent_congestion_pending_other_space)
+        || !CU_add_test(pSuite,
+            "xqc_test_send_ctl_persistent_congestion_history_wrap",
+            xqc_test_send_ctl_persistent_congestion_history_wrap)
+        || !CU_add_test(pSuite,
+            "xqc_test_send_ctl_persistent_congestion_history_reset",
+            xqc_test_send_ctl_persistent_congestion_history_reset)
+        || !CU_add_test(pSuite,
+            "xqc_test_send_ctl_persistent_congestion_recycled_probe",
+            xqc_test_send_ctl_persistent_congestion_recycled_probe)
         /* RFC 9000 §6.2 Version Negotiation abort suite */
         || !CU_add_test(pSuite, "xqc_test_vn_abort_on_unsupported_version", xqc_test_vn_abort_on_unsupported_version)
         || !CU_add_test(pSuite, "xqc_test_vn_downgrade_protection_when_version_matches", xqc_test_vn_downgrade_protection_when_version_matches)

--- a/tests/unittest/main.c
+++ b/tests/unittest/main.c
@@ -494,6 +494,9 @@ main(int argc, char *argv[])
         || !CU_add_test(pSuite,
             "xqc_test_send_ctl_persistent_congestion_recycled_probe",
             xqc_test_send_ctl_persistent_congestion_recycled_probe)
+        || !CU_add_test(pSuite,
+            "xqc_test_send_ctl_persistent_congestion_ack_range_limit",
+            xqc_test_send_ctl_persistent_congestion_ack_range_limit)
         /* RFC 9000 §6.2 Version Negotiation abort suite */
         || !CU_add_test(pSuite, "xqc_test_vn_abort_on_unsupported_version", xqc_test_vn_abort_on_unsupported_version)
         || !CU_add_test(pSuite, "xqc_test_vn_downgrade_protection_when_version_matches", xqc_test_vn_downgrade_protection_when_version_matches)

--- a/tests/unittest/xqc_conn_test.c
+++ b/tests/unittest/xqc_conn_test.c
@@ -1301,34 +1301,54 @@ xqc_test_0rtt_calc_pto_ignores_stale_max_ack_delay(void)
 
 
 /*
- * issue #672 computation-level: persistent congestion duration is another
- * ungated consumer of remote_settings.max_ack_delay. Elapsed time 200ms sits
- * between duration(default 25ms)=129ms and duration(stale 100ms)=354ms, so
- * one boundary discriminates both behaviors.
+ * RFC 9002 Section 7.6.1: a 200 ms lost interval exceeds the duration
+ * with the default 25 ms max_ack_delay, but not a stale 100 ms value.
  */
 void
 xqc_test_0rtt_persistent_congestion_default_max_ack_delay(void)
 {
-    xqc_connection_t *conn = xqc_0rtt_stale_mad_conn(100);
-    xqc_send_ctl_t *send_ctl = conn->conn_initial_path->path_send_ctl;
+    for (int stale_delay = 0; stale_delay < 2; stale_delay++) {
+        xqc_connection_t *conn = xqc_0rtt_stale_mad_conn(100);
+        CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+        xqc_path_ctx_t *path = conn->conn_initial_path;
+        xqc_send_ctl_t *send_ctl = path->path_send_ctl;
+        uint32_t inflight_before = send_ctl->ctl_bytes_in_flight;
+        xqc_send_queue_t *sq = conn->conn_send_queue;
 
-    send_ctl->ctl_srtt = 10000;
-    send_ctl->ctl_rttvar = 2000;
-    send_ctl->ctl_pto_count = XQC_CONSECUTIVE_PTO_THRESH;
+        send_ctl->ctl_srtt = 10000;
+        send_ctl->ctl_latest_rtt = 10000;
+        send_ctl->ctl_rttvar = 2000;
+        send_ctl->ctl_first_rtt_sample_time = 1;
+        send_ctl->ctl_largest_acked[XQC_PNS_APP_DATA] = 3;
+        if (stale_delay) {
+            conn->remote_settings.max_ack_delay = 100;
+        }
 
-    xqc_packet_out_t po;
-    memset(&po, 0, sizeof(po));
-    xqc_usec_t now = 1000000;
-    po.po_sent_time = now - 200000;
+        for (xqc_packet_number_t num = 1; num <= 2; num++) {
+            xqc_packet_out_t *po = xqc_packet_out_get_and_insert_send(sq,
+                XQC_PTYPE_0RTT);
+            CU_ASSERT_PTR_NOT_NULL_FATAL(po);
+            po->po_pkt.pkt_pns = XQC_PNS_APP_DATA;
+            po->po_pkt.pkt_num = num;
+            po->po_path_id = path->path_id;
+            po->po_sent_time = 1000000 + (num - 1) * 200000;
+            po->po_frame_types = XQC_FRAME_BIT_PING;
+            po->po_used_size = 1200;
+            po->po_enc_size = 1200;
+            xqc_send_ctl_on_packet_sent(send_ctl, xqc_get_pn_ctl(conn, path),
+                                        po, po->po_sent_time);
+            xqc_send_queue_remove_send(&po->po_list);
+            xqc_send_queue_insert_unacked(po,
+                &sq->sndq_unacked_packets[XQC_PNS_APP_DATA], sq);
+        }
 
-    /* (18000 + 25000) * 3 = 129000 < 200000: persistent congestion */
-    CU_ASSERT_EQUAL(xqc_send_ctl_in_persistent_congestion(send_ctl, &po, now), XQC_TRUE);
-
-    /* stale 100ms would give (18000 + 100000) * 3 = 354000 > 200000 */
-    conn->remote_settings.max_ack_delay = 100;
-    CU_ASSERT_EQUAL(xqc_send_ctl_in_persistent_congestion(send_ctl, &po, now), XQC_FALSE);
-
-    xqc_engine_destroy(conn->engine);
+        xqc_send_ctl_detect_lost(send_ctl, sq, XQC_PNS_APP_DATA, 1400000);
+        CU_ASSERT_EQUAL(conn->detected_loss_cnt, 2);
+        CU_ASSERT_EQUAL(send_ctl->ctl_bytes_in_flight, inflight_before);
+        CU_ASSERT_EQUAL(send_ctl->ctl_first_rtt_sample_time,
+                        stale_delay ? 1 : 0);
+        xqc_engine_destroy(conn->engine);
+    }
 }
 
 

--- a/tests/unittest/xqc_send_ctl_test.c
+++ b/tests/unittest/xqc_send_ctl_test.c
@@ -520,61 +520,135 @@ xqc_test_send_ctl_update_rtt_ack_delay_cap(void)
 
 
 /*
- * Issue #739 regression tests.
- *
- * Pre-fix, xqc_send_ctl_detect_lost only reset cwnd on persistent
- * congestion; min_rtt/srtt/rttvar were left at their pre-disruption
- * values. After a major path event that triggers persistent
- * congestion, the stale (smaller) srtt and rttvar made every
- * downstream PTO and persistent-congestion duration computation use
- * RTT that no longer reflects the path, repeatedly mis-triggering
- * loss detection. RFC 9002 5.2 SHOULD reset min_rtt to the newest
- * sample; ngtcp2 (lib/ngtcp2_rtb.c persistent_congestion path)
- * additionally resets srtt/rttvar to initial and clears the
- * first-sample timestamp so the next sample re-seeds the estimator.
- *
- * The fix in xqc_send_ctl_detect_lost performs exactly that reset.
- * These tests pin its observable effects and guard against
- * regressions in two directions:
- *   - that the reset is *not* applied to ordinary loss
- *   - that the early-return guard for "no RTT sample yet" still
- *     short-circuits before any reset can fire
+ * RFC 9002 Sections 7.6.1 and 7.6.2 require two lost ack-eliciting
+ * transmissions, with no intervening ACK, after a prior RTT sample.
  */
+static xqc_packet_out_t *xqc_test_send_ctl_send_packet(xqc_connection_t *conn,
+    xqc_pkt_num_space_t pns, xqc_packet_number_t pkt_num,
+    xqc_usec_t sent_time, xqc_frame_type_bit_t frames);
+static xqc_packet_out_t *xqc_test_send_ctl_seed_lost_packet(
+    xqc_connection_t *conn, xqc_packet_number_t pkt_num,
+    xqc_usec_t sent_time);
+static void xqc_test_send_ctl_arm_pc_state(xqc_send_ctl_t *send_ctl,
+    xqc_usec_t srtt, xqc_usec_t rttvar, xqc_usec_t minrtt,
+    xqc_packet_number_t largest_acked);
+static void xqc_test_send_ctl_ack(xqc_connection_t *conn,
+    xqc_pkt_num_space_t pns, xqc_packet_number_t largest,
+    xqc_packet_number_t earlier, xqc_usec_t now);
+static void xqc_test_send_ctl_assert_pc(xqc_send_ctl_t *send_ctl,
+    xqc_bool_t expected);
 
 
-/*
- * Seed a single in-flight, ack-eliciting packet on the connection's
- * initial path. po_sent_time/pkt_num are caller-supplied so the
- * caller controls the persistent-congestion duration arithmetic.
- *
- * po_used_size is left at 0 so xqc_send_ctl_decrease_inflight is a
- * no-op on inflight bookkeeping; we only need the packet to be on
- * the unacked list and on the right path so detect_lost picks it up.
- */
 static xqc_packet_out_t *
-xqc_test_send_ctl_seed_lost_packet(xqc_connection_t *conn,
-    xqc_packet_number_t pkt_num, xqc_usec_t po_sent_time)
+xqc_test_send_ctl_send_packet(xqc_connection_t *conn,
+    xqc_pkt_num_space_t pns, xqc_packet_number_t pkt_num,
+    xqc_usec_t sent_time, xqc_frame_type_bit_t frames)
 {
     xqc_send_queue_t *sq = conn->conn_send_queue;
-    xqc_send_ctl_t *send_ctl = conn->conn_initial_path->path_send_ctl;
+    xqc_path_ctx_t *path = conn->conn_initial_path;
+    xqc_pkt_type_t type = XQC_PTYPE_SHORT_HEADER;
 
-    xqc_packet_out_t *po = xqc_packet_out_get(sq);
+    if (pns == XQC_PNS_INIT) {
+        type = XQC_PTYPE_INIT;
+
+    } else if (pns == XQC_PNS_HSK) {
+        type = XQC_PTYPE_HSK;
+    }
+
+    xqc_packet_out_t *po = xqc_packet_out_get_and_insert_send(sq, type);
     if (po == NULL) {
         return NULL;
     }
 
-    po->po_pkt.pkt_type = XQC_PTYPE_SHORT_HEADER;
-    po->po_pkt.pkt_pns  = XQC_PNS_APP_DATA;
-    po->po_pkt.pkt_num  = pkt_num;
-    po->po_path_id      = send_ctl->ctl_path->path_id;
-    po->po_sent_time    = po_sent_time;
-    po->po_flag         = XQC_POF_IN_FLIGHT;
-    /* PING is ack-eliciting and is not in XQC_NEED_REPAIR. */
-    po->po_frame_types  = XQC_FRAME_BIT_PING;
-    po->po_used_size    = 0;
+    po->po_pkt.pkt_pns = pns;
+    po->po_pkt.pkt_num = pkt_num;
+    po->po_path_id = path->path_id;
+    po->po_sent_time = sent_time;
+    po->po_frame_types = frames;
+    po->po_used_size = 1200;
+    po->po_enc_size = 1200;
+    xqc_send_ctl_on_packet_sent(path->path_send_ctl,
+                                xqc_get_pn_ctl(conn, path), po, sent_time);
+    xqc_send_queue_remove_send(&po->po_list);
+    if (XQC_IS_ACK_ELICITING(frames)) {
+        xqc_send_queue_insert_unacked(po, &sq->sndq_unacked_packets[pns], sq);
 
-    xqc_send_queue_insert_unacked(po, &sq->sndq_unacked_packets[XQC_PNS_APP_DATA], sq);
+    } else {
+        xqc_send_queue_insert_free(po, &sq->sndq_free_packets, sq);
+    }
     return po;
+}
+
+
+static xqc_packet_out_t *
+xqc_test_send_ctl_seed_lost_packet(xqc_connection_t *conn,
+    xqc_packet_number_t pkt_num, xqc_usec_t sent_time)
+{
+    return xqc_test_send_ctl_send_packet(conn, XQC_PNS_APP_DATA, pkt_num,
+                                         sent_time, XQC_FRAME_BIT_PING);
+}
+
+
+static void
+xqc_test_send_ctl_arm_pc_state(xqc_send_ctl_t *send_ctl,
+    xqc_usec_t srtt, xqc_usec_t rttvar, xqc_usec_t minrtt,
+    xqc_packet_number_t largest_acked)
+{
+    send_ctl->ctl_srtt = srtt;
+    send_ctl->ctl_rttvar = rttvar;
+    send_ctl->ctl_minrtt = minrtt;
+    send_ctl->ctl_latest_rtt = srtt;
+    send_ctl->ctl_first_rtt_sample_time = 1;
+    send_ctl->ctl_pto_count = 0;
+    /* Direct loss passes model a previously received ACK above the losses. */
+    send_ctl->ctl_largest_acked[XQC_PNS_APP_DATA] = largest_acked
+        ? largest_acked + 1 : XQC_MAX_UINT64_VALUE;
+    send_ctl->ctl_conn->remote_settings.max_ack_delay = 25;
+    send_ctl->ctl_conn->conn_settings.disable_pn_skipping = 1;
+}
+
+
+static void
+xqc_test_send_ctl_ack(xqc_connection_t *conn, xqc_pkt_num_space_t pns,
+    xqc_packet_number_t largest, xqc_packet_number_t earlier, xqc_usec_t now)
+{
+    xqc_path_ctx_t *path = conn->conn_initial_path;
+    xqc_ack_info_t ack = {0};
+
+    ack.pns = pns;
+    ack.n_ranges = 1;
+    ack.ranges[0].low = largest;
+    ack.ranges[0].high = largest;
+    if (earlier != XQC_MAX_UINT64_VALUE) {
+        ack.n_ranges = 2;
+        ack.ranges[1].low = earlier;
+        ack.ranges[1].high = earlier;
+    }
+
+    /* A cross-path ACK leaves the pinned RTT estimate unchanged. */
+    CU_ASSERT_EQUAL(xqc_send_ctl_on_ack_received(path->path_send_ctl,
+        xqc_get_pn_ctl(conn, path), conn->conn_send_queue, &ack, now,
+        XQC_FALSE), XQC_OK);
+}
+
+
+static void
+xqc_test_send_ctl_assert_pc(xqc_send_ctl_t *send_ctl, xqc_bool_t expected)
+{
+    if (expected) {
+        CU_ASSERT_EQUAL(send_ctl->ctl_first_rtt_sample_time, 0);
+        CU_ASSERT_EQUAL(send_ctl->ctl_minrtt, XQC_MAX_UINT32_VALUE);
+        CU_ASSERT_EQUAL(send_ctl->ctl_srtt,
+                        send_ctl->ctl_conn->conn_settings.initial_rtt);
+        CU_ASSERT_EQUAL(send_ctl->ctl_rttvar,
+                        send_ctl->ctl_conn->conn_settings.initial_rtt / 2);
+
+    } else {
+        CU_ASSERT_NOT_EQUAL(send_ctl->ctl_first_rtt_sample_time, 0);
+        CU_ASSERT_EQUAL(send_ctl->ctl_srtt, 10000);
+        CU_ASSERT_EQUAL(send_ctl->ctl_rttvar, 2000);
+        CU_ASSERT_EQUAL(send_ctl->ctl_minrtt, 8000);
+    }
 }
 
 
@@ -582,26 +656,22 @@ void
 xqc_test_send_ctl_granularity_marks_at_boundary(void)
 {
     xqc_connection_t *conn = test_engine_connect();
-    CU_ASSERT_FATAL(conn != NULL);
-    CU_ASSERT_FATAL(conn->conn_initial_path != NULL);
-
+    CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
     xqc_send_ctl_t *send_ctl = conn->conn_initial_path->path_send_ctl;
-    CU_ASSERT_FATAL(send_ctl != NULL);
+    uint32_t inflight_before = send_ctl->ctl_bytes_in_flight;
 
     send_ctl->ctl_srtt = 0;
     send_ctl->ctl_latest_rtt = 0;
     send_ctl->ctl_largest_acked[XQC_PNS_APP_DATA] = 100;
     send_ctl->ctl_reordering_packet_threshold = XQC_kPacketThreshold;
-
-    xqc_packet_out_t *po = xqc_test_send_ctl_seed_lost_packet(conn, 99, 1);
-    CU_ASSERT_FATAL(po != NULL);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(
+        xqc_test_send_ctl_seed_lost_packet(conn, 99, 1));
 
     xqc_send_ctl_detect_lost(send_ctl, conn->conn_send_queue,
                              XQC_PNS_APP_DATA, 1001);
-
     CU_ASSERT_EQUAL(conn->detected_loss_cnt, 1);
     CU_ASSERT_EQUAL(send_ctl->sampler.loss, 1);
-
+    CU_ASSERT_EQUAL(send_ctl->ctl_bytes_in_flight, inflight_before);
     xqc_engine_destroy(conn->engine);
 }
 
@@ -610,50 +680,24 @@ void
 xqc_test_send_ctl_granularity_defers_before_boundary(void)
 {
     xqc_connection_t *conn = test_engine_connect();
-    CU_ASSERT_FATAL(conn != NULL);
-    CU_ASSERT_FATAL(conn->conn_initial_path != NULL);
-
+    CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
     xqc_send_ctl_t *send_ctl = conn->conn_initial_path->path_send_ctl;
-    CU_ASSERT_FATAL(send_ctl != NULL);
+    uint32_t inflight_before = send_ctl->ctl_bytes_in_flight;
 
     send_ctl->ctl_srtt = 0;
     send_ctl->ctl_latest_rtt = 0;
     send_ctl->ctl_largest_acked[XQC_PNS_APP_DATA] = 100;
     send_ctl->ctl_reordering_packet_threshold = XQC_kPacketThreshold;
-
-    xqc_packet_out_t *po = xqc_test_send_ctl_seed_lost_packet(conn, 99, 1);
-    CU_ASSERT_FATAL(po != NULL);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(
+        xqc_test_send_ctl_seed_lost_packet(conn, 99, 1));
 
     xqc_send_ctl_detect_lost(send_ctl, conn->conn_send_queue,
                              XQC_PNS_APP_DATA, 1000);
-
     CU_ASSERT_EQUAL(conn->detected_loss_cnt, 0);
     CU_ASSERT_EQUAL(send_ctl->sampler.loss, 0);
     CU_ASSERT_EQUAL(send_ctl->ctl_loss_time[XQC_PNS_APP_DATA], 1001);
-
+    CU_ASSERT_EQUAL(send_ctl->ctl_bytes_in_flight, inflight_before + 1200);
     xqc_engine_destroy(conn->engine);
-}
-
-
-/*
- * Build a send_ctl state that satisfies xqc_send_ctl_in_persistent_congestion:
- *   - pto_count == XQC_CONSECUTIVE_PTO_THRESH
- *   - srtt/rttvar small so duration is bounded and easy to exceed
- *   - first_rtt_sample_time non-zero so detect_lost doesn't early-return
- *   - largest_acked[APP_DATA] >= our packet's pkt_num so the loop considers it
- */
-static void
-xqc_test_send_ctl_arm_pc_state(xqc_send_ctl_t *send_ctl,
-    xqc_usec_t srtt, xqc_usec_t rttvar, xqc_usec_t minrtt,
-    xqc_packet_number_t largest_acked)
-{
-    send_ctl->ctl_srtt    = srtt;
-    send_ctl->ctl_rttvar  = rttvar;
-    send_ctl->ctl_minrtt  = minrtt;
-    send_ctl->ctl_latest_rtt = srtt;
-    send_ctl->ctl_first_rtt_sample_time = 1;
-    send_ctl->ctl_pto_count = XQC_CONSECUTIVE_PTO_THRESH;
-    send_ctl->ctl_largest_acked[XQC_PNS_APP_DATA] = largest_acked;
 }
 
 
@@ -661,57 +705,30 @@ void
 xqc_test_send_ctl_persistent_congestion_resets_rtt(void)
 {
     xqc_connection_t *conn = test_engine_connect();
-    CU_ASSERT_FATAL(conn != NULL);
-    CU_ASSERT_FATAL(conn->conn_initial_path != NULL);
-
+    CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
     xqc_send_ctl_t *send_ctl = conn->conn_initial_path->path_send_ctl;
-    CU_ASSERT_FATAL(send_ctl != NULL);
-    CU_ASSERT_FATAL(send_ctl->ctl_cong_callback != NULL);
-    CU_ASSERT_FATAL(send_ctl->ctl_cong_callback->xqc_cong_ctl_reset_cwnd != NULL);
-    CU_ASSERT_FATAL(send_ctl->ctl_cong_callback->xqc_cong_ctl_get_cwnd != NULL);
-
-    /* initial_rtt is the post-reset srtt; assert it is non-zero so the
-     * test does not silently accept an unintended 0/0 outcome. */
+    uint32_t inflight_before = send_ctl->ctl_bytes_in_flight;
+    CU_ASSERT_PTR_NOT_NULL_FATAL(
+        send_ctl->ctl_cong_callback->xqc_cong_ctl_reset_cwnd);
     CU_ASSERT_FATAL(conn->conn_settings.initial_rtt > 0);
-    conn->remote_settings.max_ack_delay = 25; /* ms */
 
-    /* Pin RTT estimator at a small, converged value. With srtt=10ms,
-     * rttvar=2ms, max_ack_delay=25ms, the persistent-congestion
-     * duration is (10 + max(8,2) + 25)ms * 3 = 129ms. Setting
-     * po_sent_time = 1us and now = 1s leaves a 999ms gap, well past
-     * the 129ms threshold. */
-    xqc_test_send_ctl_arm_pc_state(send_ctl,
-                                   /* srtt   */ 10000,
-                                   /* rttvar */  2000,
-                                   /* minrtt */  8000,
-                                   /* largest_acked */ 1);
-
-    xqc_packet_out_t *po = xqc_test_send_ctl_seed_lost_packet(conn, 1, 1);
-    CU_ASSERT_FATAL(po != NULL);
-
+    xqc_test_send_ctl_arm_pc_state(send_ctl, 10000, 2000, 8000, 0);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(
+        xqc_test_send_ctl_seed_lost_packet(conn, 1, 1000000));
+    CU_ASSERT_PTR_NOT_NULL_FATAL(
+        xqc_test_send_ctl_seed_lost_packet(conn, 2, 1200000));
     uint64_t cwnd_before = send_ctl->ctl_cong_callback->xqc_cong_ctl_get_cwnd(
         send_ctl->ctl_cong);
-    /* Cubic default init_cwnd = 10*MSS, which must exceed min_cwnd (4*MSS).
-     * If this invariant ever flips, the cwnd-reset assertion below would
-     * become a tautology, so guard it explicitly. */
-    CU_ASSERT_FATAL(cwnd_before > 0);
 
-    xqc_send_ctl_detect_lost(send_ctl, conn->conn_send_queue,
-                             XQC_PNS_APP_DATA, 1000000);
-
-    /* min_rtt resets to the xquic sentinel (XQC_MAX_UINT32_VALUE), not
-     * UINT64_MAX, to stay consistent with xqc_send_ctl_create. */
-    CU_ASSERT_EQUAL(send_ctl->ctl_minrtt, XQC_MAX_UINT32_VALUE);
-    CU_ASSERT_EQUAL(send_ctl->ctl_srtt, conn->conn_settings.initial_rtt);
-    CU_ASSERT_EQUAL(send_ctl->ctl_rttvar, conn->conn_settings.initial_rtt / 2);
-    CU_ASSERT_EQUAL(send_ctl->ctl_first_rtt_sample_time, 0);
-
-    uint64_t cwnd_after = send_ctl->ctl_cong_callback->xqc_cong_ctl_get_cwnd(
-        send_ctl->ctl_cong);
-    /* Cubic reset_cwnd collapses cwnd to min_cwnd; cubic_init sets
-     * cwnd = init_cwnd > min_cwnd. So cwnd must strictly shrink. */
-    CU_ASSERT(cwnd_after < cwnd_before);
-
+    CU_ASSERT_PTR_NOT_NULL_FATAL(
+        xqc_test_send_ctl_seed_lost_packet(conn, 3, 1390000));
+    xqc_test_send_ctl_ack(conn, XQC_PNS_APP_DATA, 3,
+                          XQC_MAX_UINT64_VALUE, 1400000);
+    xqc_test_send_ctl_assert_pc(send_ctl, XQC_TRUE);
+    CU_ASSERT_EQUAL(conn->detected_loss_cnt, 2);
+    CU_ASSERT_EQUAL(send_ctl->ctl_bytes_in_flight, inflight_before);
+    CU_ASSERT(send_ctl->ctl_cong_callback->xqc_cong_ctl_get_cwnd(
+        send_ctl->ctl_cong) < cwnd_before);
     xqc_engine_destroy(conn->engine);
 }
 
@@ -720,38 +737,27 @@ void
 xqc_test_send_ctl_persistent_congestion_rtt_reseeds_from_new_sample(void)
 {
     xqc_connection_t *conn = test_engine_connect();
-    CU_ASSERT_FATAL(conn != NULL);
-    CU_ASSERT_FATAL(conn->conn_initial_path != NULL);
-
+    CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
     xqc_send_ctl_t *send_ctl = conn->conn_initial_path->path_send_ctl;
-    CU_ASSERT_FATAL(send_ctl != NULL);
-    CU_ASSERT_FATAL(conn->conn_settings.initial_rtt > 0);
-    conn->remote_settings.max_ack_delay = 25;
 
-    /* Drive the persistent-congestion path identically to Test A so the
-     * state on entry to update_rtt is exactly what the fix produces. */
-    xqc_test_send_ctl_arm_pc_state(send_ctl, 10000, 2000, 8000, 1);
-    xqc_packet_out_t *po = xqc_test_send_ctl_seed_lost_packet(conn, 1, 1);
-    CU_ASSERT_FATAL(po != NULL);
-    xqc_send_ctl_detect_lost(send_ctl, conn->conn_send_queue,
-                             XQC_PNS_APP_DATA, 1000000);
+    xqc_test_send_ctl_arm_pc_state(send_ctl, 10000, 2000, 8000, 0);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(
+        xqc_test_send_ctl_seed_lost_packet(conn, 1, 1000000));
+    CU_ASSERT_PTR_NOT_NULL_FATAL(
+        xqc_test_send_ctl_seed_lost_packet(conn, 2, 1200000));
+    CU_ASSERT_PTR_NOT_NULL_FATAL(
+        xqc_test_send_ctl_seed_lost_packet(conn, 3, 1390000));
+    xqc_test_send_ctl_ack(conn, XQC_PNS_APP_DATA, 3,
+                          XQC_MAX_UINT64_VALUE, 1400000);
+    CU_ASSERT_EQUAL(send_ctl->ctl_first_rtt_sample_time, 0);
 
-    CU_ASSERT_FATAL(send_ctl->ctl_first_rtt_sample_time == 0);
-
-    /* Inject a new RTT sample that is orders of magnitude larger than
-     * the pre-reset estimator (8ms minrtt -> 300ms latest_rtt). Without
-     * the first_rtt_sample_time clear, the existing min(latest, minrtt)
-     * code in update_rtt would have left minrtt pegged at 8ms — the
-     * exact bug. With the clear, the first-sample branch takes the
-     * value directly. */
+    /* RFC 9002 Section 5.2: the next RTT sample seeds the estimator. */
     xqc_usec_t latest = 300000;
     xqc_send_ctl_update_rtt(send_ctl, &latest, 0);
-
     CU_ASSERT_EQUAL(send_ctl->ctl_minrtt, 300000);
-    CU_ASSERT_EQUAL(send_ctl->ctl_srtt,   300000);
+    CU_ASSERT_EQUAL(send_ctl->ctl_srtt, 300000);
     CU_ASSERT_EQUAL(send_ctl->ctl_rttvar, 150000);
-    CU_ASSERT(send_ctl->ctl_first_rtt_sample_time != 0);
-
+    CU_ASSERT_NOT_EQUAL(send_ctl->ctl_first_rtt_sample_time, 0);
     xqc_engine_destroy(conn->engine);
 }
 
@@ -760,32 +766,19 @@ void
 xqc_test_send_ctl_single_loss_does_not_reset_rtt(void)
 {
     xqc_connection_t *conn = test_engine_connect();
-    CU_ASSERT_FATAL(conn != NULL);
-    CU_ASSERT_FATAL(conn->conn_initial_path != NULL);
-
+    CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
     xqc_send_ctl_t *send_ctl = conn->conn_initial_path->path_send_ctl;
-    CU_ASSERT_FATAL(send_ctl != NULL);
-    conn->remote_settings.max_ack_delay = 25;
+    uint32_t inflight_before = send_ctl->ctl_bytes_in_flight;
 
-    /* Same RTT state and same packet timing as Test A, but pto_count
-     * is below XQC_CONSECUTIVE_PTO_THRESH so the persistent-congestion
-     * predicate fails. The packet is still marked lost (single loss),
-     * but the RTT estimator must remain untouched. */
     xqc_test_send_ctl_arm_pc_state(send_ctl, 10000, 2000, 8000, 1);
-    send_ctl->ctl_pto_count = 0;
-
-    xqc_packet_out_t *po = xqc_test_send_ctl_seed_lost_packet(conn, 1, 1);
-    CU_ASSERT_FATAL(po != NULL);
-
+    send_ctl->ctl_pto_count = 10;
+    CU_ASSERT_PTR_NOT_NULL_FATAL(
+        xqc_test_send_ctl_seed_lost_packet(conn, 1, 1000000));
     xqc_send_ctl_detect_lost(send_ctl, conn->conn_send_queue,
-                             XQC_PNS_APP_DATA, 1000000);
-
-    /* All four RTT fields must equal their pre-call values. */
-    CU_ASSERT_EQUAL(send_ctl->ctl_srtt,   10000);
-    CU_ASSERT_EQUAL(send_ctl->ctl_rttvar,  2000);
-    CU_ASSERT_EQUAL(send_ctl->ctl_minrtt,  8000);
-    CU_ASSERT(send_ctl->ctl_first_rtt_sample_time != 0);
-
+                             XQC_PNS_APP_DATA, 2000000);
+    xqc_test_send_ctl_assert_pc(send_ctl, XQC_FALSE);
+    CU_ASSERT_EQUAL(conn->detected_loss_cnt, 1);
+    CU_ASSERT_EQUAL(send_ctl->ctl_bytes_in_flight, inflight_before);
     xqc_engine_destroy(conn->engine);
 }
 
@@ -794,32 +787,334 @@ void
 xqc_test_send_ctl_persistent_congestion_no_rtt_sample_early_return(void)
 {
     xqc_connection_t *conn = test_engine_connect();
-    CU_ASSERT_FATAL(conn != NULL);
-    CU_ASSERT_FATAL(conn->conn_initial_path != NULL);
-
+    CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
     xqc_send_ctl_t *send_ctl = conn->conn_initial_path->path_send_ctl;
-    CU_ASSERT_FATAL(send_ctl != NULL);
-    conn->remote_settings.max_ack_delay = 25;
 
-    /* Arm a state where the duration check WOULD pass if reached, then
-     * clear first_rtt_sample_time so the guard at the top of the
-     * OnPacketsLost block returns before the persistent-congestion
-     * branch can fire. This pins existing behavior: the fix must not
-     * change what happens before RTT has been measured. */
-    xqc_test_send_ctl_arm_pc_state(send_ctl, 10000, 2000, 8000, 1);
+    xqc_test_send_ctl_arm_pc_state(send_ctl, 10000, 2000, 8000, 2);
     send_ctl->ctl_first_rtt_sample_time = 0;
+    CU_ASSERT_PTR_NOT_NULL_FATAL(
+        xqc_test_send_ctl_seed_lost_packet(conn, 1, 1000000));
+    CU_ASSERT_PTR_NOT_NULL_FATAL(
+        xqc_test_send_ctl_seed_lost_packet(conn, 2, 1200000));
+    xqc_send_ctl_detect_lost(send_ctl, conn->conn_send_queue,
+                             XQC_PNS_APP_DATA, 1400000);
+    CU_ASSERT_EQUAL(send_ctl->ctl_first_rtt_sample_time, 0);
+    CU_ASSERT_EQUAL(send_ctl->ctl_srtt, 10000);
+    CU_ASSERT_EQUAL(send_ctl->ctl_rttvar, 2000);
+    CU_ASSERT_EQUAL(send_ctl->ctl_minrtt, 8000);
+    CU_ASSERT_EQUAL(conn->detected_loss_cnt, 2);
+    xqc_engine_destroy(conn->engine);
+}
 
-    xqc_packet_out_t *po = xqc_test_send_ctl_seed_lost_packet(conn, 1, 1);
-    CU_ASSERT_FATAL(po != NULL);
+
+void
+xqc_test_send_ctl_persistent_congestion_duration_boundary(void)
+{
+    /* RFC 9002 Section 7.6.1: (10 + 8 + 25) ms * 3 = 129 ms. */
+    for (xqc_usec_t span = 128999; span <= 129001; span++) {
+        xqc_connection_t *conn = test_engine_connect();
+        CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+        xqc_send_ctl_t *send_ctl = conn->conn_initial_path->path_send_ctl;
+        uint32_t inflight_before = send_ctl->ctl_bytes_in_flight;
+        xqc_test_send_ctl_arm_pc_state(send_ctl, 10000, 2000, 8000, 0);
+
+        CU_ASSERT_PTR_NOT_NULL_FATAL(
+            xqc_test_send_ctl_seed_lost_packet(conn, 1, 1000000));
+        CU_ASSERT_PTR_NOT_NULL_FATAL(
+            xqc_test_send_ctl_seed_lost_packet(conn, 7, 1000000 + span));
+        CU_ASSERT_PTR_NOT_NULL_FATAL(
+            xqc_test_send_ctl_seed_lost_packet(conn, 8, 1390000));
+        CU_ASSERT_EQUAL(send_ctl->ctl_pto_count, 0);
+        xqc_test_send_ctl_ack(conn, XQC_PNS_APP_DATA, 8,
+                              XQC_MAX_UINT64_VALUE, 1400000);
+        xqc_test_send_ctl_assert_pc(send_ctl, span > 129000);
+        CU_ASSERT_EQUAL(conn->detected_loss_cnt, 2);
+        CU_ASSERT_EQUAL(send_ctl->ctl_bytes_in_flight, inflight_before);
+        xqc_engine_destroy(conn->engine);
+    }
+}
+
+
+void
+xqc_test_send_ctl_persistent_congestion_prior_rtt_required(void)
+{
+    for (int prior_sample = 0; prior_sample < 2; prior_sample++) {
+        xqc_connection_t *conn = test_engine_connect();
+        CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+        xqc_send_ctl_t *send_ctl = conn->conn_initial_path->path_send_ctl;
+        xqc_test_send_ctl_arm_pc_state(send_ctl, 10000, 2000, 8000, 2);
+        send_ctl->ctl_first_rtt_sample_time = prior_sample ? 1000000 : 0;
+        CU_ASSERT_PTR_NOT_NULL_FATAL(
+            xqc_test_send_ctl_seed_lost_packet(conn, 1, 1000000));
+        CU_ASSERT_PTR_NOT_NULL_FATAL(
+            xqc_test_send_ctl_seed_lost_packet(conn, 2, 1200000));
+        if (!prior_sample) {
+            send_ctl->ctl_first_rtt_sample_time = 1300000;
+        }
+        send_ctl->ctl_pto_count = 10;
+        xqc_send_ctl_detect_lost(send_ctl, conn->conn_send_queue,
+                                 XQC_PNS_APP_DATA, 2000000);
+        xqc_test_send_ctl_assert_pc(send_ctl, XQC_FALSE);
+        CU_ASSERT_EQUAL(conn->detected_loss_cnt, 2);
+        xqc_engine_destroy(conn->engine);
+    }
+}
+
+
+void
+xqc_test_send_ctl_persistent_congestion_ack_interrupts(void)
+{
+    for (int mode = 0; mode < 5; mode++) {
+        xqc_connection_t *conn = test_engine_connect();
+        CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+        xqc_send_ctl_t *send_ctl = conn->conn_initial_path->path_send_ctl;
+        xqc_test_send_ctl_arm_pc_state(send_ctl, 10000, 2000, 8000, 0);
+        xqc_pkt_num_space_t middle_pns = mode == 3
+                                        ? XQC_PNS_HSK : XQC_PNS_APP_DATA;
+        xqc_frame_type_bit_t middle_frame = mode >= 2
+                                            ? XQC_FRAME_BIT_ACK
+                                            : XQC_FRAME_BIT_PING;
+        CU_ASSERT_PTR_NOT_NULL_FATAL(
+            xqc_test_send_ctl_seed_lost_packet(conn, 1, 1000000));
+        CU_ASSERT_PTR_NOT_NULL_FATAL(xqc_test_send_ctl_send_packet(conn,
+            middle_pns, 2, 1100000, middle_frame));
+        CU_ASSERT_PTR_NOT_NULL_FATAL(
+            xqc_test_send_ctl_seed_lost_packet(conn, 3, 1200000));
+        CU_ASSERT_PTR_NOT_NULL_FATAL(
+            xqc_test_send_ctl_seed_lost_packet(conn, 4, 1390000));
+
+        if (mode == 1) {
+            /* Reordered ACK, after the higher packet number was ACKed. */
+            send_ctl->ctl_srtt = 1000000;
+            send_ctl->ctl_latest_rtt = 1000000;
+            send_ctl->ctl_reordering_packet_threshold = 100;
+            xqc_test_send_ctl_ack(conn, XQC_PNS_APP_DATA, 4,
+                                  XQC_MAX_UINT64_VALUE, 1400000);
+            CU_ASSERT_EQUAL(conn->detected_loss_cnt, 0);
+            send_ctl->ctl_srtt = 10000;
+            send_ctl->ctl_latest_rtt = 10000;
+            xqc_test_send_ctl_ack(conn, XQC_PNS_APP_DATA, 2,
+                                  XQC_MAX_UINT64_VALUE, 1500000);
+
+        } else if (mode >= 2 && mode <= 3) {
+            /* ACK-only packets are already recycled, so has_acked is 0. */
+            xqc_test_send_ctl_ack(conn, middle_pns, 2,
+                                  XQC_MAX_UINT64_VALUE, 1400000);
+        }
+
+        send_ctl->ctl_pto_count = 10;
+        xqc_test_send_ctl_ack(conn, XQC_PNS_APP_DATA, 4,
+                              mode == 0 ? 2 : XQC_MAX_UINT64_VALUE, 1500000);
+        /* An unacknowledged ACK-only packet does not split the interval. */
+        xqc_test_send_ctl_assert_pc(send_ctl, mode == 4);
+        xqc_engine_destroy(conn->engine);
+    }
+}
+
+
+void
+xqc_test_send_ctl_persistent_congestion_ack_eliciting_endpoints(void)
+{
+    for (int endpoint = 0; endpoint < 2; endpoint++) {
+        xqc_connection_t *conn = test_engine_connect();
+        CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+        xqc_send_ctl_t *send_ctl = conn->conn_initial_path->path_send_ctl;
+        xqc_test_send_ctl_arm_pc_state(send_ctl, 10000, 2000, 8000, 2);
+        send_ctl->ctl_pto_count = 10;
+        CU_ASSERT_PTR_NOT_NULL_FATAL(xqc_test_send_ctl_send_packet(conn,
+            XQC_PNS_APP_DATA, 1, 1000000,
+            endpoint == 0 ? XQC_FRAME_BIT_PADDING : XQC_FRAME_BIT_PING));
+        CU_ASSERT_PTR_NOT_NULL_FATAL(xqc_test_send_ctl_send_packet(conn,
+            XQC_PNS_APP_DATA, 2, 1200000,
+            endpoint == 1 ? XQC_FRAME_BIT_ACK : XQC_FRAME_BIT_PING));
+        xqc_send_ctl_detect_lost(send_ctl, conn->conn_send_queue,
+                                 XQC_PNS_APP_DATA, 2000000);
+        xqc_test_send_ctl_assert_pc(send_ctl, XQC_FALSE);
+        CU_ASSERT_EQUAL(conn->detected_loss_cnt, 1);
+        xqc_engine_destroy(conn->engine);
+    }
+}
+
+
+void
+xqc_test_send_ctl_persistent_congestion_across_loss_batches(void)
+{
+    for (int interrupted = 0; interrupted < 2; interrupted++) {
+        xqc_connection_t *conn = test_engine_connect();
+        CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+        xqc_send_ctl_t *send_ctl = conn->conn_initial_path->path_send_ctl;
+        uint32_t inflight_before = send_ctl->ctl_bytes_in_flight;
+        xqc_test_send_ctl_arm_pc_state(send_ctl, 10000, 2000, 8000, 1);
+        CU_ASSERT_PTR_NOT_NULL_FATAL(xqc_test_send_ctl_send_packet(conn,
+            XQC_PNS_APP_DATA, 1, 1000000, XQC_FRAME_BIT_DATAGRAM));
+        xqc_send_ctl_detect_lost(send_ctl, conn->conn_send_queue,
+                                 XQC_PNS_APP_DATA, 1050000);
+        CU_ASSERT_EQUAL(conn->detected_loss_cnt, 1);
+        CU_ASSERT_EQUAL(send_ctl->ctl_bytes_in_flight, inflight_before);
+        xqc_test_send_ctl_assert_pc(send_ctl, XQC_FALSE);
+
+        if (interrupted) {
+            CU_ASSERT_PTR_NOT_NULL_FATAL(xqc_test_send_ctl_send_packet(conn,
+                XQC_PNS_APP_DATA, 2, 1100000, XQC_FRAME_BIT_ACK));
+            xqc_test_send_ctl_ack(conn, XQC_PNS_APP_DATA, 2,
+                                  XQC_MAX_UINT64_VALUE, 1150000);
+        }
+
+        CU_ASSERT_PTR_NOT_NULL_FATAL(xqc_test_send_ctl_send_packet(conn,
+            XQC_PNS_APP_DATA, 3, 1200000, XQC_FRAME_BIT_DATAGRAM));
+        CU_ASSERT_PTR_NOT_NULL_FATAL(
+            xqc_test_send_ctl_seed_lost_packet(conn, 4, 1390000));
+        xqc_test_send_ctl_ack(conn, XQC_PNS_APP_DATA, 4,
+                              XQC_MAX_UINT64_VALUE, 1400000);
+        xqc_test_send_ctl_assert_pc(send_ctl, !interrupted);
+        CU_ASSERT_EQUAL(conn->detected_loss_cnt, 2);
+        CU_ASSERT_EQUAL(send_ctl->ctl_lost_dgram_cnt, 2);
+        CU_ASSERT_EQUAL(send_ctl->ctl_bytes_in_flight, inflight_before);
+        xqc_engine_destroy(conn->engine);
+    }
+}
+
+
+void
+xqc_test_send_ctl_persistent_congestion_pending_other_space(void)
+{
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+    xqc_send_ctl_t *send_ctl = conn->conn_initial_path->path_send_ctl;
+    uint32_t inflight_before = send_ctl->ctl_bytes_in_flight;
+    xqc_test_send_ctl_arm_pc_state(send_ctl, 10000, 2000, 8000, 1);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(xqc_test_send_ctl_send_packet(conn,
+        XQC_PNS_HSK, 1, 1000000, XQC_FRAME_BIT_PING));
+    CU_ASSERT_PTR_NOT_NULL_FATAL(xqc_test_send_ctl_send_packet(conn,
+        XQC_PNS_APP_DATA, 1, 1100000, XQC_FRAME_BIT_DATAGRAM));
+    CU_ASSERT_PTR_NOT_NULL_FATAL(xqc_test_send_ctl_send_packet(conn,
+        XQC_PNS_HSK, 2, 1200000, XQC_FRAME_BIT_PING));
+    send_ctl->ctl_pto_count = 10;
+    send_ctl->ctl_largest_acked[XQC_PNS_HSK] = 3;
 
     xqc_send_ctl_detect_lost(send_ctl, conn->conn_send_queue,
-                             XQC_PNS_APP_DATA, 1000000);
+                             XQC_PNS_HSK, 1400000);
+    xqc_test_send_ctl_assert_pc(send_ctl, XQC_FALSE);
+    CU_ASSERT_EQUAL(conn->detected_loss_cnt, 2);
 
-    /* No mutation, including first_rtt_sample_time itself. */
-    CU_ASSERT_EQUAL(send_ctl->ctl_srtt,   10000);
-    CU_ASSERT_EQUAL(send_ctl->ctl_rttvar,  2000);
-    CU_ASSERT_EQUAL(send_ctl->ctl_minrtt,  8000);
-    CU_ASSERT_EQUAL(send_ctl->ctl_first_rtt_sample_time, 0);
+    xqc_send_ctl_detect_lost(send_ctl, conn->conn_send_queue,
+                             XQC_PNS_APP_DATA, 1400000);
+    xqc_test_send_ctl_assert_pc(send_ctl, XQC_TRUE);
+    CU_ASSERT_EQUAL(conn->detected_loss_cnt, 3);
+    CU_ASSERT_EQUAL(send_ctl->ctl_bytes_in_flight, inflight_before);
+    xqc_engine_destroy(conn->engine);
+}
 
+
+void
+xqc_test_send_ctl_persistent_congestion_history_wrap(void)
+{
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+    xqc_send_ctl_t *send_ctl = conn->conn_initial_path->path_send_ctl;
+    uint32_t inflight_before = send_ctl->ctl_bytes_in_flight;
+    xqc_test_send_ctl_arm_pc_state(send_ctl, 10000, 2000, 8000, 1);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(xqc_test_send_ctl_send_packet(conn,
+        XQC_PNS_HSK, 1, 1000000, XQC_FRAME_BIT_PING));
+
+    for (size_t i = 1; i < XQC_PERSISTENT_CONGESTION_MAX_PACKETS; i++) {
+        CU_ASSERT_PTR_NOT_NULL_FATAL(xqc_test_send_ctl_send_packet(conn,
+            XQC_PNS_INIT, i, 1000000 + i, XQC_FRAME_BIT_ACK));
+    }
+    CU_ASSERT_PTR_NOT_NULL_FATAL(xqc_test_send_ctl_send_packet(conn,
+        XQC_PNS_APP_DATA, 1, 1200000, XQC_FRAME_BIT_DATAGRAM));
+    CU_ASSERT_PTR_NOT_NULL_FATAL(xqc_test_send_ctl_send_packet(conn,
+        XQC_PNS_HSK, 2, 1400000, XQC_FRAME_BIT_PING));
+
+    /* Losing an evicted packet must not mark its reused slot as lost. */
+    send_ctl->ctl_largest_acked[XQC_PNS_HSK] = 3;
+    xqc_send_ctl_detect_lost(send_ctl, conn->conn_send_queue,
+                             XQC_PNS_HSK, 1500000);
+    xqc_test_send_ctl_assert_pc(send_ctl, XQC_FALSE);
+    CU_ASSERT_EQUAL(conn->detected_loss_cnt, 2);
+
+    xqc_send_ctl_detect_lost(send_ctl, conn->conn_send_queue,
+                             XQC_PNS_APP_DATA, 1500000);
+    xqc_test_send_ctl_assert_pc(send_ctl, XQC_TRUE);
+    CU_ASSERT_EQUAL(conn->detected_loss_cnt, 3);
+    CU_ASSERT_EQUAL(send_ctl->ctl_bytes_in_flight, inflight_before);
+    xqc_engine_destroy(conn->engine);
+}
+
+
+void
+xqc_test_send_ctl_persistent_congestion_history_reset(void)
+{
+    for (int reset_path = 0; reset_path < 2; reset_path++) {
+        xqc_connection_t *conn = test_engine_connect();
+        CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+        xqc_send_ctl_t *send_ctl = conn->conn_initial_path->path_send_ctl;
+        uint32_t inflight_before = send_ctl->ctl_bytes_in_flight;
+        xqc_test_send_ctl_arm_pc_state(send_ctl, 10000, 2000, 8000, 1);
+        CU_ASSERT_PTR_NOT_NULL_FATAL(
+            xqc_test_send_ctl_seed_lost_packet(conn, 1, 1000000));
+        xqc_send_ctl_detect_lost(send_ctl, conn->conn_send_queue,
+                                 XQC_PNS_APP_DATA, 1050000);
+        if (reset_path) {
+            xqc_send_ctl_reset(send_ctl);
+            inflight_before = send_ctl->ctl_bytes_in_flight;
+
+        } else {
+            xqc_send_ctl_on_pns_discard(send_ctl, XQC_PNS_HSK);
+        }
+        xqc_test_send_ctl_arm_pc_state(send_ctl, 10000, 2000, 8000, 2);
+        CU_ASSERT_PTR_NOT_NULL_FATAL(
+            xqc_test_send_ctl_seed_lost_packet(conn, 2, 1200000));
+        xqc_send_ctl_detect_lost(send_ctl, conn->conn_send_queue,
+                                 XQC_PNS_APP_DATA, 1250000);
+        xqc_test_send_ctl_assert_pc(send_ctl, XQC_FALSE);
+
+        CU_ASSERT_PTR_NOT_NULL_FATAL(
+            xqc_test_send_ctl_seed_lost_packet(conn, 3, 1400000));
+        send_ctl->ctl_largest_acked[XQC_PNS_APP_DATA] = 4;
+        xqc_send_ctl_detect_lost(send_ctl, conn->conn_send_queue,
+                                 XQC_PNS_APP_DATA, 1450000);
+        xqc_test_send_ctl_assert_pc(send_ctl, XQC_TRUE);
+        CU_ASSERT_EQUAL(send_ctl->ctl_bytes_in_flight, inflight_before);
+        xqc_engine_destroy(conn->engine);
+    }
+}
+
+
+void
+xqc_test_send_ctl_persistent_congestion_recycled_probe(void)
+{
+    xqc_connection_t *conn = test_engine_connect();
+    CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+    xqc_send_ctl_t *send_ctl = conn->conn_initial_path->path_send_ctl;
+    xqc_send_queue_t *sq = conn->conn_send_queue;
+    uint32_t inflight_before = send_ctl->ctl_bytes_in_flight;
+    xqc_test_send_ctl_arm_pc_state(send_ctl, 10000, 2000, 8000, 0);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(
+        xqc_test_send_ctl_seed_lost_packet(conn, 1, 1000000));
+
+    /* Rebinding probes are recorded directly, then recycled by the sender. */
+    xqc_packet_out_t *probe = xqc_packet_out_get_and_insert_send(sq,
+        XQC_PTYPE_SHORT_HEADER);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(probe);
+    probe->po_pkt.pkt_num = 2;
+    probe->po_path_id = send_ctl->ctl_path->path_id;
+    probe->po_sent_time = 1100000;
+    probe->po_frame_types = XQC_FRAME_BIT_PATH_CHALLENGE;
+    xqc_send_ctl_pc_on_sent(send_ctl, probe);
+    xqc_send_queue_remove_send(&probe->po_list);
+    xqc_send_queue_insert_free(probe, &sq->sndq_free_packets, sq);
+    xqc_test_send_ctl_ack(conn, XQC_PNS_APP_DATA, 2,
+                          XQC_MAX_UINT64_VALUE, 1150000);
+
+    CU_ASSERT_PTR_NOT_NULL_FATAL(
+        xqc_test_send_ctl_seed_lost_packet(conn, 3, 1200000));
+    CU_ASSERT_PTR_NOT_NULL_FATAL(
+        xqc_test_send_ctl_seed_lost_packet(conn, 4, 1390000));
+    xqc_test_send_ctl_ack(conn, XQC_PNS_APP_DATA, 4,
+                          XQC_MAX_UINT64_VALUE, 1400000);
+    xqc_test_send_ctl_assert_pc(send_ctl, XQC_FALSE);
+    CU_ASSERT_EQUAL(conn->detected_loss_cnt, 2);
+    CU_ASSERT_EQUAL(send_ctl->ctl_bytes_in_flight, inflight_before);
     xqc_engine_destroy(conn->engine);
 }

--- a/tests/unittest/xqc_send_ctl_test.c
+++ b/tests/unittest/xqc_send_ctl_test.c
@@ -16,6 +16,8 @@
 #include "src/transport/xqc_transport_params.h"
 #include "src/transport/xqc_packet_out.h"
 #include "src/transport/xqc_frame.h"
+#include "src/transport/xqc_frame_parser.h"
+#include "src/transport/xqc_packet_in.h"
 
 
 /*
@@ -1117,4 +1119,75 @@ xqc_test_send_ctl_persistent_congestion_recycled_probe(void)
     CU_ASSERT_EQUAL(conn->detected_loss_cnt, 2);
     CU_ASSERT_EQUAL(send_ctl->ctl_bytes_in_flight, inflight_before);
     xqc_engine_destroy(conn->engine);
+}
+
+
+void
+xqc_test_send_ctl_persistent_congestion_ack_range_limit(void)
+{
+    for (unsigned ranges = 63; ranges <= 65; ranges++) {
+        xqc_connection_t *conn = test_engine_connect();
+        CU_ASSERT_PTR_NOT_NULL_FATAL(conn);
+        xqc_path_ctx_t *path = conn->conn_initial_path;
+        xqc_send_ctl_t *send_ctl = path->path_send_ctl;
+        uint32_t inflight_before = send_ctl->ctl_bytes_in_flight;
+        xqc_packet_number_t largest = ranges == 65 ? 130 : 128;
+        xqc_test_send_ctl_arm_pc_state(send_ctl, 10000, 2000, 8000, 0);
+
+        CU_ASSERT_PTR_NOT_NULL_FATAL(
+            xqc_test_send_ctl_seed_lost_packet(conn, 1, 1000000));
+        CU_ASSERT_PTR_NOT_NULL_FATAL(xqc_test_send_ctl_send_packet(conn,
+            XQC_PNS_APP_DATA, 2, 1100000, XQC_FRAME_BIT_ACK));
+        CU_ASSERT_PTR_NOT_NULL_FATAL(
+            xqc_test_send_ctl_seed_lost_packet(conn, 3, 1200000));
+        for (xqc_packet_number_t num = 4; num <= largest; num += 2) {
+            CU_ASSERT_PTR_NOT_NULL_FATAL(xqc_test_send_ctl_send_packet(conn,
+                XQC_PNS_APP_DATA, num, 1300000 + num,
+                num == largest ? XQC_FRAME_BIT_PING : XQC_FRAME_BIT_ACK));
+        }
+
+        /*
+         * RFC 9000 Section 19.3.1: singleton even-numbered ACK ranges.
+         * Encode largest_acked and ACK Range Count as two-byte varints;
+         * zero gaps and range lengths acknowledge every other packet.
+         * The 65th range acknowledges PN 2, inside the loss interval.
+         */
+        unsigned char wire[256] = {0x02, 0x40, 0, 0, 0x40, 0, 0};
+        wire[2] = (unsigned char) largest;
+        wire[5] = (unsigned char) (ranges - 1);
+        size_t wire_len = 7 + 2 * (ranges - 1);
+        xqc_packet_in_t packet_in = {0};
+        xqc_ack_info_t ack = {0};
+        packet_in.pos = wire;
+        packet_in.last = wire + wire_len;
+        packet_in.pi_pkt.pkt_pns = XQC_PNS_APP_DATA;
+        CU_ASSERT_EQUAL_FATAL(xqc_parse_ack_frame(&packet_in, conn, &ack),
+                              XQC_OK);
+        CU_ASSERT_PTR_EQUAL(packet_in.pos, packet_in.last);
+        CU_ASSERT_EQUAL(ack.n_ranges, ranges > 64 ? 64 : ranges);
+        CU_ASSERT_EQUAL(ack.ranges[ack.n_ranges - 1].low,
+                        ranges == 64 ? 2 : 4);
+        CU_ASSERT_EQUAL(xqc_send_ctl_on_ack_received(send_ctl,
+            xqc_get_pn_ctl(conn, path), conn->conn_send_queue, &ack, 1400000,
+            XQC_FALSE), XQC_OK);
+        xqc_test_send_ctl_assert_pc(send_ctl, ranges == 63);
+        CU_ASSERT_EQUAL(conn->detected_loss_cnt, 2);
+        CU_ASSERT_EQUAL(send_ctl->ctl_bytes_in_flight, inflight_before);
+
+        if (ranges >= 64) {
+            /* A fresh, fully observed suffix can still establish loss. */
+            CU_ASSERT_PTR_NOT_NULL_FATAL(xqc_test_send_ctl_seed_lost_packet(
+                conn, largest + 1, 1600000));
+            CU_ASSERT_PTR_NOT_NULL_FATAL(xqc_test_send_ctl_seed_lost_packet(
+                conn, largest + 2, 1800000));
+            CU_ASSERT_PTR_NOT_NULL_FATAL(xqc_test_send_ctl_seed_lost_packet(
+                conn, largest + 3, 1990000));
+            xqc_test_send_ctl_ack(conn, XQC_PNS_APP_DATA, largest + 3,
+                                  XQC_MAX_UINT64_VALUE, 2000000);
+            xqc_test_send_ctl_assert_pc(send_ctl, XQC_TRUE);
+            CU_ASSERT_EQUAL(conn->detected_loss_cnt, 4);
+            CU_ASSERT_EQUAL(send_ctl->ctl_bytes_in_flight, inflight_before);
+        }
+        xqc_engine_destroy(conn->engine);
+    }
 }

--- a/tests/unittest/xqc_send_ctl_test.h
+++ b/tests/unittest/xqc_send_ctl_test.h
@@ -62,4 +62,17 @@ void xqc_test_send_ctl_persistent_congestion_rtt_reseeds_from_new_sample(void);
 void xqc_test_send_ctl_single_loss_does_not_reset_rtt(void);
 void xqc_test_send_ctl_persistent_congestion_no_rtt_sample_early_return(void);
 
+/* RFC 9002 Sections 7.6.1 and 7.6.2 loss-interval requirements. */
+void xqc_test_send_ctl_persistent_congestion_duration_boundary(void);
+void xqc_test_send_ctl_persistent_congestion_prior_rtt_required(void);
+void xqc_test_send_ctl_persistent_congestion_ack_interrupts(void);
+void xqc_test_send_ctl_persistent_congestion_ack_eliciting_endpoints(void);
+void xqc_test_send_ctl_persistent_congestion_across_loss_batches(void);
+
+void xqc_test_send_ctl_persistent_congestion_pending_other_space(void);
+void xqc_test_send_ctl_persistent_congestion_history_wrap(void);
+void xqc_test_send_ctl_persistent_congestion_history_reset(void);
+
+void xqc_test_send_ctl_persistent_congestion_recycled_probe(void);
+
 #endif

--- a/tests/unittest/xqc_send_ctl_test.h
+++ b/tests/unittest/xqc_send_ctl_test.h
@@ -75,4 +75,6 @@ void xqc_test_send_ctl_persistent_congestion_history_reset(void);
 
 void xqc_test_send_ctl_persistent_congestion_recycled_probe(void);
 
+void xqc_test_send_ctl_persistent_congestion_ack_range_limit(void);
+
 #endif


### PR DESCRIPTION
### Mechanism

Detect persistent congestion from the sending-time span of lost ack-eliciting
packets after an RTT sample, independently of PTO count, per
[RFC 9002 Sections 7.6.1–7.6.2](https://www.rfc-editor.org/rfc/rfc9002.html#section-7.6).
Retained per-path history checks intervening acknowledgments across packet
number spaces, including recycled ACK-only packets and direct path probes.
Bounded history keeps the newest suffix when full and clears potentially
truncated ACK-range evidence; existing cwnd and RTT reset behavior is preserved.

Fixes: #730

### Validation Cases

- 801 — Sustained loss with zero PTO triggers persistent congestion and recovers.
- 802 — An intervening acknowledgment prevents persistent congestion and data transfer continues.

### CONTRIBUTING.md

- Overall: Pending
- Local regression: Complete
- CI: Pending — Build on Ubuntu; Test BabaSSL on Ubuntu 24.04 with GCC 13; Build on macOS (macos-latest)
